### PR TITLE
agent: remove FileSearchTool cleanup

### DIFF
--- a/tests/integration/test_file_handling.py
+++ b/tests/integration/test_file_handling.py
@@ -348,9 +348,10 @@ async def test_code_interpreter_tool(real_openai_client: AsyncOpenAI, tmp_path: 
         agency = Agency(code_interpreter_agent, user_context=None)
 
         # Test the simple usage of the code interpreter tool (answer is always 37)
+        # Use a deterministic script to avoid RNG differences across environments
         question = """
         Use CodeInterpreter tool to execute this script and tell me the results:
-        ```import random\nrandom.seed(115)\nprint(random.randint(1, 100))```
+        ```print(sum([10, 20, 7]))```
         """
 
         response_result = await agency.get_response(question)


### PR DESCRIPTION
## Summary
- remove FileSearchTool dependency and temp vector store cleanup from AttachmentManager
- make code interpreter integration test deterministic
- drop vector store cleanup scenarios from AttachmentManager tests

## Testing
- `make ci`
- `uv run pytest tests/integration/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68b64831bbdc8323b10537db694198ab