### PR TITLE
feature: expose streaming run response wrapper

### DIFF
--- a/src/agency_swarm/__init__.py
+++ b/src/agency_swarm/__init__.py
@@ -46,6 +46,7 @@ from openai.types.shared import Reasoning  # noqa: E402
 
 from .agency.core import Agency  # noqa: E402
 from .agent.core import AgencyContext, Agent  # noqa: E402
+from .agent.execution_streaming import StreamingRunResponse  # noqa: E402
 from .context import MasterContext  # noqa: E402
 from .hooks import PersistenceHooks  # noqa: E402
 from .integrations.fastapi import run_fastapi  # noqa: E402
@@ -77,6 +78,7 @@ __all__ = [
     "Agent",
     "Agency",
     "AgencyContext",
+    "StreamingRunResponse",
     "BaseTool",
     "MasterContext",
     "ThreadManager",

--- a/tests/test_agent_modules/test_agent_initialization.py
+++ b/tests/test_agent_modules/test_agent_initialization.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from agents import FunctionTool, ModelSettings
+from agents import FunctionTool, ModelSettings, StopAtTools
 from pydantic import BaseModel, Field
 
 from agency_swarm import Agent
@@ -37,6 +37,22 @@ def test_agent_initialization_with_tools():
     agent = Agent(name="Agent2", instructions="Use tools", tools=[tool1])
     assert len(agent.tools) == 1
     assert agent.tools[0] == tool1
+
+
+def test_agent_initialization_with_stop_at_tools_object():
+    """Agent accepts StopAtTools typed dict for tool_use_behavior."""
+    behavior = StopAtTools(stop_at_tool_names=["ToolA", "ToolB"])
+    agent = Agent(name="AgentStopAtTools", instructions="Test", tool_use_behavior=behavior)
+
+    assert agent.tool_use_behavior == behavior
+
+
+def test_agent_initialization_with_stop_at_tools_dict():
+    """Agent accepts plain StopAtTools-compatible dict for tool_use_behavior."""
+    behavior_dict = {"stop_at_tool_names": ["ToolC"]}
+    agent = Agent(name="AgentStopAtToolsDict", instructions="Test", tool_use_behavior=behavior_dict)
+
+    assert agent.tool_use_behavior == behavior_dict
 
 
 def test_agent_initialization_with_model_settings():


### PR DESCRIPTION
feature: expose streaming run response wrapper
- Adds StreamingRunResponse with lazy event-loop binding/adoption.
- Updates agent/agency streaming paths to return the wrapper and surface it publicly.
- Extends streaming tests to exercise wrapper semantics, including final-result propagation through both agent and agency streaming.