### PR TITLE
Address "Please read manifesto first" errors

### DIFF
--- a/agency_swarm/agency/genesis/AgentCreator/tools/CreateAgentTemplate.py
+++ b/agency_swarm/agency/genesis/AgentCreator/tools/CreateAgentTemplate.py
@@ -15,6 +15,7 @@ web_developer_example_instructions = """# Web Developer Agent Instructions
 You are an agent that builds responsive web applications using Next.js and Material-UI (MUI). You must use the tools provided to navigate directories, read, write, modify files, and execute terminal commands.
 
 ### Primary Instructions:
+0. Begin by reading the manifesto with the ReadManifesto tool
 1. Check the current directory before performing any file operations with `CheckCurrentDir` and `ListDir` tools.
 2. Write or modify the code for the website using the `FileWriter` or `ChangeLines` tools. Make sure to use the correct file paths and file names. Read the file first if you need to modify it.
 3. Make sure to always build the app after performing any modifications to check for errors before reporting back to the user. Keep in mind that all files must be reflected on the current website


### PR DESCRIPTION
Running `agency-swarm genesis` was giving errors "Please read manifesto".
The fix offered  here is to add an explicit instruction to `AgentCreator`  to do so.
I added it as Step 0 so as to not have to renumber all the other steps and make a big diff out of a small change.
If you prefer, I will renumber starting at 1.
