### PR TITLE
Fix persistent MCP manager driver reuse

### DIFF
--- a/tests/test_agent_modules/test_mcp_manager.py
+++ b/tests/test_agent_modules/test_mcp_manager.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agency_swarm.tools.mcp_manager import LoopAffineAsyncProxy, PersistentMCPServerManager
+
+
+class _DummyServer:
+    def __init__(self) -> None:
+        self.name = "dummy"
+        self.session = None
+        self.connect_calls = 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+        self.session = object()
+
+    async def cleanup(self) -> None:
+        self.session = None
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_reuses_driver_for_proxy() -> None:
+    manager = PersistentMCPServerManager()
+    server = _DummyServer()
+
+    await manager.ensure_connected(server)
+    proxy = LoopAffineAsyncProxy(server, manager)
+
+    await manager.ensure_connected(proxy)
+
+    try:
+        assert len(manager._drivers) == 1
+    finally:
+        await manager.shutdown()


### PR DESCRIPTION
## Summary
- ensure the persistent MCP server manager always indexes drivers by the real server instance so proxies reuse a single driver
- add a regression test covering the proxy reuse scenario for `ensure_connected`

## Testing
- uv run pytest tests/test_agent_modules/test_mcp_manager.py -v
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68cd682b15f08323bd46348ceec8f628