### PR TITLE
fix: cli error handling and AGENTS.md compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,12 @@ dev-dependencies = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/agency_swarm"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/agency_swarm/cli/utils/generate-agent-from-settings.ts" = "agency_swarm/cli/utils/generate-agent-from-settings.ts"
+
+[tool.hatch.build.targets.sdist.force-include]
+"src/agency_swarm/cli/utils/generate-agent-from-settings.ts" = "agency_swarm/cli/utils/generate-agent-from-settings.ts"
+
 [tool.ruff]
 line-length = 120
 target-version = "py313"

--- a/src/agency_swarm/cli/main.py
+++ b/src/agency_swarm/cli/main.py
@@ -3,6 +3,8 @@
 import argparse
 import sys
 
+from agency_swarm.utils.create_agent_template import create_agent_template
+
 from .migrate_agent import migrate_agent_command
 
 
@@ -58,10 +60,9 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "migrate-agent":
-        migrate_agent_command(args.settings_file, args.output_dir)
+        exit_code = migrate_agent_command(args.settings_file, args.output_dir)
+        sys.exit(exit_code)
     elif args.command == "create-agent-template":
-        from agency_swarm.utils.create_agent_template import create_agent_template
-
         try:
             success = create_agent_template(
                 agent_name=args.name,

--- a/src/agency_swarm/cli/migrate_agent.py
+++ b/src/agency_swarm/cli/migrate_agent.py
@@ -1,6 +1,7 @@
 """Migrate OpenAI Assistant settings.json to Agency Swarm v1.x agent."""
 
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
@@ -30,66 +31,59 @@ def find_typescript_script() -> Path | None:
 
 
 def check_node_dependencies() -> bool:
-    """Check if Node.js and required dependencies are available."""
-    import platform
-
+    """Check if Node.js and ts-node are available."""
     is_windows = platform.system() == "Windows"
 
-    try:
-        # Check if Node.js is available
-        subprocess.run(["node", "--version"], capture_output=True, check=True, shell=is_windows)
-
-        # Check if TypeScript is available (either globally or via npx)
-        try:
-            subprocess.run(["npx", "tsc", "--version"], capture_output=True, check=True, shell=is_windows)
-            return True
-        except subprocess.CalledProcessError:
-            try:
-                subprocess.run(["tsc", "--version"], capture_output=True, check=True, shell=is_windows)
-                return True
-            except subprocess.CalledProcessError:
-                # Try ts-node as well since we need it
-                try:
-                    subprocess.run(["npx", "ts-node", "--version"], capture_output=True, check=True, shell=is_windows)
-                    return True
-                except subprocess.CalledProcessError:
-                    return False
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    # Node.js is required
+    if not _command_succeeds(["node", "--version"], shell=is_windows):
         return False
 
+    # ts-node is required (we run the TypeScript directly via ts-node)
+    # Try npx first (more common), then global install
+    if _command_succeeds(["npx", "ts-node", "--version"], shell=is_windows):
+        return True
 
-def migrate_agent_command(settings_file: str, output_dir: str = ".") -> None:
-    """Main function to generate agent from settings.json using TypeScript script."""
-    import platform
+    return _command_succeeds(["ts-node", "--version"], shell=is_windows)
 
+
+def migrate_agent_command(settings_file: str, output_dir: str = ".") -> int:
+    """Main function to generate agent from settings.json using TypeScript script.
+
+    Returns
+    -------
+    int
+        Exit code: 0 for success, 1 for error.
+    """
     is_windows = platform.system() == "Windows"
 
     settings_path = Path(settings_file)
 
     if not settings_path.exists():
-        print(f"Error: Settings file '{settings_file}' not found.")
-        return
+        print(f"Error: Settings file '{settings_file}' not found.", file=sys.stderr)
+        return 1
 
     # Find the TypeScript script
     ts_script = find_typescript_script()
     if not ts_script:
-        print("Error: TypeScript generator script 'generate-agent-from-settings.ts' not found.")
-        print("Expected location: src/agency_swarm/cli/utils/generate-agent-from-settings.ts")
-        return
+        print("Error: TypeScript generator script 'generate-agent-from-settings.ts' not found.", file=sys.stderr)
+        print("Expected location: src/agency_swarm/cli/utils/generate-agent-from-settings.ts", file=sys.stderr)
+        return 1
 
     # Check Node.js dependencies
     if not check_node_dependencies():
-        print("Error: Node.js and TypeScript are required to run the agent generator.")
-        print("Please install Node.js and TypeScript:")
-        print("  1. Install Node.js: https://nodejs.org/")
-        print("  2. Install TypeScript: npm install -g typescript ts-node")
-        return
+        print("Error: Node.js and ts-node are required to run the agent generator.", file=sys.stderr)
+        print("Please install Node.js and ts-node:", file=sys.stderr)
+        print("  1. Install Node.js: https://nodejs.org/", file=sys.stderr)
+        print("  2. Install ts-node: npm install -g ts-node", file=sys.stderr)
+        return 1
 
     # Resolve paths before changing directories
     original_cwd = Path.cwd()
     output_path = Path(output_dir).resolve()
     settings_arg = str(settings_path.resolve())
     output_path.mkdir(parents=True, exist_ok=True)
+
+    result: subprocess.CompletedProcess | None = None
 
     try:
         os.chdir(output_path)
@@ -103,19 +97,34 @@ def migrate_agent_command(settings_file: str, output_dir: str = ".") -> None:
 
         result = subprocess.run(cmd, capture_output=True, text=True, shell=is_windows)
 
-        if result.returncode == 0:
-            print(result.stdout)
-        else:
-            print("Error running TypeScript generator:")
-            print(result.stderr)
-            if result.stdout:
-                print("Output:")
-                print(result.stdout)
-            sys.exit(1)
-
     except Exception as e:
-        print(f"Error running agent generator: {e}")
-        sys.exit(1)
+        print(f"Error running agent generator: {e}", file=sys.stderr)
+        return 1
     finally:
         # Restore original working directory
         os.chdir(original_cwd)
+
+    # Handle result after restoring directory
+    if result and result.returncode == 0:
+        if result.stdout:
+            print(result.stdout)
+        return 0
+
+    # Error case
+    print("Error running TypeScript generator:", file=sys.stderr)
+    if result and result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result and result.stdout:
+        print("Output:", file=sys.stderr)
+        print(result.stdout, file=sys.stderr)
+
+    return result.returncode if result else 1
+
+
+def _command_succeeds(command: list[str], *, shell: bool) -> bool:
+    """Check if a command runs successfully."""
+    try:
+        subprocess.run(command, capture_output=True, check=True, shell=shell)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False

--- a/src/agency_swarm/cli/utils/generate-agent-from-settings.ts
+++ b/src/agency_swarm/cli/utils/generate-agent-from-settings.ts
@@ -2,12 +2,12 @@
 
 /**
  * Script to generate Agency Swarm v1.x agent from settings.json file.
- * 
+ *
  * Usage:
  *   npx ts-node generate-agent-from-settings.ts <settings.json>
  *   OR
  *   node generate-agent-from-settings.js <settings.json>
- * 
+ *
  * This will create a single agent folder in the current directory.
  */
 
@@ -59,21 +59,21 @@ function mapJsonTypeToPython(jsonType: string): string {
 function generatePydanticModel(schema: any, className: string): string {
   const properties = schema.schema_?.properties || schema.properties || {};
   const required = schema.schema_?.required || schema.required || [];
-  
+
   let modelClass = `class ${className}(BaseModel):\n`;
-  
+
   for (const [fieldName, fieldDef] of Object.entries(properties)) {
     const field = fieldDef as any;
-    
+
     // Map the type
     const pythonType = mapJsonTypeToPython(field.type || 'string');
-    
+
     // Check if field is required
     const isRequired = required.includes(fieldName);
-    
+
     // Build Field parameters dynamically from all available properties
     const fieldParams: string[] = [];
-    
+
     // Add all field properties except 'type' (which becomes the Python type)
     for (const [key, value] of Object.entries(field)) {
       if (key !== 'type' && value !== undefined && value !== null) {
@@ -90,7 +90,7 @@ function generatePydanticModel(schema: any, className: string): string {
         }
       }
     }
-    
+
     // Generate the field definition
     if (isRequired && fieldParams.length > 0) {
       modelClass += `    ${fieldName}: ${pythonType} = Field(${fieldParams.join(', ')})\n`;
@@ -102,7 +102,7 @@ function generatePydanticModel(schema: any, className: string): string {
       modelClass += `    ${fieldName}: ${pythonType} = None\n`;
     }
   }
-  
+
   return modelClass;
 }
 
@@ -119,7 +119,7 @@ function toPythonObject(obj: any): string {
     return '[' + obj.map(item => toPythonObject(item)).join(', ') + ']';
   }
   if (typeof obj === 'object') {
-    const pairs = Object.entries(obj).map(([key, value]) => 
+    const pairs = Object.entries(obj).map(([key, value]) =>
       `"${key}": ${toPythonObject(value)}`
     );
     return '{' + pairs.join(', ') + '}';
@@ -133,26 +133,26 @@ function toPythonObject(obj: any): string {
 function sanitizeName(name: string): string {
   // Replace spaces with underscores
   let sanitized = name.replace(/\s+/g, '_');
-  
+
   // Remove other special characters (but keep letters, numbers, underscores)
   sanitized = sanitized.replace(/[^a-zA-Z0-9_]/g, '');
-  
+
   // Remove multiple underscores
   sanitized = sanitized.replace(/_+/g, '_');
-  
+
   // Remove leading/trailing underscores
   sanitized = sanitized.replace(/^_+|_+$/g, '');
-  
+
   // If starts with digit, prepend 'agent_'
   if (/^\d/.test(sanitized)) {
     sanitized = 'agent_' + sanitized;
   }
-  
+
   // Ensure it's not empty
   if (!sanitized) {
     sanitized = 'agent';
   }
-  
+
   return sanitized;
 }
 
@@ -169,29 +169,29 @@ function generateInstructionsMd(agentData: AgentSettings): string {
  */
 function generateAgentPy(agentData: AgentSettings, agentName: string): string {
   const displayName = agentData.name;
-  
+
   // Build optional agent parameters
   let optionalParams = '';
-  
+
   if (agentData.description) {
     optionalParams += `    description="${agentData.description}",\n`;
   }
-  
+
   // Handle response_format for JSON output
   let pydanticModelClass = '';
   if (agentData.response_format && agentData.response_format !== "auto") {
-    if (agentData.response_format === "json_object" || 
+    if (agentData.response_format === "json_object" ||
         (typeof agentData.response_format === "object" && agentData.response_format.type === "json_object")) {
       // For JSON object output, use AgentOutputSchema with dict[str, Any]
       optionalParams += `    output_type=AgentOutputSchema(dict[str, Any], strict_json_schema=False),\n`;
       optionalParams += `    validation_attempts=5,\n`;
-    } else if (typeof agentData.response_format === "object" && 
-               agentData.response_format.type === "json_schema" && 
+    } else if (typeof agentData.response_format === "object" &&
+               agentData.response_format.type === "json_schema" &&
                agentData.response_format.json_schema) {
       // For JSON schema, create a Pydantic model class
       const schema = agentData.response_format.json_schema;
       const className = schema.name || 'OutputModel';
-      
+
       pydanticModelClass = generatePydanticModel(schema, className);
       optionalParams += `    output_type=${className},\n`;
     } else {
@@ -200,110 +200,110 @@ function generateAgentPy(agentData: AgentSettings, agentName: string): string {
       optionalParams += `    output_type=${pythonCompatibleJson},\n`;
     }
   }
-  
+
   // Extract built-in tools from the tools array and create proper Tool objects
   const toolImports: string[] = [];
   const toolInstances: string[] = [];
-  
+
   if (agentData.tools) {
     for (const tool of agentData.tools) {
       if (tool.type === "file_search") {
         toolImports.push("FileSearchTool");
-        
+
         // Configure FileSearchTool with all available parameters
         let fileSearchConfig = "FileSearchTool(";
         const configParts: string[] = [];
-        
+
         if (agentData.tool_resources?.file_search?.vector_store_ids?.length) {
           const vectorStoreIds = agentData.tool_resources.file_search.vector_store_ids
             .map(id => `"${id}"`)
             .join(', ');
           configParts.push(`vector_store_ids=[${vectorStoreIds}]`);
         }
-        
+
         // Add max_num_results if present in the tool definition
         if (tool.file_search?.max_num_results !== undefined) {
           configParts.push(`max_num_results=${tool.file_search.max_num_results}`);
         }
-        
-        
+
+
         // Add ranking_options if present in the tool definition
         if (tool.file_search?.ranking_options) {
           const rankingOptions = tool.file_search.ranking_options;
           let rankingConfig = "ranking_options=RankingOptions(";
           const rankingParts: string[] = [];
-          
+
           // Always set ranker to "auto" regardless of original value (ranker likely will outdated)
           rankingParts.push(`ranker="auto"`);
-          
+
           if (rankingOptions.score_threshold !== undefined) {
             rankingParts.push(`score_threshold=${rankingOptions.score_threshold}`);
           }
-          
+
           rankingConfig += rankingParts.join(', ') + ")";
           configParts.push(rankingConfig);
-          
+
           // Add RankingOptions to imports
           if (!toolImports.includes("RankingOptions")) {
             toolImports.push("RankingOptions");
           }
         }
-        
+
         // Add filters if present (would need Filters import too)
         if (tool.file_search?.filters) {
-          configParts.push(`filters=${JSON.stringify(tool.file_search.filters)}`);
+          configParts.push(`filters=${toPythonObject(tool.file_search.filters)}`);
           // Add Filters to imports
           if (!toolImports.includes("Filters")) {
             toolImports.push("Filters");
           }
         }
-        
+
         fileSearchConfig += configParts.join(', ') + ")";
         toolInstances.push(fileSearchConfig);
       } else if (tool.type === "code_interpreter") {
         toolImports.push("CodeInterpreterTool");
-        
+
         // Configure CodeInterpreterTool with proper structure
         const fileIds = agentData.tool_resources?.code_interpreter?.file_ids || [];
         const fileIdsStr = fileIds.map(id => `"${id}"`).join(', ');
-        
+
         const codeInterpreterConfig = `CodeInterpreterTool(
             tool_config=CodeInterpreter(
                 container=CodeInterpreterContainerCodeInterpreterToolAuto(type="auto", file_ids=[${fileIdsStr}]),
                 type="code_interpreter",
             )
         )`;
-        
+
         toolInstances.push(codeInterpreterConfig);
       }
     }
   }
-  
+
   if (toolInstances.length > 0) {
     optionalParams += `    tools=[${toolInstances.join(', ')}],\n`;
   }
-  
+
   // Add model as direct parameter if provided
   if (agentData.model) {
     optionalParams += `    model="${agentData.model}",\n`;
   }
-  
+
   // Build ModelSettings - only if we have model settings to include (excluding model)
   let modelSettingsBlock = '';
   let modelSettingsParams: string[] = [];
-  
+
   if (agentData.temperature !== undefined) {
     modelSettingsParams.push(`temperature=${agentData.temperature}`);
   }
-  
+
   if (agentData.top_p !== undefined) {
     modelSettingsParams.push(`top_p=${agentData.top_p}`);
   }
-  
+
   if (agentData.reasoning_effort) {
     modelSettingsParams.push(`reasoning=Reasoning(effort="${agentData.reasoning_effort}")`);
   }
-  
+
   // Only include ModelSettings if we have parameters for it
   if (modelSettingsParams.length > 0) {
     const formattedParams = modelSettingsParams.join(',\n        ');
@@ -311,23 +311,23 @@ function generateAgentPy(agentData: AgentSettings, agentName: string): string {
         ${formattedParams}
     ),\n`;
   }
-  
+
   // Determine imports
   let imports = `from agency_swarm import Agent`;
   if (modelSettingsParams.length > 0) {
     imports += `, ModelSettings`;
   }
-  
+
   // Check if AgentOutputSchema is needed for JSON output
-  const needsAgentOutputSchema = agentData.response_format && 
-    (agentData.response_format === "json_object" || 
+  const needsAgentOutputSchema = agentData.response_format &&
+    (agentData.response_format === "json_object" ||
      (typeof agentData.response_format === "object" && agentData.response_format.type === "json_object"));
-  
+
   // Check if Pydantic imports are needed for JSON schema
-  const needsPydantic = agentData.response_format && 
-    typeof agentData.response_format === "object" && 
+  const needsPydantic = agentData.response_format &&
+    typeof agentData.response_format === "object" &&
     agentData.response_format.type === "json_schema";
-  
+
   if (needsAgentOutputSchema) {
     imports = `from typing import Any\nfrom agents.agent_output import AgentOutputSchema\n` + imports;
   } else if (needsPydantic) {
@@ -340,26 +340,26 @@ function generateAgentPy(agentData: AgentSettings, agentName: string): string {
     // Separate RankingOptions and Filters from regular agent tools
     const agentTools = toolImports.filter(tool => !['RankingOptions', 'Filters'].includes(tool));
     const openaiTools = toolImports.filter(tool => ['RankingOptions', 'Filters'].includes(tool));
-    
+
     if (agentTools.length > 0) {
       imports += `\nfrom agents import ${agentTools.join(', ')}`;
     }
-    
+
     if (openaiTools.includes('RankingOptions')) {
       imports += `\nfrom openai.types.responses.file_search_tool_param import RankingOptions`;
     }
-    
+
     if (openaiTools.includes('Filters')) {
       imports += `\nfrom openai.types.responses.file_search_tool_param import Filters`;
     }
   }
-  
+
   // Check if CodeInterpreter is needed and add separate import
   const needsCodeInterpreter = agentData.tools?.some(tool => tool.type === "code_interpreter");
   if (needsCodeInterpreter) {
     imports += `\nfrom openai.types.responses.tool_param import CodeInterpreter, CodeInterpreterContainerCodeInterpreterToolAuto`;
   }
-  
+
   const content = `${imports}
 
 ${pydanticModelClass}${pydanticModelClass ? '\n' : ''}${agentName} = Agent(
@@ -372,7 +372,7 @@ if __name__ == "__main__":
     agency = Agency(${agentName})
     print(agency.get_response_sync("What's your name?"))
 `;
-  
+
   return content;
 }
 
@@ -391,21 +391,21 @@ __all__ = ["${agentName}"]
  */
 function main(): void {
   const args = process.argv.slice(2);
-  
+
   if (args.length !== 1) {
     console.log('Usage: npx ts-node generate-agent-from-settings.ts <settings.json>');
     process.exit(1);
   }
-  
+
   const settingsFile = args[0];
-  
+
   if (!fs.existsSync(settingsFile)) {
     console.log(`Error: Settings file '${settingsFile}' not found.`);
     process.exit(1);
   }
-  
+
   let settingsData: any;
-  
+
   try {
     const fileContent = fs.readFileSync(settingsFile, 'utf8');
     settingsData = JSON.parse(fileContent);
@@ -417,10 +417,10 @@ function main(): void {
     }
     process.exit(1);
   }
-  
+
   // Handle both single agent object and array of agents
   let agentsList: AgentSettings[];
-  
+
   if (Array.isArray(settingsData)) {
     if (settingsData.length === 0) {
       console.log('Error: Empty agent list in settings file.');
@@ -431,52 +431,52 @@ function main(): void {
   } else {
     agentsList = [settingsData];
   }
-  
+
   const generatedAgents: string[] = [];
-  
+
   // Process each agent
   for (let i = 0; i < agentsList.length; i++) {
     const agentData = agentsList[i];
-    
+
     // Extract agent information
     const displayName = agentData.name || `Agent${i + 1}`;
     const agentName = sanitizeName(displayName);
-    
+
     console.log(`\n[${i + 1}/${agentsList.length}] Generating agent: ${displayName} -> ${agentName}`);
-    
+
     // Create agent directory
     const agentDir = agentName;
     if (fs.existsSync(agentDir)) {
       console.log(`Warning: Directory '${agentName}' already exists. Files will be overwritten.`);
     }
-    
+
     if (!fs.existsSync(agentDir)) {
       fs.mkdirSync(agentDir, { recursive: true });
     }
-    
+
     // Generate files
     try {
       // Generate instructions.md
       const instructionsContent = generateInstructionsMd(agentData);
       fs.writeFileSync(path.join(agentDir, 'instructions.md'), instructionsContent, 'utf8');
-      
+
       // Generate agent.py
       const agentContent = generateAgentPy(agentData, agentName);
       fs.writeFileSync(path.join(agentDir, `${agentName}.py`), agentContent, 'utf8');
-      
+
       // Generate __init__.py
       const initContent = generateInitPy(agentName, displayName);
       fs.writeFileSync(path.join(agentDir, '__init__.py'), initContent, 'utf8');
-      
+
       console.log(`Successfully generated agent '${displayName}' in directory '${agentName}/'`);
       generatedAgents.push(agentName);
-      
+
     } catch (error) {
       console.log(`Error generating agent '${displayName}': ${error}`);
       process.exit(1);
     }
   }
-  
+
   // Summary
   console.log(`\n=== Generation Complete ===`);
   console.log(`Generated ${generatedAgents.length} agent(s):`);
@@ -486,7 +486,7 @@ function main(): void {
     console.log(`     - instructions.md`);
     console.log(`     - __init__.py`);
   });
-  
+
   console.log(`\n* Review and customize agent configurations as needed.`);
 }
 

--- a/src/agency_swarm/ui/demos/copilot/package.json
+++ b/src/agency_swarm/ui/demos/copilot/package.json
@@ -15,7 +15,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.522.0",
-    "next": "15.3.4",
+    "next": "^15.4.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1"

--- a/tests/test_cli_modules/__init__.py
+++ b/tests/test_cli_modules/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for CLI modules."""

--- a/tests/test_cli_modules/test_migrate_agent.py
+++ b/tests/test_cli_modules/test_migrate_agent.py
@@ -1,0 +1,152 @@
+"""Tests for CLI migration helper utilities."""
+
+from pathlib import Path
+from subprocess import CalledProcessError, CompletedProcess
+
+import pytest
+
+from agency_swarm.cli import migrate_agent
+
+
+def test_check_node_dependencies_requires_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure dependency check fails when Node.js is unavailable."""
+
+    def fake_run(command, capture_output, check, shell):  # type: ignore[no-untyped-def]
+        raise FileNotFoundError()
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    assert migrate_agent.check_node_dependencies() is False
+
+
+def test_check_node_dependencies_requires_ts_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure dependency check fails when ts-node is unavailable even if Node is present."""
+
+    def fake_run(command, capture_output, check, shell):  # type: ignore[no-untyped-def]
+        # Node is available
+        if command[0] == "node":
+            return CompletedProcess(command, 0)
+        # ts-node is not available
+        raise CalledProcessError(1, command)
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    assert migrate_agent.check_node_dependencies() is False
+
+
+def test_check_node_dependencies_succeeds_with_npx_ts_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dependency check should succeed when npx ts-node is available."""
+
+    def fake_run(command, capture_output, check, shell):  # type: ignore[no-untyped-def]
+        if command[0] == "node":
+            return CompletedProcess(command, 0)
+        if command[:2] == ["npx", "ts-node"]:
+            return CompletedProcess(command, 0)
+        raise CalledProcessError(1, command)
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    assert migrate_agent.check_node_dependencies() is True
+
+
+def test_check_node_dependencies_succeeds_with_global_ts_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dependency check should succeed with globally installed ts-node when npx fails."""
+
+    def fake_run(command, capture_output, check, shell):  # type: ignore[no-untyped-def]
+        if command[0] == "node":
+            return CompletedProcess(command, 0)
+        if command[:2] == ["npx", "ts-node"]:
+            raise CalledProcessError(1, command)  # npx not available
+        if command[0] == "ts-node":
+            return CompletedProcess(command, 0)  # global install available
+        raise CalledProcessError(1, command)
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    assert migrate_agent.check_node_dependencies() is True
+
+
+def test_find_typescript_script_exists() -> None:
+    """The generator script should be discoverable in the package."""
+    ts_path = migrate_agent.find_typescript_script()
+    assert ts_path is not None
+    assert ts_path.exists()
+    assert ts_path.name == "generate-agent-from-settings.ts"
+
+
+def test_migrate_agent_command_missing_settings_returns_error(tmp_path: Path) -> None:
+    """Missing settings files should return exit code 1."""
+    exit_code = migrate_agent.migrate_agent_command(str(tmp_path / "missing.json"), str(tmp_path))
+    assert exit_code == 1
+
+
+def test_migrate_agent_command_missing_script_returns_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing TypeScript script should return exit code 1."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text("{}")
+
+    monkeypatch.setattr(migrate_agent, "find_typescript_script", lambda: None)
+
+    exit_code = migrate_agent.migrate_agent_command(str(settings_path), str(tmp_path))
+    assert exit_code == 1
+
+
+def test_migrate_agent_command_dependency_failure_returns_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dependency check failure should return exit code 1."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text("{}")
+
+    ts_script = tmp_path / "generate-agent-from-settings.ts"
+    ts_script.write_text("// stub")
+
+    monkeypatch.setattr(migrate_agent, "find_typescript_script", lambda: ts_script)
+    monkeypatch.setattr(migrate_agent, "check_node_dependencies", lambda: False)
+
+    exit_code = migrate_agent.migrate_agent_command(str(settings_path), str(tmp_path))
+    assert exit_code == 1
+
+
+def test_migrate_agent_command_successful_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful execution should return exit code 0."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text("{}")
+
+    ts_script = tmp_path / "generate-agent-from-settings.ts"
+    ts_script.write_text("// stub")
+
+    monkeypatch.setattr(migrate_agent, "find_typescript_script", lambda: ts_script)
+    monkeypatch.setattr(migrate_agent, "check_node_dependencies", lambda: True)
+
+    completed = CompletedProcess(["npx", "ts-node"], 0, stdout="Agent generated successfully\n", stderr="")
+
+    def fake_run(command, capture_output, text, shell):  # type: ignore[no-untyped-def]
+        return completed
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    exit_code = migrate_agent.migrate_agent_command(str(settings_path), str(tmp_path))
+    assert exit_code == 0
+
+
+def test_migrate_agent_command_failed_execution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failed execution should return non-zero exit code."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text("{}")
+
+    ts_script = tmp_path / "generate-agent-from-settings.ts"
+    ts_script.write_text("// stub")
+
+    monkeypatch.setattr(migrate_agent, "find_typescript_script", lambda: ts_script)
+    monkeypatch.setattr(migrate_agent, "check_node_dependencies", lambda: True)
+
+    completed = CompletedProcess(["npx", "ts-node"], 2, stdout="", stderr="TypeScript error\n")
+
+    def fake_run(command, capture_output, text, shell):  # type: ignore[no-untyped-def]
+        return completed
+
+    monkeypatch.setattr("agency_swarm.cli.migrate_agent.subprocess.run", fake_run)
+
+    exit_code = migrate_agent.migrate_agent_command(str(settings_path), str(tmp_path))
+    assert exit_code == 2


### PR DESCRIPTION
- cli/main: fix conditional import violation (moved to top-level)
- cli/main: properly propagate migrate-agent exit codes
- cli/migrate_agent: refactor nested try/except into clean helper
- cli/migrate_agent: fix dependency check (only check node + ts-node, not tsc)
- cli/migrate_agent: improve error handling (stderr, explicit exit codes)
- cli/migrate_agent: move private helper to end per convention
- cli/utils: fix bug using JSON.stringify for filters (use toPythonObject)
- pyproject.toml: bundle TypeScript file in distribution
- tests: add 10 unit tests for migrate_agent (public API only, AGENTS.md compliant)