### PR TITLE
Make BaseTool.additional_instructions parameter optional

### DIFF
--- a/agency_swarm/agency/agency.py
+++ b/agency_swarm/agency/agency.py
@@ -1051,7 +1051,7 @@ class Agency:
             message_files: Optional[List[str]] = Field(default=None,
                                                        description="A list of file ids to be sent as attachments to this message. Only use this if you have the file id that starts with 'file-'.",
                                                        examples=["file-1234", "file-5678"])
-            additional_instructions: str = Field(default=None,
+            additional_instructions: Optional[List[str]] = Field(default=None,
                                                  description="Any additional instructions or clarifications that you would like to provide to the recipient agent.")
             
             class ToolConfig:


### PR DESCRIPTION
Fix https://github.com/VRSEN/agency-swarm/issues/168

The issue is that we enforce strict str type on the additional_instructions parameter:

🐧 RoutingAgent 🛠️ Executing Function
Function(arguments='{"my_primary_instructions":"...","recipient":"...Agent","message":"...","additional_instructions":null}', name='SendMessage')
────────────────────────────────────────────────────────────────────────────────
SendMessage ⚙️ Function Output
Error: 1 validation error for SendMessage additional_instructions Input should
be a valid string [type=string_type, input_value=None, input_type=NoneType]

The fix: to use Optional.