### PR TITLE
fix: isolate agent runtime state per agency

### DIFF
--- a/examples/custom_send_message.py
+++ b/examples/custom_send_message.py
@@ -13,18 +13,20 @@ Run with: python examples/custom_send_message.py
 """
 
 import asyncio
-import json
 import logging
 import os
 import sys
 
-# Path setup so the example can be run standalone
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
-
 from pydantic import BaseModel, Field
 
-from agency_swarm import Agency, Agent, ModelSettings, function_tool
-from agency_swarm.tools.send_message import SendMessage, SendMessageHandoff
+# Path setup so the example can be run standalone
+examples_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(examples_root, "src"))
+sys.path.insert(0, examples_root)
+
+from agency_swarm import Agency, Agent, ModelSettings, function_tool  # noqa: E402
+from agency_swarm.tools.send_message import SendMessage, SendMessageHandoff  # noqa: E402
+from examples.utils import print_highlighted_send_message_args  # noqa: E402
 
 # Setup logging
 logging.basicConfig(level=logging.WARNING)
@@ -138,17 +140,7 @@ agency = Agency(
 
 # Helper function to visualize send message arguments
 def print_send_message_args(agency, agent_name: str) -> None:
-    agent_messages = agency._agent_contexts[agent_name].thread_manager._store.messages
-    args_str = ""
-    for message in agent_messages:
-        if message["type"] == "function_call" and message["name"].startswith("send_message"):
-            args = json.loads(message["arguments"])
-            args_str = json.dumps(args, indent=2)
-            if "key_moments" in args_str and "decisions" in args_str:
-                args_str = args_str.replace('"key_moments"', '\033[32m"key_moments"\033[0m').replace(
-                    '"decisions"', '\033[32m"decisions"\033[0m'
-                )
-            print(args_str)
+    print_highlighted_send_message_args(agency, agent_name=agent_name)
 
 
 async def main():

--- a/examples/multi_agent_workflow.py
+++ b/examples/multi_agent_workflow.py
@@ -25,9 +25,12 @@ from pydantic import BaseModel, Field
 # Configure basic logging
 logging.basicConfig(level=logging.WARNING, format="%(asctime)s - %(levelname)s - %(message)s")
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+examples_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(examples_root, "src"))
+sys.path.insert(0, examples_root)
 
 from agency_swarm import Agency, Agent, RunContextWrapper, function_tool  # noqa: E402
+from examples.utils import print_send_message_exchange  # noqa: E402
 
 
 # --- Structured Output Types ---
@@ -129,21 +132,9 @@ agency = Agency(
 
 
 # Helper function to visualize send message arguments
-def print_send_message_history(agency, agent_name: str) -> None:
-    agent_messages = agency._agent_contexts[agent_name].thread_manager._store.messages
-    call_ids = []
+def print_send_message_history(agency: Agency, agent_name: str) -> None:
     print("Message history for inter-agent communications:")
-    i = 1
-    for message in agent_messages:
-        if "parent_run_id" not in message or "role" not in message:
-            continue
-        if message["role"] == "user" and message["agent"] is not None and message["callerAgent"] is not None:
-            call_ids.append(message["parent_run_id"])
-            print(f"{i}. {message['callerAgent']} -> {message['agent']} message: {message['content']}\n")
-            i += 1
-        elif message["role"] == "assistant" and message["parent_run_id"] in call_ids:
-            print(f"{i}. {message['agent']} -> {message['callerAgent']} response: {message['content'][0]['text']}\n")
-            i += 1
+    print_send_message_exchange(agency, owner=agent_name)
 
 
 async def run_workflow():

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,8 +1,13 @@
+import json
 import shutil
 import tempfile
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
+
+_GREEN = "\033[32m"
+_RESET = "\033[0m"
 
 
 def _extract_text(content: object) -> str:
@@ -67,3 +72,52 @@ def temporary_files_folder(source_subdir: str = "data") -> Iterator[Path]:
         yield destination
     finally:
         shutil.rmtree(temp_root, ignore_errors=True)
+
+
+def iter_agent_messages(agency, *, agent_name: str | None = None) -> Iterator[dict[str, Any]]:
+    """Yield stored messages filtered by optional caller/agent name."""
+    for message in agency.thread_manager.get_all_messages():
+        if not isinstance(message, dict):
+            continue
+        if agent_name and not (message.get("callerAgent") == agent_name or message.get("agent") == agent_name):
+            continue
+        yield message
+
+
+def iter_send_message_calls(agency, *, agent_name: str | None = None) -> Iterator[dict[str, Any]]:
+    """Yield send_message function call records matching optional agent filter."""
+    for message in iter_agent_messages(agency, agent_name=agent_name):
+        if message.get("type") == "function_call" and str(message.get("name", "")).startswith("send_message"):
+            yield message
+
+
+def format_json_call(arguments: str | dict[str, Any]) -> str:
+    """Return pretty JSON from arguments string/dict."""
+    if isinstance(arguments, str):
+        parsed = json.loads(arguments or "{}")
+    else:
+        parsed = arguments
+    return json.dumps(parsed, indent=2)
+
+
+def print_highlighted_send_message_args(agency, *, agent_name: str | None = None) -> None:
+    """Pretty-print send_message call arguments with highlighted keys."""
+    for message in iter_send_message_calls(agency, agent_name=agent_name):
+        rendered = format_json_call(message.get("arguments", {}))
+        rendered = rendered.replace('"key_moments"', f'{_GREEN}"key_moments"{_RESET}').replace(
+            '"decisions"', f'{_GREEN}"decisions"{_RESET}'
+        )
+        print(rendered)
+
+
+def print_send_message_exchange(agency, *, owner: str) -> None:
+    """Print send_message requests/responses involving a specific agent."""
+    call_ids: dict[str, dict[str, Any]] = {}
+    for message in iter_agent_messages(agency, agent_name=owner):
+        if message.get("type") == "function_call" and str(message.get("name", "")).startswith("send_message"):
+            call_ids[str(message.get("parent_run_id"))] = message
+            payload = format_json_call(message.get("arguments", {}))
+            print(f"Request {message.get('callerAgent')} -> {message.get('agent')}:\n{payload}\n")
+        elif message.get("type") == "assistant" and str(message.get("parent_run_id")) in call_ids:
+            response_text = _extract_text(message.get("content") or message.get("output"))
+            print(f"Response {message.get('agent')} -> {message.get('callerAgent')}: {response_text}\n")

--- a/src/agency_swarm/agency/helpers.py
+++ b/src/agency_swarm/agency/helpers.py
@@ -155,9 +155,7 @@ def read_instructions(agency: "Agency", path: str) -> None:
 
 def get_agent_context(agency: "Agency", agent_name: str) -> AgencyContext:
     """Get the agency context for a specific agent."""
-    if agent_name not in agency._agent_contexts:
-        raise ValueError(f"No context found for agent: {agent_name}")
-    return agency._agent_contexts[agent_name]
+    return agency.get_agent_context(agent_name)
 
 
 def run_fastapi(

--- a/src/agency_swarm/agency/visualization.py
+++ b/src/agency_swarm/agency/visualization.py
@@ -29,6 +29,8 @@ def get_agency_structure(agency: "Agency", include_tools: bool = True) -> dict[s
         else:
             instructions = agency.shared_instructions or getattr(agent, "instructions", "") or ""
 
+        runtime_state = agency._agent_runtime_state.get(agent_name)
+
         agent_data: dict[str, Any] = {
             "label": agent_name,
             "description": getattr(agent, "description", "") or "",
@@ -37,7 +39,7 @@ def get_agency_structure(agency: "Agency", include_tools: bool = True) -> dict[s
             "tools": [],
             "instructions": instructions,
             "model": agent.model,
-            "hasSubagents": bool(getattr(agent, "_subagents", {})),
+            "hasSubagents": bool(runtime_state.subagents if runtime_state else {}),
         }
 
         node = {

--- a/src/agency_swarm/agent/context_types.py
+++ b/src/agency_swarm/agent/context_types.py
@@ -1,20 +1,63 @@
+import asyncio
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from agency_swarm.tools.concurrency import ToolConcurrencyManager
+    from agency_swarm.tools.send_message import SendMessage
     from agency_swarm.utils.thread import ThreadManager
 
     from .core import Agent
 
 
 @dataclass
+class AgentRuntimeState:
+    """Holds mutable per-agency runtime state for a logical agent instance."""
+
+    tool_concurrency_manager: "ToolConcurrencyManager"
+    subagents: dict[str, "Agent"] = field(default_factory=dict)
+    send_message_tools: dict[str, "SendMessage"] = field(default_factory=dict)
+    pending_per_thread: dict[int | None, set[str]] = field(default_factory=dict)
+    handoffs: list[Any] = field(default_factory=list)
+    pending_lock: asyncio.Lock = field(init=False)
+
+    def __init__(self, tool_concurrency_manager: "ToolConcurrencyManager | None" = None):
+        from agency_swarm.tools.concurrency import ToolConcurrencyManager
+
+        self.tool_concurrency_manager = tool_concurrency_manager or ToolConcurrencyManager()
+        self.subagents = {}
+        self.send_message_tools = {}
+        self.pending_per_thread = {}
+        self.handoffs = []
+        self.pending_lock = asyncio.Lock()
+
+
 class AgencyContext:
     """Agency-specific context for an agent to enable multi-agency support."""
 
-    agency_instance: Any
-    thread_manager: "ThreadManager"
-    subagents: dict[str, "Agent"]
-    load_threads_callback: Callable[[], dict[str, Any]] | None = None
-    save_threads_callback: Callable[[dict[str, Any]], None] | None = None
-    shared_instructions: str | None = None
+    def __init__(
+        self,
+        agency_instance: Any,
+        thread_manager: "ThreadManager",
+        runtime_state: AgentRuntimeState | None = None,
+        subagents: dict[str, "Agent"] | None = None,
+        load_threads_callback: Callable[..., Any] | None = None,
+        save_threads_callback: Callable[..., Any] | None = None,
+        shared_instructions: str | None = None,
+    ) -> None:
+        self.agency_instance = agency_instance
+        self.thread_manager = thread_manager
+        self.runtime_state = runtime_state or AgentRuntimeState()
+        self.load_threads_callback = load_threads_callback
+        self.save_threads_callback = save_threads_callback
+        self.shared_instructions = shared_instructions
+
+        if subagents:
+            for agent in subagents.values():
+                self.runtime_state.subagents[agent.name.lower()] = agent
+
+    @property
+    def subagents(self) -> dict[str, "Agent"]:
+        """Retained for backward compatibility."""
+        return {agent.name: agent for agent in self.runtime_state.subagents.values()}

--- a/src/agency_swarm/context.py
+++ b/src/agency_swarm/context.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .agent.context_types import AgentRuntimeState
     from .agent.core import Agent
     from .utils.thread import ThreadManager
 
@@ -28,6 +29,7 @@ class MasterContext:
     thread_manager: "ThreadManager"
     agents: dict[str, "Agent"]
     user_context: dict[str, Any] = field(default_factory=dict)
+    agent_runtime_state: dict[str, "AgentRuntimeState"] = field(default_factory=dict)
     current_agent_name: str | None = None  # Name of the agent currently executing
     shared_instructions: str | None = None  # Shared instructions from the agency
     _current_agent_run_id: str | None = None  # Current agent run ID for tracking
@@ -44,6 +46,8 @@ class MasterContext:
             raise TypeError("MasterContext 'agents' must be a dictionary.")
         if not isinstance(self.user_context, dict):
             raise TypeError("MasterContext 'user_context' must be a dictionary.")
+        if not isinstance(self.agent_runtime_state, dict):
+            raise TypeError("MasterContext 'agent_runtime_state' must be a dictionary.")
 
     def get(self, key: str, default: Any = None) -> Any:
         """Helper method to access user_context fields with a default."""

--- a/tests/integration/agency/test_multi_agency_support.py
+++ b/tests/integration/agency/test_multi_agency_support.py
@@ -87,8 +87,8 @@ class TestMultiAgencySupport:
         assert id(agency2.agents["SharedAgent"]) == id(shared_agent)
 
         # Verify each agency has its own context for the shared agent
-        context1 = agency1._get_agent_context("SharedAgent")
-        context2 = agency2._get_agent_context("SharedAgent")
+        context1 = agency1.get_agent_context("SharedAgent")
+        context2 = agency2.get_agent_context("SharedAgent")
 
         # Verify contexts are different and isolated
         assert context1.agency_instance is agency1
@@ -103,8 +103,8 @@ class TestMultiAgencySupport:
         await agency2.get_response("Set test_value to 'agency2_value' using the SharedStateTool")
 
         # Get agency contexts for the shared agent
-        context1 = agency1._get_agent_context("SharedAgent")
-        context2 = agency2._get_agent_context("SharedAgent")
+        context1 = agency1.get_agent_context("SharedAgent")
+        context2 = agency2.get_agent_context("SharedAgent")
 
         assert context1.thread_manager is not context2.thread_manager
 
@@ -146,8 +146,8 @@ class TestMultiAgencySupport:
     async def test_subagent_registration_isolation(self, shared_agent, agency1, agency2):
         """Test that subagent registration is isolated between agencies."""
         # Get agency contexts for the shared agent
-        context1 = agency1._get_agent_context("SharedAgent")
-        context2 = agency2._get_agent_context("SharedAgent")
+        context1 = agency1.get_agent_context("SharedAgent")
+        context2 = agency2.get_agent_context("SharedAgent")
 
         # Each agency should have different subagents
         subagents1 = context1.subagents
@@ -248,8 +248,8 @@ class TestStatelessContextPassing:
     def test_context_factory_validation(self, shared_agent, agency1, agency2):
         """Test that context factory pattern works correctly."""
         # Each agency should have its own context for the shared agent
-        context1 = agency1._get_agent_context("SharedAgent")
-        context2 = agency2._get_agent_context("SharedAgent")
+        context1 = agency1.get_agent_context("SharedAgent")
+        context2 = agency2.get_agent_context("SharedAgent")
 
         # Contexts should be different instances
         assert context1 is not context2
@@ -258,4 +258,4 @@ class TestStatelessContextPassing:
 
         # Invalid agent name should raise error
         with pytest.raises(ValueError, match="No context found for agent"):
-            agency1._get_agent_context("NonexistentAgent")
+            agency1.get_agent_context("NonexistentAgent")

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -97,8 +97,12 @@ def test_agent_flow_with_handoff_tool():
 
     assert len(agency.agents) == 3
 
-    # Check that handoffs are created for the agents
-    print(f"agent1.tools: {agent1.handoffs}")
-    assert agent1.handoffs[0].tool_name == "transfer_to_Agent2"
-    assert agent2.handoffs[0].tool_name == "transfer_to_Agent3"
-    assert len(agent3.handoffs) == 0
+    runtime_state1 = agency.get_agent_runtime_state("Agent1")
+    runtime_state2 = agency.get_agent_runtime_state("Agent2")
+
+    handoff_names_1 = [handoff.tool_name for handoff in runtime_state1.handoffs]
+    handoff_names_2 = [handoff.tool_name for handoff in runtime_state2.handoffs]
+
+    assert "transfer_to_Agent2" in handoff_names_1
+    assert "transfer_to_Agent3" in handoff_names_2
+    assert not agency.get_agent_runtime_state("Agent3").handoffs

--- a/tests/test_agent_modules/test_agent_subagents.py
+++ b/tests/test_agent_modules/test_agent_subagents.py
@@ -7,21 +7,16 @@ def test_register_subagent(minimal_agent):
     """Test registering a subagent."""
     recipient = Agent(name="Recipient", instructions="Receive messages")
     minimal_agent.register_subagent(recipient)
-    # Subagents are stored with lowercase keys for case-insensitive lookup
-    assert "recipient" in minimal_agent._subagents
-    assert minimal_agent._subagents["recipient"] == recipient
+    send_tool = next(tool for tool in minimal_agent.tools if getattr(tool, "name", "").startswith("send_message"))
+    assert recipient.name in [agent.name for agent in send_tool.recipients.values()]
 
 
 def test_register_subagent_adds_send_message_tool(minimal_agent):
     """Test that registering a subagent adds the send_message tool."""
     recipient = Agent(name="Recipient", instructions="Receive messages")
-    initial_tool_count = len(minimal_agent.tools)
     minimal_agent.register_subagent(recipient)
-    assert len(minimal_agent.tools) == initial_tool_count + 1
-    # Check that the tool name follows the expected pattern
     tool_names = [getattr(tool, "name", None) for tool in minimal_agent.tools]
-    expected_tool_name = "send_message"
-    assert expected_tool_name in tool_names
+    assert "send_message" in tool_names
 
 
 def test_register_subagent_idempotent(minimal_agent):
@@ -29,8 +24,9 @@ def test_register_subagent_idempotent(minimal_agent):
     recipient = Agent(name="Recipient", instructions="Receive messages")
     minimal_agent.register_subagent(recipient)
     initial_tool_count = len(minimal_agent.tools)
-    initial_subagent_count = len(minimal_agent._subagents)
+    send_tool = next(tool for tool in minimal_agent.tools if getattr(tool, "name", "").startswith("send_message"))
+    initial_recipient_count = len(send_tool.recipients)
     # Register again
     minimal_agent.register_subagent(recipient)
     assert len(minimal_agent.tools) == initial_tool_count
-    assert len(minimal_agent._subagents) == initial_subagent_count
+    assert len(send_tool.recipients) == initial_recipient_count


### PR DESCRIPTION
#### Summary

- Moved all mutable agent state (subagents, send_message tools, handoffs, concurrency locks) into new `AgentRuntimeState` containers created per agency and accessible through the agency context.  
- Refactored `SendMessage`, agent setup, and execution helpers to read and write only through runtime state, allowing safe reuse of module-level agents across multiple agencies without shared-state leaks.  
- Updated examples and regression tests to assert against runtime containers, restoring precise expectations for handoffs, send_message recipients, and pending guards.

#### Details

- **Runtime Containers**  
  - Added `AgentRuntimeState` and updated `AgencyContext` construction to embed runtime data (`src/agency_swarm/agent/context_types.py`).  
  - Agencies now initialize `_agent_runtime_state` maps and expose `get_agent_context` and `get_agent_runtime_state` accessors (`src/agency_swarm/agency/core.py`).  

- **Configuration & Execution**  
  - `configure_agents` and `register_subagent` now populate runtime handoffs and send_message instances instead of mutating agent attributes.  
  - Execution helpers splice runtime handoffs per run and restore originals; one-call guards now pull concurrency managers from runtime state when available (`src/agency_swarm/agent/execution_helpers.py`, `src/agency_swarm/agent/tools.py`).  

- **SendMessage Isolation**  
  - `SendMessage` now shares recipients, pending guards, and locks via runtime state and builds per-recipient contexts without borrowing sender state (`src/agency_swarm/tools/send_message.py`).  

- **Verification & Examples**  
  - Regression tests focus on runtime containers, reinstating precise handoff assertions and module-level isolation checks, including a new guard-focused test (`tests/test_agent_modules/send_message/test_pending_isolation.py`).  
  - Examples reuse shared utilities to inspect send_message traffic via the agency context (`examples/utils.py`).  