### PR TITLE
Hack to reduce rate limit flakiness

### DIFF
--- a/agency_swarm/threads/thread.py
+++ b/agency_swarm/threads/thread.py
@@ -205,6 +205,21 @@ class Thread:
                     )
                     self._create_run(recipient_agent, additional_instructions, event_handler, tool_choice)
                     error_attempts += 1
+                elif error_attempts < 1 and "rate limit reached" in self.run.last_error.message.lower():
+                    print("Rate limit reached. Waiting for 30 seconds.")
+                    time.sleep(30)
+                    self._create_run(recipient_agent, additional_instructions, event_handler, tool_choice)
+                    error_attempts += 1
+                elif 1 <= error_attempts < 5 and "rate limit reached" in self.run.last_error.message.lower():
+                    print("Rate limit reached. Waiting for 30 seconds.")
+                    time.sleep(30)
+                    self.client.beta.threads.messages.create(
+                        thread_id=self.thread.id,
+                        role="user",
+                        content="Continue."
+                    )
+                    self._create_run(recipient_agent, additional_instructions, event_handler, tool_choice)
+                    error_attempts += 1
                 else:
                     raise Exception("OpenAI Run Failed. Error: ", self.run.last_error.message)
             # return assistant message


### PR DESCRIPTION
I often run into the system crashing due to OpenAI rate limit. 
With this change, the program halts for 30 seconds and then resumes - instead of hard crash.

Note: This is a hack based on my limited experience of the platform. I suggest the reviewer considers alternative solutions first.