### PR TITLE
Fix hosted tool preservation routing for agent threads

### DIFF
--- a/src/agency_swarm/agent/execution.py
+++ b/src/agency_swarm/agent/execution.py
@@ -139,7 +139,9 @@ class Execution:
                 logger.debug(f"Preparing to save {len(run_result.new_items)} new items from RunResult")
 
                 # Only extract hosted tool results if hosted tools were actually used
-                hosted_tool_outputs = extract_hosted_tool_results_if_needed(self.agent, run_result.new_items)
+                hosted_tool_outputs = extract_hosted_tool_results_if_needed(
+                    self.agent, run_result.new_items, caller_agent=sender_name
+                )
 
                 # Extract direct file annotations from assistant messages
                 assistant_messages = [item for item in run_result.new_items if isinstance(item, MessageOutputItem)]

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -240,7 +240,11 @@ def prepare_master_context(
     )
 
 
-def extract_hosted_tool_results_if_needed(agent: "Agent", run_items: list[RunItem]) -> list[TResponseInputItem]:
+def extract_hosted_tool_results_if_needed(
+    agent: "Agent",
+    run_items: list[RunItem],
+    caller_agent: str | None = None,
+) -> list[TResponseInputItem]:
     """
     Optimized version that only extracts hosted tool results if hosted tools were actually used.
     This prevents expensive parsing on every response when no hosted tools exist.
@@ -263,7 +267,7 @@ def extract_hosted_tool_results_if_needed(agent: "Agent", run_items: list[RunIte
         logger.debug("No hosted tool calls found in run_items")
         return []  # Early exit - no hosted tools used
 
-    return MessageFormatter.extract_hosted_tool_results(agent, run_items)
+    return MessageFormatter.extract_hosted_tool_results(agent, run_items, caller_agent=caller_agent)
 
 
 def setup_execution(

--- a/src/agency_swarm/agent/execution_streaming.py
+++ b/src/agency_swarm/agent/execution_streaming.py
@@ -200,7 +200,9 @@ def _persist_streamed_items(
         if isinstance(origin := item.get("message_origin"), str)
     }
 
-    hosted_tool_outputs = MessageFormatter.extract_hosted_tool_results(agent, collected_items)
+    hosted_tool_outputs = MessageFormatter.extract_hosted_tool_results(
+        agent, collected_items, caller_agent=sender_name
+    )
     if hosted_tool_outputs:
         filtered_hosted_outputs = MessageFilter.filter_messages(hosted_tool_outputs)  # type: ignore[arg-type]
         for hosted_item in filtered_hosted_outputs:

--- a/src/agency_swarm/messages/message_formatter.py
+++ b/src/agency_swarm/messages/message_formatter.py
@@ -195,10 +195,19 @@ class MessageFormatter:
             logger.debug(f"Added {len(item_dict['citations'])} citations to {msg_type} {run_item_obj.raw_item.id}")  # type: ignore[typeddict-item]
 
     @staticmethod
-    def extract_hosted_tool_results(agent: "Agent", run_items: list[RunItem]) -> list[TResponseInputItem]:
+    def extract_hosted_tool_results(
+        agent: "Agent",
+        run_items: list[RunItem],
+        caller_agent: str | None = None,
+    ) -> list[TResponseInputItem]:
         """
         Extract hosted tool results (FileSearch, WebSearch) from assistant message content
         and create special assistant messages to capture search results in conversation history.
