### PR TITLE
fix: align launcher chat persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Avoid growing already large files. Prefer extracting focused modules. If you mus
 - Do not test private APIs or patch private attributes/methods. Interact via public interfaces only.
 - Prefer behavior verification over implementation details. Tests should validate externally observable outcomes.
 - Keep mocks/stubs minimal and realistic; avoid over-mocking. Use simple stubs to emulate public behavior only.
+- When possible, exercise actual framework components instead of crafting bespoke stand-ins.
 - Follow the testing pyramid: prioritize unit tests for focused logic; add integration tests for real wiring/flows without duplicating unit scopes.
 - Avoid duplicate assertions across unit and integration levels; each test should have a clear, non-overlapping purpose.
 - Use descriptive, stable names (no throwaway labels); optimize for readability and intent.

--- a/src/agency_swarm/utils/thread.py
+++ b/src/agency_swarm/utils/thread.py
@@ -172,6 +172,10 @@ class ThreadManager:
         self._store.add_messages(messages)
         self._save_messages()
 
+    def persist(self) -> None:
+        """Manually trigger the save callback with current messages, if configured."""
+        self._save_messages()
+
     def get_conversation_history(self, agent: str, caller_agent: str | None = None) -> list[TResponseInputItem]:
         """Get conversation history for a specific interaction pair.
 

--- a/tests/integration/test_guardrails_integration.py
+++ b/tests/integration/test_guardrails_integration.py
@@ -102,6 +102,7 @@ def test_input_guardrail_guidance_and_persistence(input_guardrail_agency: Agency
     assert "prefix your request with 'Support:'" in system_msgs[-1].get("content", "")
     assert system_msgs[-1].get("message_origin") == "input_guardrail_message"
 
+
 def test_input_guardrail_error(input_guardrail_agency: Agency):
     agency = input_guardrail_agency
     agency.agents["InputGuardrailAgent"].throw_input_guardrail_error = True


### PR DESCRIPTION
- keep TerminalDemoLauncher.CURRENT_CHAT_ID in sync with agency instances and guard rollbacks by restoring the prior id whenever a load fails
- harden persistence.load_chat to validate payloads, respect add_messages/add_message APIs, and fire persist callbacks so resumed chats reuse the original files
- expose ThreadManager.persist and teach the terminal demo to flush before issuing new chat ids, eliminating shadow transcript files from temporary sessions
- extend launcher regression tests with real ThreadManager usage plus pytest fixture resets, and document testing guidance about exercising framework components