### PR TITLE
fix: FastAPI integration additional_instructions parameter support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^docs/
@@ -12,7 +12,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.12.12
     hooks:
       - id: ruff
         args: [--fix, --select=I]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,14 @@ Avoid growing already large files. Prefer extracting focused modules. If you mus
   - No root-level tests (organize by module)
 - Name test files clearly (e.g. `test_thread_isolation.py`), never generic root names
 
+### Testing Protocol (Behavior-Only, Minimal Mocks)
+- Do not test private APIs or patch private attributes/methods. Interact via public interfaces only.
+- Prefer behavior verification over implementation details. Tests should validate externally observable outcomes.
+- Keep mocks/stubs minimal and realistic; avoid over-mocking. Use simple stubs to emulate public behavior only.
+- Follow the testing pyramid: prioritize unit tests for focused logic; add integration tests for real wiring/flows without duplicating unit scopes.
+- Avoid duplicate assertions across unit and integration levels; each test should have a clear, non-overlapping purpose.
+- Use descriptive, stable names (no throwaway labels); optimize for readability and intent.
+
 ## 🚨 ZERO FUNCTIONAL CHANGES DURING REFACTORING
 
 ### Allowed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,12 +98,11 @@ Run non-interactive examples from /examples directory. Never run examples/intera
 2. **Agent:** Extends `agents.Agent`; file handling, sub-agent registration, tool management, uses `send_message`, supports structured outputs
 3. **Thread Management (`thread.py`):** Thread isolation per conversation, persistence, history tracking
 4. **Context Sharing (`context.py`):** Shared state via `MasterContext`, passed through execution hooks
-5. **Tool System (`tools/`):** Recommended: `@function_tool` decorator; legacy: `BaseTool`; `SendMessage` for inter-agent comms
+5. **Tool System (`tools/`):** Recommended: `@function_tool` decorator; second option: `BaseTool`; `SendMessage` for inter-agent comms
 
 ### Architectural Patterns
 - Communication: Sender/receiver pairs on `Agency` (see `examples/`)
 - Persistence: Load/save callbacks (see `examples/`)
-- Prefer modern tool creation (`@function_tool`); legacy supported
 
 ## Version and Documentation
 - **v1.x:** Latest released version (OpenAI Agents SDK / Responses API)
@@ -113,6 +112,7 @@ Run non-interactive examples from /examples directory. Never run examples/intera
 
 ### Documentation Rules (Mandatory)
 - All documentation writing and updates MUST follow `docs/mintlify.cursorrules` for formatting, components, links, and page metadata. Treat it as a mandatory rules file alongside this document.
+- Reference the exact code files relevant to the documented behavior so maintainers know where to look.
 
 ## Python Requirements
 - **Python >= 3.12 (development on 3.13)** — project developed and primarily tested on 3.13; CI ensures 3.12 compatibility.

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -59,10 +59,16 @@ Optionally, you can specify following parameters:
 - app_token_env (default: `"APP_TOKEN"`) - Name of the env variable storing app token.
 - return_app (default: False) - If True, will return the FastAPI instead of running the server
 - cors_origins: (default: ["*"])
+- enable_agui (default: `False`) - Enable AG-UI protocol compatibility for streaming endpoints
+- enable_logging (default: `False`) - Enable request tracking and expose `/get_logs` endpoint
+- logs_dir (default: `"activity-logs"`) - Directory for log files when logging is enabled
 
-This will create 2 endpoints for the agency:
+This will create 3 endpoints for the agency:
 - `/test_agency/get_response`
 - `/test_agency/get_response_stream`
+- `/test_agency/get_metadata`
+
+If `enable_logging=True`, a `/get_logs` endpoint is also added.
 
 Both of these endpoints will accept following input parameters:
 
