### PR TITLE
fix: improve files_folder parsing to detect and reuse existing vector store directories

### DIFF
--- a/examples/interactive/hybrid_communication_flows.py
+++ b/examples/interactive/hybrid_communication_flows.py
@@ -103,11 +103,13 @@ class SendMessageWithProjectContext(SendMessage):
 # You can adjust the reminder message or disable it entirely by adjusting parameters below.
 class CustomReminderHandoff(SendMessageHandoff):
     """SendMessageHandoff with custom reminder."""
-    add_reminder = True # True by default
+
+    add_reminder = True  # True by default
 
     # Note: this reminder is for the recipient agent, not the caller agent.
     # Default reminder: "You are now {recipient_agent_name}. Please continue the task."
     reminder_override = "You are developer agent, do not forget to ask for security audit."
+
 
 project_manager = Agent(
     name="ProjectManager",

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -204,7 +204,7 @@ class Agent(BaseAgent[MasterContext]):
             raise RuntimeError(f"Agent {self.name} has no file manager configured")
 
         self.file_manager.read_instructions()
-        self.file_manager._parse_files_folder_for_vs_id()
+        self.file_manager.parse_files_folder_for_vs_id()
         parse_schemas(self)
         load_tools_from_folder(self)
 

--- a/src/agency_swarm/agent/file_manager.py
+++ b/src/agency_swarm/agent/file_manager.py
@@ -408,7 +408,7 @@ class AgentFileManager:
 
     def _create_or_identify_vector_store(self, folder_path: Path) -> str | None:
         """Create vector store and rename folder, or extract existing VS ID from path."""
-        vs_id_match = re.search(r"(.+)_(vs_[a-zA-Z0-9_]{15,})$", str(folder_path))
+        vs_id_match = re.search(r"(.+)_(vs_[a-zA-Z0-9]{15,})$", str(folder_path))
 
         if vs_id_match:
             if not folder_path.exists():

--- a/src/agency_swarm/agent/file_manager.py
+++ b/src/agency_swarm/agent/file_manager.py
@@ -170,7 +170,13 @@ class AgentFileManager:
         # ALWAYS check for existing vector store directories first, regardless of original directory existence
         parent = folder_path.parent
         base_name = folder_path.name
-        candidates = list(parent.glob(f"{base_name}_vs_*"))
+        base_name_without_vs = base_name.split("_vs_")[0] if "_vs_" in base_name else base_name
+
+        candidates = list(parent.glob(f"{base_name_without_vs}_vs_*"))
+
+        # If the provided folder already points to a vector store directory, prefer it.
+        if folder_path.exists() and "_vs_" in base_name and folder_path not in candidates:
+            candidates.insert(0, folder_path)
 
         if candidates:
             # Use the first existing vector store directory found

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -364,7 +364,7 @@ async def generate_chat_name(new_messages: list[TResponseInputItem]):
     class ResponseFormat(BaseModel):
         chat_name: str = Field(description="A fitting name for the provided chat history.")
 
-    @output_guardrail # type: ignore[arg-type]
+    @output_guardrail  # type: ignore[arg-type]
     async def response_content_guardrail(
         context: RunContextWrapper, agent: Agent, response_text: str | type[BaseModel]
     ) -> GuardrailFunctionOutput:
@@ -383,7 +383,8 @@ async def generate_chat_name(new_messages: list[TResponseInputItem]):
         )
 
     from agency_swarm.messages import MessageFormatter
-    formatted_messages = str(MessageFormatter.strip_agency_metadata(new_messages)) # type: ignore[arg-type]
+
+    formatted_messages = str(MessageFormatter.strip_agency_metadata(new_messages))  # type: ignore[arg-type]
     if len(formatted_messages) > 1000:
         formatted_messages = "HISTORY TRUNCATED TO 1000 CHARACTERS:\n" + formatted_messages[:1000]
 
@@ -393,7 +394,7 @@ async def generate_chat_name(new_messages: list[TResponseInputItem]):
         name="NameGenerator",
         model=model,
         instructions=(
-"""
+            """
 You are a helpful assistant that generates a human-friendly title for a conversation.
 You will receive a list of messages where the first one is the user input and the rest are
 related to the assistant response.

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -44,8 +44,7 @@ class BaseRequest(BaseModel):
     )
     additional_instructions: str | None = None
     generate_chat_name: bool | None = Field(
-        default=False,
-        description="Generate a fitting chat name for the user input."
+        default=False, description="Generate a fitting chat name for the user input."
     )
 
 

--- a/src/agency_swarm/messages/message_formatter.py
+++ b/src/agency_swarm/messages/message_formatter.py
@@ -122,12 +122,7 @@ class MessageFormatter:
         cleaned = []
         for msg in messages:
             # Create a copy without agency fields (including citations which OpenAI doesn't accept)
-            clean_msg = {
-                k: v
-                for k, v in msg.items()
-                if k
-                not in MessageFormatter.metadata_fields
-            }
+            clean_msg = {k: v for k, v in msg.items() if k not in MessageFormatter.metadata_fields}
             cleaned.append(clean_msg)
         return cleaned
 

--- a/src/agency_swarm/tools/mcp_manager.py
+++ b/src/agency_swarm/tools/mcp_manager.py
@@ -82,9 +82,7 @@ class PersistentMCPServerManager:
         # Wait until driver has connected
         if not ready_evt.wait(timeout=self._timeouts.get("connect", 20.0)):
             # Handle timeout explicitly
-            raise TimeoutError(
-                f"Server {getattr(server, 'name', '<unnamed>')} failed to connect within timeout"
-            )
+            raise TimeoutError(f"Server {getattr(server, 'name', '<unnamed>')} failed to connect within timeout")
         # Track whether this driver created the session to decide who cleans up
         created_by_driver = getattr(real_server, "session", None) is not None
         self._drivers[real_server] = {"queue": queue, "real": real_server, "created_by_driver": created_by_driver}


### PR DESCRIPTION
Improve `files_folder` parsing to detect and reuse existing vector store directories (including when the provided path is already a VS directory) and update tests to cover reuse, creation/rename, and missing-folder error logging.

- AgentFileManager (`src/agency_swarm/agent/file_manager.py`):
  - Enhance `_parse_files_folder_for_vs_id` to:
    - Derive `base_name_without_vs` and glob for `{name}_vs_*` consistently.
    - Prefer the provided folder when it already points to a vector store directory.
    - Reuse the detected vector store directory and update `files_folder`, `_associated_vector_store_id`, and paths.

- Tests (`tests/test_agent_modules/test_agent_file_manager.py`):
  - Add tests for reusing a detected vector store, creating/renaming a folder without warnings, and logging an error when the directory is missing.
  - Streamline docstrings and remove obsolete cases.