### PR TITLE
Fix: harden agent file ID parsing

### DIFF
--- a/src/agency_swarm/agent/file_manager.py
+++ b/src/agency_swarm/agent/file_manager.py
@@ -169,9 +169,10 @@ class AgentFileManager:
         if os.path.isfile(f_path):
             file_name, _ = os.path.splitext(f_path)
             file_name = os.path.basename(file_name)
-            match = re.search(r"_file-([A-Za-z0-9]*\d[A-Za-z0-9]*)$", file_name)
+            match = re.search(r"_file-([A-Za-z0-9]{15,})$", file_name)
             if match:
-                return f"file-{match.group(1)}"
+                id_suffix = match.group(1)
+                return f"file-{id_suffix}"
             return None
         else:
             raise FileNotFoundError(f"File not found: {f_path}")

--- a/tests/test_agent_modules/test_agent_file_manager.py
+++ b/tests/test_agent_modules/test_agent_file_manager.py
@@ -192,7 +192,7 @@ class TestAgentFileManager:
         mock_agent.client_sync = Mock()
 
         uploaded = Mock()
-        uploaded.id = "file-abc123"
+        uploaded.id = "file-S1ABocPKz5LspVToYHJXWP"
         uploaded.created_at = 1_700_000_000
         mock_agent.client_sync.files.create.return_value = uploaded
 
@@ -209,7 +209,7 @@ class TestAgentFileManager:
 
         assert result == uploaded.id
 
-        renamed_path = tmp_path / "report_file-final_file-abc123.txt"
+        renamed_path = tmp_path / "report_file-final_file-S1ABocPKz5LspVToYHJXWP.txt"
         assert renamed_path.exists()
         assert file_manager.get_id_from_file(renamed_path) == uploaded.id
         mock_agent.client_sync.files.retrieve.assert_not_called()
@@ -223,6 +223,30 @@ class TestAgentFileManager:
         # Should raise FileNotFoundError
         with pytest.raises(FileNotFoundError, match="File not found: /nonexistent/file.txt"):
             file_manager.get_id_from_file("/nonexistent/file.txt")
+
+    def test_get_id_from_file_accepts_digit_free_ids(self, tmp_path):
+        """Digit-free, mixed-case OpenAI IDs remain discoverable in local filenames."""
+
+        mock_agent = Mock()
+        file_manager = AgentFileManager(mock_agent)
+
+        path = tmp_path / "notes_file-XugufptanjcVTjYYDTTadG.txt"
+        path.write_text("content", encoding="utf-8")
+
+        assert file_manager.get_id_from_file(path) == "file-XugufptanjcVTjYYDTTadG", (
+            "Expected digit-free OpenAI file IDs to be recognized"
+        )
+
+    def test_get_id_from_file_accepts_lowercase_ids(self, tmp_path):
+        """All-lowercase OpenAI IDs remain discoverable."""
+
+        mock_agent = Mock()
+        file_manager = AgentFileManager(mock_agent)
+
+        path = tmp_path / "draft_file-abcdefghijklmnopqrstuv.txt"
+        path.write_text("content", encoding="utf-8")
+
+        assert file_manager.get_id_from_file(path) == "file-abcdefghijklmnopqrstuv"
 
     def test_parse_files_folder_reuses_detected_vector_store(self, tmp_path, caplog):
         """Reuse an existing vector store directory without logging errors."""

--- a/tests/test_agent_modules/test_tools_utils.py
+++ b/tests/test_agent_modules/test_tools_utils.py
@@ -114,7 +114,9 @@ class TestFromOpenAPISchema:
 
         with patch("agency_swarm.tools.utils.httpx.AsyncClient") as mock_client_cls:
             client = AsyncMock()
-            client.request.return_value.json.return_value = {"id": "456"}
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"id": "456"}
+            client.request.return_value = mock_response
             mock_client_cls.return_value.__aenter__.return_value = client
 
             from_openapi_schema(base_spec)


### PR DESCRIPTION
## Summary

Stabilizes file ID recovery during vector-store synchronization without relying on undocumented casing rules and silences OpenAPI tool test warnings by fixing the mock response chain.

## Changes

1. **File ID Parsing** (src/agency_swarm/agent/file_manager.py): Recognize a filename as an OpenAI upload only when its `_file-…` suffix contains at least 15 alphanumeric characters. This still accepts digit-free IDs (e.g., `file-XugufptanjcVTjYYDTTadG`) while ignoring obvious human-written names like `report_file-final.txt`.  
2. **Regression Coverage** (tests/test_agent_modules/test_agent_file_manager.py): Updated fixtures to real-world IDs and added focused tests for both digit-free mixed-case and all-lowercase suffixes to ensure future parsing changes remain accurate.  
3. **Mock Chaining Fix** (tests/test_agent_modules/test_tools_utils.py): Reuse an explicit `mock_response` so the async HTTP client no longer triggers the “coroutine was never awaited” warning.