### PR TITLE
fix: harden mcp shutdown handling

### DIFF
--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -1,5 +1,4 @@
 # --- Core Agency class definition ---
-import asyncio
 import atexit
 import logging
 import os
@@ -232,7 +231,8 @@ class Agency:
         logger.info("Agency initialization complete.")
 
         # Register MCP shutdown at process exit so persistent servers are cleaned in scripts
-        atexit.register(lambda: asyncio.run(default_mcp_manager.shutdown()))
+        if default_mcp_manager.mark_atexit_registered():
+            atexit.register(default_mcp_manager.shutdown_sync)
 
     # Private helper methods that were missed during split
     def get_agent_context(self, agent_name: str) -> AgencyContext:

--- a/tests/test_agent_modules/test_mcp_manager.py
+++ b/tests/test_agent_modules/test_mcp_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from agency_swarm.tools.mcp_manager import LoopAffineAsyncProxy, PersistentMCPServerManager
@@ -17,6 +19,16 @@ class _DummyServer:
         self.session = None
 
 
+class _SlowCleanupServer(_DummyServer):
+    def __init__(self, delay: float) -> None:
+        super().__init__()
+        self.delay = delay
+
+    async def cleanup(self) -> None:
+        await asyncio.sleep(self.delay)
+        await super().cleanup()
+
+
 @pytest.mark.asyncio
 async def test_ensure_connected_reuses_driver_for_proxy() -> None:
     manager = PersistentMCPServerManager()
@@ -31,3 +43,20 @@ async def test_ensure_connected_reuses_driver_for_proxy() -> None:
         assert len(manager._drivers) == 1
     finally:
         await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_handles_cleanup_timeout() -> None:
+    manager = PersistentMCPServerManager()
+    server = _SlowCleanupServer(delay=0.1)
+
+    manager._timeouts["cleanup"] = 0.01
+
+    await manager.ensure_connected(server)
+
+    try:
+        await manager.shutdown()
+    except TimeoutError as exc:  # pragma: no cover - current behavior under test
+        pytest.fail(f"shutdown should not propagate TimeoutError: {exc}")
+
+    assert manager._drivers == {}


### PR DESCRIPTION
Harden persistent MCP shutdown so cleanup never leaks errors or double-registers exit hooks.

- src/agency_swarm/agency/core.py guard atexit registration with manager flag
- src/agency_swarm/tools/mcp_manager.py add timeout fallback and sync shutdown helper
- tests/test_agent_modules/test_mcp_manager.py cover shutdown timeout recovery