@@ -70,8 +76,8 @@ Both of these endpoints will accept following input parameters:
 
 ```python v1.x
 message: str
-# Entire chat history containing previous messages across all threads in a form of {'thread_1': ConversationThread, 'thread_2': ConversationThread, ...}
-chat_history: dict[str, ConversationThread] = None
+# Entire chat history as a flat list of messages with metadata like 'agent', 'callerAgent' and 'timestamp'
+chat_history: list[dict[str, Any]] = None
 recipient_agent: str = None
 file_ids: list[str] = None
 # Files to download and attach to the agent. Should be provided in a form of a mapping: {"filename_1":"url", "filename_2":"url", ...}
@@ -118,12 +124,28 @@ def test_tool(example_field: str) -> str:
 agent1 = Agent(name="Assistant1", instructions="You are assistant 1.")
 agent2 = Agent(name="Assistant2", instructions="You are assistant 2.")
 
-# Create agencies
-agency1 = Agency(agent1, name="test_agency_1")
-agency2 = Agency(agent2, name="test_agency_2")
+# Create agency factory functions for proper thread management
+def create_agency_1(load_threads_callback=None, save_threads_callback=None):
+    return Agency(
+        agent1, 
+        name="test_agency_1",
+        load_threads_callback=load_threads_callback,
+        save_threads_callback=save_threads_callback,
+    )
+
+def create_agency_2(load_threads_callback=None, save_threads_callback=None):
+    return Agency(
+        agent2, 
+        name="test_agency_2",
+        load_threads_callback=load_threads_callback,
+        save_threads_callback=save_threads_callback,
+    )
 
 run_fastapi(
-    agencies=[agency1, agency2],
+    agencies={
+        "test_agency_1": create_agency_1,
+        "test_agency_2": create_agency_2,
+    },
     tools=[example_tool, test_tool],
 )
 ```
@@ -145,25 +167,45 @@ class TestTool(BaseTool):
   def run(self):
       return "Result of TestTool operation"
 
