### PR TITLE
Remove strict Parameter from Tool Schema When False

### DIFF
--- a/agency_swarm/agents/agent.py
+++ b/agency_swarm/agents/agent.py
@@ -430,9 +430,14 @@ class Agent():
             elif issubclass(tool, Retrieval):
                 tools.append(tool().model_dump())
             elif issubclass(tool, BaseTool):
+                tool_config = tool.openai_schema
+                # remove strict if it's set to False
+                if 'function' in tool_config and 'strict' in tool_config['function']:
+                    if tool_config['function']['strict'] is False:
+                        tool_config['function'].pop('strict', None)
                 tools.append({
                     "type": "function",
-                    "function": tool.openai_schema
+                    "function": tool_config
                 })
             else:
                 raise Exception("Invalid tool type.")


### PR DESCRIPTION
### Description
This PR removes the `strict` parameter when it is set to `False` in the `get_oai_tools` method of `agency_swarm/agents/agent.py`. This change ensures correct functionality and compatibility with the Azure OpenAI API by eliminating conflicting configurations.

Fixes #177 