+
+        Args:
+            agent: The agent whose run produced the hosted tool results.
+            run_items: Items emitted during the run.
+            caller_agent: Active conversation partner initiating the run (None for user).
         """
         synthetic_outputs = []
 
@@ -243,7 +252,7 @@ class MessageFormatter:
                                 "message_origin": "file_search_preservation",
                             },
                             agent=agent.name,
-                            caller_agent=None,
+                            caller_agent=caller_agent,
                         )
                     )
                     logger.debug(f"Created file_search results message for call_id: {tool_call.id}")
@@ -277,7 +286,7 @@ class MessageFormatter:
                                 "message_origin": "web_search_preservation",
                             },
                             agent=agent.name,
-                            caller_agent=None,
+                            caller_agent=caller_agent,
                         )
                     )
                     logger.debug(f"Created web_search results message for call_id: {tool_call.id}")

--- a/tests/integration/communication/test_hosted_tool_preservation_routing.py
+++ b/tests/integration/communication/test_hosted_tool_preservation_routing.py
@@ -1,0 +1,55 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from agency_swarm import Agency, Agent
+from agents import MessageOutputItem, ToolCallItem
+from openai.types.responses import ResponseFunctionWebSearch, ResponseOutputMessage, ResponseOutputText
+
+
+@pytest.mark.asyncio
+async def test_hosted_tool_preservation_stays_in_agent_thread():
+    orchestrator = Agent(name="Orchestrator", instructions="Coordinate")
+    worker = Agent(name="Worker", instructions="Execute")
+
+    agency = Agency(orchestrator, communication_flows=[(orchestrator, worker)])
+    worker_context = agency._agent_contexts[worker.name]
+
+    tool_call = ResponseFunctionWebSearch(
+        id="webcall_1",
+        action={"type": "search", "query": "foo"},
+        status="completed",
+        type="web_search_call",
+    )
+    assistant_msg = ResponseOutputMessage(
+        id="msg_1",
+        role="assistant",
+        content=[ResponseOutputText(type="output_text", text="Search results", annotations=[])],
+        status="completed",
+        type="message",
+    )
+
+    run_result = SimpleNamespace(
+        new_items=[ToolCallItem(worker, tool_call), MessageOutputItem(worker, assistant_msg)],
+        final_output="Search results",
+    )
+
+    with patch("agents.Runner.run", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = run_result
+        await worker.get_response(
+            "Need info",
+            sender_name=orchestrator.name,
+            agency_context=worker_context,
+        )
+
+    thread_manager = agency.thread_manager
+    agent_thread = thread_manager.get_conversation_history(worker.name, orchestrator.name)
+    preserved_items = [
+        item for item in agent_thread if item.get("message_origin") == "web_search_preservation"
+    ]
+
+    assert preserved_items, "Hosted tool preservation should appear in agent-to-agent thread"
+    assert all(item.get("callerAgent") == orchestrator.name for item in preserved_items)
+
+    user_thread = thread_manager.get_conversation_history(worker.name, None)
+    assert not any(item.get("message_origin") == "web_search_preservation" for item in user_thread)

--- a/tests/test_agent_modules/test_hosted_tool_results.py
+++ b/tests/test_agent_modules/test_hosted_tool_results.py
@@ -32,12 +32,12 @@ async def test_web_search_results_have_metadata():
         MessageOutputItem(agent, assistant_msg),
     ]
 
-    results = MessageFormatter.extract_hosted_tool_results(agent, run_items)
+    results = MessageFormatter.extract_hosted_tool_results(agent, run_items, caller_agent="UserOne")
 
     assert results, "Expected hosted tool result"
     result = results[0]
     assert result.get("agent") == agent.name
-    assert result.get("callerAgent") is None
+    assert result.get("callerAgent") == "UserOne"
     assert "WEB_SEARCH_RESULTS" in result.get("content", "")
 
 


### PR DESCRIPTION
## Summary
- propagate the active caller into hosted tool preservation messages so agent-to-agent runs retain context in the correct thread
- pass `sender_name` through execution helpers and streaming persistence when extracting hosted tool results
- add regression coverage to ensure hosted tool preservation stays off the user thread and update metadata expectations

## Testing
- uv run pytest tests/test_agent_modules/test_hosted_tool_results.py
- uv run pytest tests/integration/communication/test_hosted_tool_preservation_routing.py

------
https://chatgpt.com/codex/tasks/task_e_68ecfb2166e08323be74dd146fecf67f