### PR TITLE
feature: allow for unit test files within tools folder without meltdown

### DIFF
--- a/agency_swarm/agents/agent.py
+++ b/agency_swarm/agents/agent.py
@@ -587,7 +587,11 @@ class Agent:
         if os.path.isdir(self.tools_folder):
             f_paths = os.listdir(self.tools_folder)
             f_paths = [
-                f for f in f_paths if not f.startswith(".") and not f.startswith("__")
+                f
+                for f in f_paths
+                if not f.startswith(".")
+                and not f.startswith("__")
+                and not f.endswith("_test.py")
             ]
             f_paths = [os.path.join(self.tools_folder, f) for f in f_paths]
             for f_path in f_paths:


### PR DESCRIPTION
Just a simple PR to allow for those of us who like to put unit tests in their own files. Ignores the `_test.py` suffix within the tools_folder path.