### PR TITLE
feat: bump openai to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "openai==1.10.0",
+    "openai==1.12.0",
     "instructor==0.4.8",
     "deepdiff==6.7.1",
     "termcolor==2.3.0",


### PR DESCRIPTION
We are importing your Agent class into our app and have a poetry dependency conflict with the 3.10 version of openai that you currently have pegged. 

