### PR TITLE
Adjusted run_fastapi method to process calls sequentially

### DIFF
--- a/agency_swarm/agency/agency.py
+++ b/agency_swarm/agency/agency.py
@@ -1147,9 +1147,16 @@ class Agency:
                 logger.info(f"Shutting down MCP server: {server.name}")
                 server.cleanup()
 
-    def run_fastapi(self, host: str = "0.0.0.0", port: int = 8000, app_token_env: str = "APP_TOKEN"):
+    def run_fastapi(
+            self, 
+            host: str = "0.0.0.0", 
+            port: int = 8000, 
+            app_token_env: str = "APP_TOKEN", 
+            return_app: bool = False
+        ):
         """
-        Launch a FastAPI server exposing the agency's completion and streaming endpoints using the shared integrations.fastapi.run_fastapi utility.
+        Launch a FastAPI server exposing the agency's completion and 
+        streaming endpoints using the shared integrations.fastapi.run_fastapi utility.
         """
         from agency_swarm.integrations.fastapi import run_fastapi
-        run_fastapi(agencies=[self], host=host, port=port, app_token_env=app_token_env)
+        return run_fastapi(agencies=[self], host=host, port=port, app_token_env=app_token_env, return_app=return_app)

--- a/agency_swarm/integrations/fastapi.py
+++ b/agency_swarm/integrations/fastapi.py
@@ -135,10 +135,11 @@ def run_fastapi(
 
     app.add_exception_handler(Exception, exception_handler)
 
+    print("Created endpoints:\n" + "\n".join(endpoints))
+
     if return_app:
         return app
 
     print(f"Starting FastAPI server at http://{host}:{port}")
-    print("Created endpoints:\n" + "\n".join(endpoints))
     
     uvicorn.run(app, host=host, port=port)

--- a/tests/demos/fastapi_demo.py
+++ b/tests/demos/fastapi_demo.py
@@ -9,7 +9,7 @@ from agency_swarm.integrations.fastapi import run_fastapi
 
 load_dotenv()
 
-os.environ["app_token"] = "123" # Can be set in .env file
+os.environ["APP_TOKEN"] = "123" # Can be set in .env file
 
 
 class ExampleTool(BaseTool):

--- a/tests/demos/fastapi_demo.py
+++ b/tests/demos/fastapi_demo.py
@@ -1,0 +1,43 @@
+import os
+
+import uvicorn
+from dotenv import load_dotenv
+from pydantic import Field
+
+from agency_swarm import Agency, Agent, BaseTool
+from agency_swarm.integrations.fastapi import run_fastapi
+
+load_dotenv()
+
+os.environ["app_token"] = "123" # Can be set in .env file
+
+
+class ExampleTool(BaseTool):
+    input: str = Field(..., description="The input to the tool")
+
+    def run(self):
+        return "Hello, world!"
+    
+ceo = Agent(
+    name="CEO",
+    description="Responsible for client communication, task planning and management.",
+    instructions="Responsible for client communication, task planning and management.",
+)
+
+test_agent = Agent(
+    name="Test Agent1",
+    description="Responsible for testing.",
+    instructions="Test agent",  # can be a file like ./instructions.md
+)
+
+agency = Agency([ceo, [ceo, test_agent]], name="test_agency")
+
+# Create FastAPI app
+app = run_fastapi(agencies=[agency], tools=[ExampleTool], return_app=True)
+
+# To deploy agency only (tools won't be deployed), you can use the class method
+# agency.run_fastapi()
+
+if __name__ == "__main__":
+    print("\nAfter endpoints are deployed, you can run test_request_demo.py to test them.\n")
+    uvicorn.run(app, host="0.0.0.0", port=7860)

--- a/tests/demos/fastapi_request_demo.py
+++ b/tests/demos/fastapi_request_demo.py
@@ -1,0 +1,41 @@
+"""
+Test script that sends a test request to an endpoint created within the fastapi_demo.py file.
+
+Use this to verify that your FastAPI tool endpoints are working correctly.
+
+Usage:
+    python fastapi_request_demo.py
+"""
+
+import requests
+from requests.exceptions import ConnectionError
+
+AGENCY_ENDPOINT = "http://localhost:7860/test_agency/get_completion"
+TOOL_ENDPOINT = "http://localhost:7860/tool/ExampleTool"
+BEARER_TOKEN = "123"
+
+headers = {"Authorization": f"Bearer {BEARER_TOKEN}"}
+
+def send_completion_request():
+    try:
+        data = {"message": "Hello, how are you doing?"}
+        response = requests.post(AGENCY_ENDPOINT, json=data, headers=headers)
+        print(f"Completion response: {response.text}")
+    except ConnectionError:
+        print("Could not connect to the server, please run fastapi_demo.py prior to running this script.")
+    except Exception as e:
+        print(f"Error: {e}")
+
+def send_tool_request():
+    try:
+        data = {"input": "Test input"}
+        response = requests.post(TOOL_ENDPOINT, json=data, headers=headers)
+        print(f"Tool response: {response.text}")
+    except ConnectionError:
+        print("Could not connect to the server, please run fastapi_demo.py prior to running this script.")
+    except Exception as e:
+        print(f"Error: {e}")
+
+if __name__ == "__main__":
+    send_completion_request()
+    send_tool_request()


### PR DESCRIPTION
- Made adjustments to run_fastapi method to process calls sequentially in order to avoid thread mixups on parallel calls. 
- Added some other minor quality of life updates. 
- Added demo files to create and test fastapi endpoints created by run_fastapi method