### PR TITLE
Add selenium related requirements to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ termcolor==2.3.0
 python-dotenv==1.0.0
 rich==13.7.0
 jsonref==1.1.0
+webdriver-manager==4.0.1
+selenium-stealth==1.0.6


### PR DESCRIPTION
Notably, `webdriver-manager` and `selenium-stealth` seem to be required for genesis to perform selenium searches (when looking up APIs, etc.). Adding these to `requirements.txt` eliminates the errors encountered when using the genesis jupyter notebook.