### PR TITLE
feat: add show_reasoning parameter to control reasoning traces display

### DIFF
--- a/examples/interactive/terminal_demo.py
+++ b/examples/interactive/terminal_demo.py
@@ -61,4 +61,4 @@ agency = create_demo_agency()
 
 
 if __name__ == "__main__":
-    agency.terminal_demo()
+    agency.terminal_demo(show_reasoning=True)

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -454,13 +454,13 @@ class Agency:
 
         return visualize(self, output_file, include_tools, open_browser)
 
-    def terminal_demo(self) -> None:
+    def terminal_demo(self, show_reasoning: bool = False) -> None:
         """
         Run a terminal demo of the agency.
         """
         from .visualization import terminal_demo
 
-        return terminal_demo(self)
+        return terminal_demo(self, show_reasoning=show_reasoning)
 
     def copilot_demo(
         self,

--- a/src/agency_swarm/agency/visualization.py
+++ b/src/agency_swarm/agency/visualization.py
@@ -146,14 +146,14 @@ def visualize(
     )
 
 
-def terminal_demo(agency: "Agency") -> None:
+def terminal_demo(agency: "Agency", show_reasoning: bool = False) -> None:
     """
     Run a terminal demo of the agency.
     """
     # Import and run the terminal demo
     from agency_swarm.ui.demos.launcher import TerminalDemoLauncher
 
-    TerminalDemoLauncher.start(agency)
+    TerminalDemoLauncher.start(agency, show_reasoning=show_reasoning)
 
 
 def copilot_demo(

--- a/src/agency_swarm/ui/core/console_event_adapter.py
+++ b/src/agency_swarm/ui/core/console_event_adapter.py
@@ -115,6 +115,11 @@ class ConsoleEventAdapter:
                     # --- Reasoning summary streaming (o-series models) ---
                     if data_type == "response.reasoning_summary_text.delta":
                         if not self.show_reasoning:
+                            # Show only header when reasoning is disabled
+                            if not self._reasoning_displayed:
+                                header_text = f"[italic dim]🧠 {agent_name} Reasoning[/]"
+                                self.console.print(header_text)
+                                self._reasoning_displayed = True
                             return
                         try:
                             delta_text = getattr(data, "delta", "") or ""
@@ -222,6 +227,11 @@ class ConsoleEventAdapter:
                         # If a reasoning item is added, open the reasoning region and seed content if present
                         if getattr(item, "type", "") == "reasoning":
                             if not self.show_reasoning:
+                                # Show only header when reasoning is disabled
+                                if not self._reasoning_displayed:
+                                    header_text = f"[italic dim]🧠 {agent_name} Reasoning[/]"
+                                    self.console.print(header_text)
+                                    self._reasoning_displayed = True
                                 return
                             # Seed with any current summary text
                             try:
@@ -285,6 +295,13 @@ class ConsoleEventAdapter:
                         # Ensure reasoning region is finalized on item completion
                         item = data.item
                         if getattr(item, "type", "") == "reasoning":
+                            if not self.show_reasoning:
+                                # Show only header when reasoning is disabled
+                                if not self._reasoning_displayed:
+                                    header_text = f"[italic dim]🧠 {agent_name} Reasoning[/]"
+                                    self.console.print(header_text)
+                                    self._reasoning_displayed = True
+                                return
                             # If we didn't receive deltas, use the item's final summary text
                             try:
                                 summaries = getattr(item, "summary", []) or []

--- a/src/agency_swarm/ui/demos/launcher.py
+++ b/src/agency_swarm/ui/demos/launcher.py
@@ -210,7 +210,7 @@ class TerminalDemoLauncher:
         return await _compact(agency_instance, args)
 
     @staticmethod
-    def start(agency_instance: Agency) -> None:
+    def start(agency_instance: Agency, show_reasoning: bool = False) -> None:
         from .terminal import start_terminal  # defer import to keep file light
 
-        start_terminal(agency_instance)
+        start_terminal(agency_instance, show_reasoning=show_reasoning)

--- a/src/agency_swarm/ui/demos/terminal.py
+++ b/src/agency_swarm/ui/demos/terminal.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 
 
-def start_terminal(agency_instance) -> None:
+def start_terminal(agency_instance, show_reasoning: bool = False) -> None:
     """Run the terminal demo: input loop, slash commands, and streaming output."""
     import asyncio
     import logging
@@ -24,7 +24,7 @@ def start_terminal(agency_instance) -> None:
 
     chat_id = f"run_demo_chat_{uuid.uuid4()}"
 
-    event_converter = ConsoleEventAdapter()
+    event_converter = ConsoleEventAdapter(show_reasoning=show_reasoning)
     event_converter.console.rule()
     try:
         cwd = os.getcwd()


### PR DESCRIPTION
Add configurable show_reasoning parameter (default: false) to control whether reasoning trace deltas are displayed in terminal demo. When disabled, only reasoning headers are shown.