### PR TITLE
fix: add tsx runner support and resolve build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ fastapi = [
     "httpx>=0.28.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "coverage>=7.8.2",
     "mypy>=1.16.0",
     "pre-commit>=4.2.0",
@@ -86,8 +86,11 @@ packages = ["src/agency_swarm"]
 [tool.hatch.build.targets.wheel.force-include]
 "src/agency_swarm/cli/utils/generate-agent-from-settings.ts" = "agency_swarm/cli/utils/generate-agent-from-settings.ts"
 
-[tool.hatch.build.targets.sdist.force-include]
-"src/agency_swarm/cli/utils/generate-agent-from-settings.ts" = "agency_swarm/cli/utils/generate-agent-from-settings.ts"
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/agency_swarm/**/*.py",
+    "src/agency_swarm/**/*.ts",
+]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
- cli/migrate_agent: prefer tsx over ts-node for TypeScript execution
- cli/migrate_agent: return tuple (available, runner) from check_node_dependencies
- cli/migrate_agent: update error messages to mention tsx as primary option
- test_migrate_agent: add test for tsx success path (complete coverage)
- test_migrate_agent: update all tests for new tuple return signature
- pyproject.toml: migrate to dependency-groups format (fixes deprecation)
- pyproject.toml: use glob patterns for sdist includes (fixes build failure)