### PR TITLE
Increase max_retries from 5 to 10

### DIFF
--- a/agency_swarm/util/oai.py
+++ b/agency_swarm/util/oai.py
@@ -22,7 +22,7 @@ def get_openai_client():
                 raise ValueError("OpenAI API key is not set. Please set it using set_openai_key.")
             client = instructor.patch(openai.OpenAI(api_key=api_key,
                                                     timeout=httpx.Timeout(60.0, read=30, connect=5.0),
-                                                    max_retries=5,
+                                                    max_retries=10,
                                                     default_headers={"OpenAI-Beta": "assistants=v2"})
                                       )
     return client


### PR DESCRIPTION
Users who are on Tier 2 or below usually experience rate limit errors when running the `genesis` command.

This PR adds two changes:
- It specifically handles the "rate limit exceeded" error and sleeps for  - at least - 60 seconds to avoid running into [TPM problems](https://platform.openai.com/docs/guides/rate-limits/error-mitigation)
- The max_retries is increased from 5 to 10