### PR TITLE
agents: rename return_input_guardrail_errors -> throw_input_guardrail_error

### DIFF
--- a/docs/additional-features/output-validation.mdx
+++ b/docs/additional-features/output-validation.mdx
@@ -143,10 +143,10 @@ async def require_task_prefix(
     context: RunContextWrapper, agent: Agent, user_input: str | list[str]
 ) -> GuardrailFunctionOutput:
     """Require user requests to begin with 'Request:'"""
-    
+
     # Handle single string input
     condition = not user_input.startswith("Request:")
-    
+
     return GuardrailFunctionOutput(
         output_info="Prefix your request with 'Request:' describing what you need." if condition else "",
         tripwire_triggered=condition,
@@ -161,17 +161,17 @@ agent = Agent(
 
 #### Input Guardrail Return Format
 
-Agent's configuration includes an optional parameter called `return_input_guardrail_errors`, which defines how the guardrail error will be processed and presented to the caller:
+Agent's configuration includes an optional parameter called `throw_input_guardrail_error`, which defines how the guardrail error will be processed and presented to the caller:
 ```python
 agent = Agent(
     name="CustomerSupportAgent",
     instructions="You are a helpful customer support agent.",
     input_guardrails=[require_task_prefix],
-    return_input_guardrail_errors=True,
+    throw_input_guardrail_error=False,
 )
 ```
-If set to `False`, triggering a guardrail will raise a corresponding exception, as described in the next section.        
-If set to `True` (its default value), the guardrail error will be returned to the user/caller agent as if it were a genuine response from the recipient. For example, using the agent above:
+If set to `True`, triggering a guardrail will raise a corresponding exception, as described in the next section.
+If set to `False` (its default value), the guardrail error will be returned to the user/caller agent as if it were a genuine response from the recipient. For example, using the agent above:
 ```python
 response = await agency.get_response("Hello!")
 print(response.final_output)
@@ -215,7 +215,7 @@ Instead, an appropriate system message will be added in order to log a guardrail
 </Note>
 
 #### Input Guardrail Exceptions
-Unlike output guardrails, if an input guardrail exception is raised (`return_input_guardrail_errors` should be set to `False` for that to happen), the error will be immediately returned back to the user/caller agent.     
+Unlike output guardrails, if an input guardrail exception is raised (`throw_input_guardrail_error` should be set to `True` for that to happen), the error will be immediately returned back to the user/caller agent.    
 For user messages, the error processing is similar to output guardrails.
 
 ```python
@@ -225,7 +225,7 @@ except InputGuardrailTripwireTriggered as e:
     print(f"Validation failed: {e.guardrail_result.output_info}")
 ```
 
-Each triggered guardrail will also leave a corresponding system message containing error message inside of a chat history. Regardless of the `return_input_guardrail_errors` parameter value.
+Each triggered guardrail will also leave a corresponding system message containing error message inside of a chat history. Regardless of the `throw_input_guardrail_error` parameter value.
 
 <Note>
 The validation_attempts parameter currently does not apply to input guardrails.
@@ -267,7 +267,7 @@ worker = Agent(
     instructions="You are the worker agent.",
     input_guardrails=[require_task_prefix],
     output_guardrails=[require_response_prefix],
-    return_input_guardrail_errors=False,
+    throw_input_guardrail_error=True,
 )
 
 agency = Agency(
@@ -287,7 +287,7 @@ Similarly, the response of the worker to the CEO agent will be checked against t
 the specified number of `validation_attempts` it will need to generate a correct response. In this case, the requirement is that the worker's response should start with
 the word "Response:", otherwise it will receive the error message `"ERROR: Your response must start with 'Response:'"`
 
-It is recommended to set `return_input_guardrail_errors=False` for the agency's internal agents. While `True` value is also supported, setting it to `False` will add an
+It is recommended to set `throw_input_guardrail_error=True` for the agency's internal agents. While `False` value is also supported, setting it to `True` will add an
 extra error prefix to the recipient's response to indicate the issue and avoid potential confusion.
 
 <Warning>

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -52,7 +52,7 @@ The new `Agent` class extends the base `agents.Agent` with Agency Swarm-specific
 | Send Message Tool Class *(optional)* | `send_message_tool_class` | Custom SendMessage tool class to use for inter-agent communication. If None, uses the default SendMessage class. Default: `None` |
 | Include Search Results *(optional)* | `include_search_results` | Include search results in FileSearchTool output for citation extraction. Default: `False` |
 | Validation Attempts *(optional)* | `validation_attempts` | Number of retries when an output guardrail trips. Default: `1` |
-| Return Input Guardrail Errors *(optional)* | `return_input_guardrail_errors` | If set to `True`, input guardrail errors will be returned as agent's response. If set to `False`, will return a corresponding error. Default: `None` |
+| Throw Input Guardrail Error *(optional)* | `throw_input_guardrail_error` | If set to `True`, input guardrail errors raise an exception. If set to `False`, the guardrail message is returned as the agent's response. Default: `False` |
 
 ### Core Agent Parameters
 

--- a/examples/guardrails.py
+++ b/examples/guardrails.py
@@ -119,7 +119,7 @@ customer_support_agent = Agent(
     model_settings=ModelSettings(temperature=0.0),
     input_guardrails=[require_support_prefix],
     validation_attempts=1,  # set to 0 for immediate fail-fast behavior
-    return_input_guardrail_errors=True,  # set to False to return an exception when the input guardrail is triggered
+    throw_input_guardrail_error=False,  # set to True to raise an exception when the input guardrail is triggered
 )
 
 database_agent = Agent(
@@ -134,7 +134,7 @@ database_agent = Agent(
     model_settings=ModelSettings(temperature=0.0),
     input_guardrails=[require_name],
     output_guardrails=[forbid_email_output],
-    return_input_guardrail_errors=False,  # Keep false so the support agent sees message as an error.
+    throw_input_guardrail_error=True,  # Keep true so the support agent sees message as an error.
 )
 
 

--- a/src/agency_swarm/agent/execution.py
+++ b/src/agency_swarm/agent/execution.py
@@ -122,7 +122,7 @@ class Execution:
                 current_agent_run_id=current_agent_run_id,
                 parent_run_id=parent_run_id,
                 validation_attempts=int(getattr(self.agent, "validation_attempts", 1) or 0),
-                return_input_guardrail_errors=getattr(self.agent, "return_input_guardrail_errors", False),
+                throw_input_guardrail_error=getattr(self.agent, "throw_input_guardrail_error", False),
             )
             completion_info = (
                 f"Output Type: {type(run_result.final_output).__name__}"
@@ -297,7 +297,7 @@ class Execution:
                 current_agent_run_id=current_agent_run_id,
                 parent_run_id=parent_run_id,
                 validation_attempts=int(getattr(self.agent, "validation_attempts", 1) or 0),
-                return_input_guardrail_errors=getattr(self.agent, "return_input_guardrail_errors", True),
+                throw_input_guardrail_error=getattr(self.agent, "throw_input_guardrail_error", False),
             ):
                 yield event
 

--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -131,6 +131,17 @@ def handle_deprecated_parameters(kwargs: dict[str, Any]) -> dict[str, Any]:
         )
         deprecated_args_used["refresh_from_id"] = kwargs.pop("refresh_from_id")
 
+    if "return_input_guardrail_errors" in kwargs:
+        val = kwargs.pop("return_input_guardrail_errors")
+        warnings.warn(
+            "'return_input_guardrail_errors' has been renamed to 'throw_input_guardrail_error'.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        # Inverse semantics: return_input_guardrail_errors=True means do NOT throw
+        kwargs["throw_input_guardrail_error"] = not bool(val)
+        deprecated_args_used["return_input_guardrail_errors"] = val
+
     # Handle response_format parameter mapping to output_type
     if "response_format" in kwargs:
         response_format = kwargs.pop("response_format")

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -442,10 +442,10 @@ class SendMessage(FunctionTool):
                 f"Input guardrail triggered during sub-call via tool '{self.name}' from "
                 f"'{sender_name_for_call}' to '{recipient_name_for_call}': {message}"
             )
-            if self.recipient_agent.return_input_guardrail_errors:
-                return message
-            else:
+            if self.recipient_agent.throw_input_guardrail_error:
                 return f"Error getting response from the agent: {message}"
+            else:
+                return message
 
         except Exception as e:
             logger.error(

--- a/tests/test_agent_modules/send_message/test_extra_params.py
+++ b/tests/test_agent_modules/send_message/test_extra_params.py
@@ -11,7 +11,7 @@ class StubAgent:
     def __init__(self, name: str):
         self.name = name
         self.description = ""
-        self.return_input_guardrail_errors = False
+        self.throw_input_guardrail_error = True
 
     async def get_response(
         self,
@@ -172,7 +172,7 @@ class SenderStub:
     def __init__(self, name: str, description: str = "") -> None:
         self.name = name
         self.description = description
-        self.return_input_guardrail_errors = True
+        self.throw_input_guardrail_error = False
 
     async def get_response(self, **kwargs):  # pragma: no cover - simple stub
         class Resp:

--- a/tests/test_agent_modules/test_guardrail_validation.py
+++ b/tests/test_agent_modules/test_guardrail_validation.py
@@ -39,7 +39,7 @@ async def test_input_guardrail_no_retry_streaming(monkeypatch, minimal_agent):
     agent = minimal_agent
     # Ensure multiple attempts available to prove no retry happens
     agent.validation_attempts = 2
-    agent.return_input_guardrail_errors = False
+    agent.throw_input_guardrail_error = True
 
     ctx = AgencyContext(agency_instance=None, thread_manager=ThreadManager(), subagents={})
 
@@ -77,7 +77,7 @@ async def test_input_guardrail_no_retry_streaming(monkeypatch, minimal_agent):
 @patch("agents.Runner.run", new_callable=AsyncMock)
 async def test_input_guardrail_returns_error_non_stream(mock_runner_run, minimal_agent, mock_thread_manager):
     agent = minimal_agent
-    agent.return_input_guardrail_errors = True
+    agent.throw_input_guardrail_error = False
 
     class _InRes:
         output = GuardrailFunctionOutput(


### PR DESCRIPTION
- rename return_input_guardrail_errors -> throw_input_guardrail_error
- update execution paths, SendMessage, tests, docs, and examples
- add deprecation shim and init arg mapping with inverse semantics
