### PR TITLE
Fix function call output deduplication

### DIFF
--- a/src/agency_swarm/utils/thread.py
+++ b/src/agency_swarm/utils/thread.py
@@ -49,7 +49,8 @@ class MessageStore:
                     self.messages[idx] = message
                     logger.debug("Replacing duplicate message with id %s and type %s", message_id, msg_type)
                     return
-        elif msg_type == "function_call_output" and message.get("call_id"):
+
+        if msg_type == "function_call_output":
             call_id = message.get("call_id")
             if call_id and call_id != FAKE_RESPONSES_ID:
                 for idx, existing in enumerate(self.messages):

--- a/tests/test_agent_modules/test_thread_manager.py
+++ b/tests/test_agent_modules/test_thread_manager.py
@@ -114,6 +114,32 @@ def test_duplicate_function_call_output_replaces_existing_entry():
     assert manager._store.messages[0]["output"] == "final"
 
 
+def test_function_call_output_dedupes_by_call_id_even_with_unique_ids():
+    manager = ThreadManager()
+
+    first_output = {
+        "type": "function_call_output",
+        "id": "msg-1",
+        "call_id": "call-1",
+        "output": "placeholder",
+        "timestamp": 1,
+    }
+    final_output = {
+        "type": "function_call_output",
+        "id": "msg-2",
+        "call_id": "call-1",
+        "output": "final",
+        "timestamp": 2,
+    }
+
+    manager.add_message(first_output)
+    manager.add_message(final_output)
+
+    assert len(manager._store.messages) == 1
+    assert manager._store.messages[0]["id"] == "msg-2"
+    assert manager._store.messages[0]["output"] == "final"
+
+
 def test_placeholder_messages_are_not_deduped():
     manager = ThreadManager()
 


### PR DESCRIPTION
## Summary
- allow MessageStore to check function_call_output duplicates by call_id even when message ids differ
- cover the regression with a unit test that reproduces the duplicate call output scenario

## Testing
- uv run pytest tests/test_agent_modules/test_thread_manager.py


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates `function_call_output` messages by `call_id` regardless of differing `id`s and adds a unit test to cover it.
> 
> - **Fix**: `MessageStore.add_message` in `src/agency_swarm/utils/thread.py`
>   - Reworks dedupe logic so `function_call_output` entries are replaced based on matching `call_id` even when message `id` values differ.
> - **Tests**: `tests/test_agent_modules/test_thread_manager.py`
>   - Add `test_function_call_output_dedupes_by_call_id_even_with_unique_ids` to validate the new dedupe behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4eed001c4c30540c8926c5ca5e16edf5ce8017b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->