-# Create agencies
-agency1 = Agency([agent], name="test_agency_1")
-agency2 = Agency([agent], name="test_agency_2")
+# Create agency factory functions for proper thread management
+def create_agency_1(load_threads_callback=None, save_threads_callback=None):
+    return Agency(
+        [agent], 
+        name="test_agency_1",
+        load_threads_callback=load_threads_callback,
+        save_threads_callback=save_threads_callback,
+    )
+
+def create_agency_2(load_threads_callback=None, save_threads_callback=None):
+    return Agency(
+        [agent], 
+        name="test_agency_2",
+        load_threads_callback=load_threads_callback,
+        save_threads_callback=save_threads_callback,
+    )
 
 run_fastapi(
-    agencies=[agency_test_1, agency_test_2],
+    agencies={
+        "test_agency_1": create_agency_1,
+        "test_agency_2": create_agency_2,
+    },
     tools=[ExampleTool, TestTool],
 )
 ```
 
 </CodeGroup>
 
-This will create 6 following endpoints:
+This will create the following endpoints:
 - `/test_agency_1/get_response`
 - `/test_agency_1/get_response_stream`
+- `/test_agency_1/get_metadata`
 - `/test_agency_2/get_response`
 - `/test_agency_2/get_response_stream`
+- `/test_agency_2/get_metadata`
 - `/tool/ExampleTool` (for BaseTools) or `/tool/example_tool` (for function tools)
 - `/tool/TestTool` (for BaseTools) or `/tool/test_tool` (for function tools)
+
+If `enable_logging=True`, a `/get_logs` endpoint is also added.
 
 Inputs for the tool endpoints will follow their respective schemas.
 
@@ -237,11 +279,19 @@ print("Response:", tool_response.json())
   Each agency is served at:
   - `/your_agency_name/get_response` (POST)
   - `/your_agency_name/get_response_stream` (POST, streaming responses)
+  - `/your_agency_name/get_metadata` (GET)
 
 - **Tool Endpoints:**
   Each tool is served at:
   - `/tool/ToolClassName` (POST) - v0.x
   - `/tool/function_name` (POST) - v1.x
+
+- **Logging Endpoint:**
+  When `enable_logging=True`:
+  - `/get_logs` (POST)
+
+- **AG-UI Protocol:**
+  When `enable_agui=True`, only the streaming endpoint is exposed and follows the AG-UI protocol for enhanced frontend integration.
 
 ---
 

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -43,6 +43,7 @@ def make_response_endpoint(request_model, agency_factory: Callable[..., Agency],
                 return []
 
         combined_file_ids = request.file_ids
+        file_ids_map = None
         if request.file_urls is not None:
             try:
                 file_ids_map = await upload_from_urls(request.file_urls)

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -239,6 +239,7 @@ def make_agui_chat_endpoint(request_model, agency_factory: Callable[..., Agency]
                 snapshot_messages = [message.model_dump() for message in request.messages]
                 async for event in agency.get_response_stream(
                     message=request.messages[-1].content,
+                    additional_instructions=request.additional_instructions,
                 ):
                     agui_event = agui_adapter.openai_to_agui_events(
                         event,

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -23,6 +23,7 @@ class RunAgentInputCustom(RunAgentInput):
             "Each message should contain 'agent', 'callerAgent', 'timestamp' and other OpenAI fields."
         ),
     )
+    additional_instructions: str | None = None
 
 
 class BaseRequest(BaseModel):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,13 +2,11 @@
 
 import os
 
+import pytest
+
 # Importing agency_swarm triggers .env loading via python-dotenv
 import agency_swarm  # noqa: F401
 
-# Verify API key is loaded
+# Verify API key is loaded; fail integration tests if missing
 if not os.getenv("OPENAI_API_KEY"):
-    import warnings
-
-    warnings.warn(
-        "OPENAI_API_KEY not found in environment. Integration tests requiring API access will fail.", stacklevel=2
-    )
+    pytest.fail("OPENAI_API_KEY not found in environment")

--- a/tests/integration/test_fastapi_additional_instructions.py
+++ b/tests/integration/test_fastapi_additional_instructions.py
@@ -1,0 +1,153 @@
+"""Integration tests to verify additional_instructions handling in FastAPI endpoints."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agency_swarm import Agency, Agent, run_fastapi
+
+
+@pytest.fixture
+def agency_factory():
+    """Factory function to create a test agency."""
+
+    def create_agency(load_threads_callback=None, save_threads_callback=None):
+        agent = Agent(name="TestAgent", instructions="Base instructions")
+        return Agency(
+            agent,
+            load_threads_callback=load_threads_callback,
+            save_threads_callback=save_threads_callback,
+        )
+
+    return create_agency
+
+
+def test_non_streaming_additional_instructions(monkeypatch, agency_factory):
+    """Test that additional_instructions are passed to non-streaming endpoint."""
+    captured_params = {}
+
+    async def fake_get_response(self, message, additional_instructions=None, **kwargs):
+        captured_params["additional_instructions"] = additional_instructions
+        return SimpleNamespace(final_output="Test response", new_items=[])
+
+    monkeypatch.setattr(Agent, "get_response", fake_get_response)
+
+    app = run_fastapi(agencies={"test_agency": agency_factory}, return_app=True, app_token_env="")
+    client = TestClient(app)
+
+    response = client.post(
+        "/test_agency/get_response",
+        json={"message": "Hello", "additional_instructions": "Be very brief"},
+    )
+
+    assert response.status_code == 200
+    assert captured_params["additional_instructions"] == "Be very brief"
+
+
+def test_streaming_additional_instructions(monkeypatch, agency_factory):
+    """Test that additional_instructions are passed to streaming endpoint."""
+    captured_params = {}
+
+    async def fake_get_response_stream(self, message, additional_instructions=None, **kwargs):
+        captured_params["additional_instructions"] = additional_instructions
+        # Yield at least one event
+        yield {"type": "text", "data": "Test"}
+
+    monkeypatch.setattr(Agent, "get_response_stream", fake_get_response_stream)
+
+    app = run_fastapi(agencies={"test_agency": agency_factory}, return_app=True, app_token_env="")
+    client = TestClient(app)
+
+    with client.stream(
+        "POST",
+        "/test_agency/get_response_stream",
+        json={"message": "Hello", "additional_instructions": "Be very brief"},
+    ) as response:
+        assert response.status_code == 200
+        # Consume the stream
+        list(response.iter_lines())
+
+    assert captured_params["additional_instructions"] == "Be very brief"
+
+
+def test_agui_additional_instructions(monkeypatch, agency_factory):
+    """Test that additional_instructions are passed to AG-UI endpoint."""
+    captured_params = {}
+
+    async def fake_get_response_stream(self, message, additional_instructions=None, **kwargs):
+        captured_params["additional_instructions"] = additional_instructions
+        # Yield at least one event
+        yield {"type": "text", "data": "Test"}
+
+    monkeypatch.setattr(Agent, "get_response_stream", fake_get_response_stream)
+
+    app = run_fastapi(
+        agencies={"test_agency": agency_factory},
+        return_app=True,
+        app_token_env="",
+        enable_agui=True,
+    )
+    client = TestClient(app)
+
+    agui_payload = {
+        "thread_id": "test_thread",
+        "run_id": "test_run",
+        "state": None,
+        "messages": [{"id": "msg1", "role": "user", "content": "Hello"}],
+        "tools": [],
+        "context": [],
+        "forwardedProps": None,
+        "additional_instructions": "Be very brief",
+    }
+
+    with client.stream("POST", "/test_agency/get_response_stream", json=agui_payload) as response:
+        assert response.status_code == 200
+        # Consume the stream
+        list(response.iter_lines())
+
+    assert captured_params["additional_instructions"] == "Be very brief"
+
+
+def test_additional_instructions_none_handling(monkeypatch, agency_factory):
+    """Test that None additional_instructions are handled properly."""
+    captured_params = {}
+
+    async def fake_get_response(self, message, additional_instructions=None, **kwargs):
+        captured_params["additional_instructions"] = additional_instructions
+        return SimpleNamespace(final_output="Test response", new_items=[])
+
+    monkeypatch.setattr(Agent, "get_response", fake_get_response)
+
+    app = run_fastapi(agencies={"test_agency": agency_factory}, return_app=True, app_token_env="")
+    client = TestClient(app)
+
+    # Test without additional_instructions field
+    response = client.post("/test_agency/get_response", json={"message": "Hello"})
+
+    assert response.status_code == 200
+    assert captured_params["additional_instructions"] is None
+
+
+@pytest.mark.asyncio
+async def test_additional_instructions_real_integration(agency_factory):
+    """Test with a real agency instance (without mocking) to ensure end-to-end functionality."""
+    agent = Agent(
+        name="TestAgent",
+        instructions="You are a test agent. Follow any additional instructions carefully.",
+    )
+
+    agency = Agency(agent)
+
+    # Test that additional_instructions don't break the real call
+    response = await agency.get_response(message="Say hello", additional_instructions="Keep it under 10 words")
+
+    # Verify we get a response (even if we can't verify the LLM actually followed the instructions)
+    assert response.final_output is not None
+    assert isinstance(response.final_output, str)
+    assert len(response.final_output) > 0
+
+
+if __name__ == "__main__":
+    # Allow direct execution for debugging
+    pytest.main([__file__, "-v"])

--- a/tests/test_agent_modules/send_message/test_extra_params.py
+++ b/tests/test_agent_modules/send_message/test_extra_params.py
@@ -1,0 +1,247 @@
+import json
+from typing import Any, cast
+
+import pytest
+from pydantic import BaseModel, Field
+
+from agency_swarm.tools.send_message import SendMessage
+
+
+class StubAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.description = ""
+        self.return_input_guardrail_errors = False
+
+    async def get_response(
+        self,
+        message: str,
+        sender_name: str,
+        additional_instructions: str | None,
+        agency_context,
+        parent_run_id: str | None,
+    ):
+        class Resp:
+            final_output = "ack"
+
+        return Resp()
+
+
+class SendMessageNested(SendMessage):
+    class ExtraParams(BaseModel):
+        foo: str = Field(description="extra field")
+
+
+@pytest.mark.asyncio
+async def test_nested_extra_params_validates_and_sends():
+    """Validates that nested ExtraParams are merged and invocation succeeds."""
+    sender = StubAgent("Sender")
+    recipient = StubAgent("Recipient")
+    tool = SendMessageNested(sender, recipients={"B": recipient})
+    assert "foo" in tool.params_json_schema["properties"]
+    assert "foo" in tool.params_json_schema["required"]
+
+    class Wrapper:
+        class Context:
+            agents = {"B": recipient}
+            user_context = None
+            thread_manager = None
+            shared_instructions = None
+            _is_streaming = False
+            _streaming_context = None
+
+        context = Context()
+
+    args = json.dumps(
+        {
+            "recipient_agent": "B",
+            "my_primary_instructions": "hi",
+            "message": "msg",
+            "additional_instructions": "",
+            "foo": "bar",
+        }
+    )
+    out = await tool.on_invoke_tool(Wrapper(), args)
+    assert out == "ack"
+
+
+class NumericParams(BaseModel):
+    count: int = Field(description="Count")
+
+
+class SendMessageWithCount(SendMessage):
+    extra_params_model = NumericParams
+
+
+@pytest.mark.asyncio
+async def test_validation_type_error_unit():
+    """Type mismatch in ExtraParams should return a validation error message."""
+    sender = StubAgent("Sender")
+    recipient = StubAgent("Recipient")
+    tool = SendMessageWithCount(sender, {"B": recipient})
+
+    class Wrapper:
+        class Context:
+            agents = {"B": recipient}
+            user_context = None
+            thread_manager = None
+            shared_instructions = None
+            _is_streaming = False
+            _streaming_context = None
+
+        context = Context()
+
+    bad_args = json.dumps(
+        {
+            "recipient_agent": "B",
+            "my_primary_instructions": "",
+            "message": "hi",
+            "additional_instructions": "",
+            "count": "bad",
+        }
+    )
+
+    out = await tool.on_invoke_tool(Wrapper(), bad_args)
+    assert isinstance(out, str) and out.startswith("Error: Invalid extra parameters")
+
+
+class BadExtra(BaseModel):
+    foo: str
+
+    @classmethod
+    def model_json_schema(cls, *a, **kw):  # type: ignore[override]
+        raise ValueError("boom")
+
+
+class SendMessageBad(SendMessage):
+    ExtraParams = BadExtra
+
+
+def test_bad_extra_params_model_gracefully_handled():
+    """If ExtraParams schema generation fails, the tool should still operate without extra validation."""
+    sender = StubAgent("Sender")
+    recipient = StubAgent("Recipient")
+    tool = SendMessageBad(sender, recipients={"B": recipient})
+    assert "foo" not in tool.params_json_schema["properties"]
+
+    class Wrapper:
+        class Context:
+            agents = {"B": recipient}
+            user_context = None
+            thread_manager = None
+            shared_instructions = None
+            _is_streaming = False
+            _streaming_context = None
+
+        context = Context()
+
+    # Should succeed without requiring/validating 'foo'
+    ok_args = json.dumps(
+        {
+            "recipient_agent": "B",
+            "my_primary_instructions": "inst",
+            "message": "m",
+            "additional_instructions": "",
+        }
+    )
+    # Also should not fail if unknown 'foo' is supplied since schema merge failed
+    extra_args = json.dumps(
+        {
+            "recipient_agent": "B",
+            "my_primary_instructions": "inst",
+            "message": "m",
+            "additional_instructions": "",
+            "foo": "x",
+        }
+    )
+    # Both calls should return a non-error string
+    import asyncio
+
+    out1 = asyncio.get_event_loop().run_until_complete(tool.on_invoke_tool(Wrapper(), ok_args))
+    out2 = asyncio.get_event_loop().run_until_complete(tool.on_invoke_tool(Wrapper(), extra_args))
+    assert isinstance(out1, str)
+    assert isinstance(out2, str)
+    assert not out1.startswith("Error: Invalid extra parameters")
+    assert not out2.startswith("Error: Invalid extra parameters")
+
+
+# Additional nested schema coverage (int + str fields)
+
+
+class SenderStub:
+    def __init__(self, name: str, description: str = "") -> None:
+        self.name = name
+        self.description = description
+        self.return_input_guardrail_errors = True
+
+    async def get_response(self, **kwargs):  # pragma: no cover - simple stub
+        class Resp:
+            final_output = "done"
+
+        return Resp()
+
+
+class SendMessageWithNested(SendMessage):
+    class ExtraParams(BaseModel):
+        foo: int = Field(description="foo")
+        bar: str = Field(description="bar")
+
+
+@pytest.mark.asyncio
+async def test_nested_extra_params_schema_and_success() -> None:
+    """End-to-end: merged schema fields validate and a success response returns."""
+    sender = cast(Any, SenderStub("Sender"))
+    recipient = cast(Any, SenderStub("Recipient"))
+    tool = SendMessageWithNested(sender_agent=sender, recipients={"B": recipient})
+
+    props = tool.params_json_schema["properties"]
+    assert props["foo"]["type"] == "integer"
+    assert props["bar"]["type"] == "string"
+    required = tool.params_json_schema["required"]
+    assert "foo" in required and "bar" in required
+
+    args = {
+        "recipient_agent": "B",
+        "my_primary_instructions": "inst",
+        "message": "hi",
+        "additional_instructions": "",
+        "foo": 1,
+        "bar": "x",
+    }
+
+    class Wrapper:  # minimal public-like wrapper
+        context = type(
+            "Ctx",
+            (),
+            {
+                "agents": {"B": recipient},
+                "user_context": None,
+                "thread_manager": None,
+                "shared_instructions": None,
+            },
+        )()
+
+    result = await tool.on_invoke_tool(cast(Any, Wrapper()), json.dumps(args))
+    assert result == "done"
+
+
+@pytest.mark.asyncio
+async def test_nested_extra_params_missing_field_error() -> None:
+    """Missing required nested field should produce a validation error message."""
+    sender = cast(Any, SenderStub("Sender"))
+    recipient = cast(Any, SenderStub("Recipient"))
+    tool = SendMessageWithNested(sender_agent=sender, recipients={"B": recipient})
+
+    args = {
+        "recipient_agent": "B",
+        "my_primary_instructions": "",
+        "message": "",
+        "additional_instructions": "",
+        "foo": 1,
+    }
+
+    class Wrapper:
+        context = None
+
+    result = await tool.on_invoke_tool(cast(Any, Wrapper()), json.dumps(args))
+    assert isinstance(result, str) and result.startswith("Error: Invalid extra parameters")

--- a/tests/test_agent_modules/test_ui_converters.py
+++ b/tests/test_agent_modules/test_ui_converters.py
@@ -366,6 +366,7 @@ class TestConsoleEventAdapter:
         adapter.response_buffer = ""
         adapter.message_output = None
         adapter.console = MagicMock()
+        adapter.handoff_agent = None  # Initialize handoff_agent properly
 
         # Create real methods by binding them from ConsoleEventAdapter
         with patch("agency_swarm.ui.core.console_event_adapter.ConsoleEventAdapter"):


### PR DESCRIPTION
- Fix AG-UI endpoint to pass additional_instructions to agency.get_response_stream()
- Add additional_instructions field to RunAgentInputCustom model for AG-UI protocol compatibility
- Update FastAPI documentation to match current implementation:
  - Document enable_agui, enable_logging, and logs_dir parameters
  - Correct endpoint count (3 endpoints per agency, not 2)
  - Fix chat_history type description (flat list vs dict)
  - Update example code to use factory functions instead of direct Agency instances
  - Add documentation for /get_metadata and /get_logs endpoints
- Add comprehensive integration tests for additional_instructions functionality
- Fix test initialization issue in UI converters

Fixes the issue where additional_instructions POST parameter was being ignored by the FastAPI AG-UI streaming endpoint, ensuring consistency across all FastAPI endpoints.