### PR TITLE
Handle StopIteration exception by providing default None value when executing tools iteratively

### DIFF
--- a/agency_swarm/threads/thread.py
+++ b/agency_swarm/threads/thread.py
@@ -94,8 +94,8 @@ class Thread:
 
     def _execute_tool(self, tool_call):
         funcs = self.recipient_agent.functions
-        func = next(iter([func for func in funcs if func.__name__ == tool_call.function.name]))
-
+        func = next((func for func in funcs if func.__name__ == tool_call.function.name), None)
+        
         if not func:
             return f"Error: Function {tool_call.function.name} not found. Available functions: {[func.__name__ for func in funcs]}"
 


### PR DESCRIPTION
When GPT4 attempts to invoke a tool using a name that doesn't match any of the provided tools (I notice it can make mistakes related to capitalization), a StopIteration exception is thrown on the line modified in this PR, crashing my app. By setting a default None value, the code will successfully progress to the following lines in which a None func value is handled properly.