### PR TITLE
refactor: adopt sdk response models

### DIFF
--- a/tests/test_agent_modules/test_agui_adapter.py
+++ b/tests/test_agent_modules/test_agui_adapter.py
@@ -23,6 +23,19 @@ from ag_ui.core import (
     ToolMessage,
     UserMessage,
 )
+from openai.types.responses import (
+    ResponseCodeInterpreterToolCall,
+    ResponseFileSearchToolCall,
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+from openai.types.responses.response_file_search_tool_call import Result as FileSearchResult
+from openai.types.responses.response_function_call_arguments_delta_event import ResponseFunctionCallArgumentsDeltaEvent
+from openai.types.responses.response_output_item_added_event import ResponseOutputItemAddedEvent
+from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+from openai.types.responses.response_output_text import AnnotationFileCitation
+from openai.types.responses.response_text_delta_event import Logprob, ResponseTextDeltaEvent
 from pydantic import BaseModel
 
 from agency_swarm.ui.core.agui_adapter import AguiAdapter, serialize
@@ -135,17 +148,40 @@ def test_openai_events_emit_message_lifecycle():
     adapter = AguiAdapter()
     run_id = "run-1"
 
+    message = ResponseOutputMessage(
+        id="m-1",
+        content=[ResponseOutputText(annotations=[], text="Hi", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
     start_event = make_raw_event(
-        SimpleNamespace(
+        ResponseOutputItemAddedEvent(
+            item=message,
+            output_index=0,
+            sequence_number=1,
             type="response.output_item.added",
-            item=SimpleNamespace(type="message", role="assistant", id="m-1"),
         )
     )
-    delta_event = make_raw_event(SimpleNamespace(type="response.output_text.delta", item_id="m-1", delta="Hi"))
+
+    delta_event = make_raw_event(
+        ResponseTextDeltaEvent(
+            content_index=0,
+            delta="Hi",
+            item_id="m-1",
+            logprobs=[],
+            output_index=0,
+            sequence_number=2,
+            type="response.output_text.delta",
+        )
+    )
     done_event = make_raw_event(
-        SimpleNamespace(
+        ResponseOutputItemDoneEvent(
+            item=message,
+            output_index=0,
+            sequence_number=3,
             type="response.output_item.done",
-            item=SimpleNamespace(type="message", id="m-1"),
         )
     )
 
@@ -162,29 +198,52 @@ def test_openai_events_emit_message_lifecycle():
 def test_openai_events_track_tool_calls_and_arguments():
     adapter = AguiAdapter()
     run_id = "run-2"
-    raw_tool = SimpleNamespace(type="function_call", id="item-1", call_id="call-1", name="search", arguments="{}")
+    raw_tool = ResponseFunctionToolCall(
+        arguments="{}",
+        call_id="call-1",
+        name="search",
+        type="function_call",
+        id="item-1",
+        status="in_progress",
+    )
 
     adapter.openai_to_agui_events(
-        make_raw_event(SimpleNamespace(type="response.output_item.added", item=raw_tool)),
+        make_raw_event(
+            ResponseOutputItemAddedEvent(
+                item=raw_tool,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.added",
+            )
+        ),
         run_id=run_id,
     )
     args_event = adapter.openai_to_agui_events(
         make_raw_event(
-            SimpleNamespace(type="response.function_call_arguments.delta", item_id="item-1", delta='{"q": "')
+            ResponseFunctionCallArgumentsDeltaEvent(
+                item_id="item-1",
+                delta='{"q": "',
+                output_index=0,
+                sequence_number=2,
+                type="response.function_call_arguments.delta",
+            )
         ),
         run_id=run_id,
     )
     done_events = adapter.openai_to_agui_events(
         make_raw_event(
-            SimpleNamespace(
+            ResponseOutputItemDoneEvent(
                 type="response.output_item.done",
-                item=SimpleNamespace(
-                    type="function_call",
-                    id="item-1",
+                item=ResponseFunctionToolCall(
+                    arguments='{"q": "weather"}',
                     call_id="call-1",
                     name="search",
-                    arguments='{"q": "weather"}',
+                    type="function_call",
+                    id="item-1",
+                    status="completed",
                 ),
+                output_index=0,
+                sequence_number=3,
             )
         ),
         run_id=run_id,
@@ -195,6 +254,50 @@ def test_openai_events_track_tool_calls_and_arguments():
     assert isinstance(done_events, list)
     assert isinstance(done_events[0], ToolCallEndEvent)
     assert isinstance(done_events[1], MessagesSnapshotEvent)
+
+
+def test_openai_typed_events_emit_message_lifecycle():
+    adapter = AguiAdapter()
+    run_id = "typed-run"
+
+    message = ResponseOutputMessage(
+        id="msg-typed",
+        content=[ResponseOutputText(annotations=[], text="Hello world", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+
+    start_event = ResponseOutputItemAddedEvent(
+        item=message,
+        output_index=0,
+        sequence_number=1,
+        type="response.output_item.added",
+    )
+    delta_event = ResponseTextDeltaEvent(
+        content_index=0,
+        delta="!",
+        item_id="msg-typed",
+        logprobs=[Logprob(token="!", logprob=0.0, top_logprobs=[])],
+        output_index=0,
+        sequence_number=2,
+        type="response.output_text.delta",
+    )
+    done_event = ResponseOutputItemDoneEvent(
+        item=message,
+        output_index=0,
+        sequence_number=3,
+        type="response.output_item.done",
+    )
+
+    start = adapter.openai_to_agui_events(make_raw_event(start_event), run_id=run_id)
+    delta = adapter.openai_to_agui_events(make_raw_event(delta_event), run_id=run_id)
+    done = adapter.openai_to_agui_events(make_raw_event(done_event), run_id=run_id)
+
+    assert isinstance(start, TextMessageStartEvent)
+    assert isinstance(delta, TextMessageContentEvent)
+    assert isinstance(done, TextMessageEndEvent)
+    assert delta.message_id == "msg-typed"
 
 
 def test_openai_events_handles_exceptions_with_run_error():
@@ -271,8 +374,14 @@ def test_openai_events_ignore_tool_done_without_call_id():
 def test_run_item_stream_events_emit_snapshots():
     adapter = AguiAdapter()
     run_id = "run-3"
-    output_content = SimpleNamespace(text="Answer", annotations=None)
-    raw_item = SimpleNamespace(id="msg-1", content=[output_content])
+    output_content = ResponseOutputText(annotations=[], text="Answer", type="output_text")
+    raw_item = ResponseOutputMessage(
+        id="msg-1",
+        content=[output_content],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
     item = SimpleNamespace(raw_item=raw_item)
 
     events = adapter.openai_to_agui_events(make_stream_event("message_output_created", item), run_id=run_id)
@@ -285,10 +394,15 @@ def test_run_item_stream_events_emit_snapshots():
 def test_run_item_stream_with_annotations_returns_custom_event():
     adapter = AguiAdapter()
     run_id = "annotated"
-    annotation = MagicMock()
-    annotation.model_dump.return_value = {"type": "citation", "offset": 1}
-    output_content = SimpleNamespace(text="Answer", annotations=[annotation])
-    raw_item = SimpleNamespace(id="msg-annot", content=[output_content])
+    annotation = AnnotationFileCitation(file_id="file-annot", filename="doc.pdf", index=1, type="file_citation")
+    output_content = ResponseOutputText(annotations=[annotation], text="Answer", type="output_text")
+    raw_item = ResponseOutputMessage(
+        id="msg-annot",
+        content=[output_content],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
     item = SimpleNamespace(raw_item=raw_item)
 
     events = adapter.openai_to_agui_events(make_stream_event("message_output_created", item), run_id=run_id)
@@ -296,7 +410,7 @@ def test_run_item_stream_with_annotations_returns_custom_event():
     assert isinstance(events, list)
     assert any(isinstance(e, CustomEvent) for e in events)
     custom = next(e for e in events if isinstance(e, CustomEvent))
-    assert custom.value["annotations"] == [{"type": "citation", "offset": 1}]
+    assert custom.value["annotations"] == [annotation.model_dump()]
 
 
 def test_run_item_stream_ignores_message_without_text():
@@ -354,18 +468,49 @@ def test_run_item_stream_unknown_event_is_returned_as_raw_event():
 def test_tool_meta_handles_non_function_tools():
     adapter = AguiAdapter()
 
-    file_search = SimpleNamespace(
-        type="file_search_call",
+    typed_file_search = ResponseFileSearchToolCall(
         id="file-1",
         queries=["foo"],
-        results=["bar"],
+        status="completed",
+        type="file_search_call",
+        results=[FileSearchResult(file_id="doc", text="bar")],
     )
-    code_interpreter = SimpleNamespace(
-        type="code_interpreter_call",
-        id="ci-7",
+    typed_code_interpreter = ResponseCodeInterpreterToolCall(
         code="print(42)",
         container_id="cont",
-        outputs=["42"],
+        id="ci-7",
+        outputs=[{"type": "logs", "logs": "42"}],
+        type="code_interpreter_call",
+        status="completed",
+    )
+
+    @dataclasses.dataclass
+    class LegacyFileSearchCall:
+        type: str
+        id: str
+        queries: list[str]
+        results: list[dict]
+
+    @dataclasses.dataclass
+    class LegacyCodeInterpreterCall:
+        type: str
+        id: str
+        code: str
+        container_id: str
+        outputs: list[dict]
+
+    file_search = LegacyFileSearchCall(
+        type="file_search_call",
+        id=typed_file_search.id,
+        queries=typed_file_search.queries or [],
+        results=json.loads(typed_file_search.model_dump_json())["results"],
+    )
+    code_interpreter = LegacyCodeInterpreterCall(
+        type="code_interpreter_call",
+        id=typed_code_interpreter.id,
+        code=typed_code_interpreter.code or "",
+        container_id=typed_code_interpreter.container_id,
+        outputs=[{"type": "logs", "logs": "42"}],
     )
 
     file_meta = adapter._tool_meta(file_search)

--- a/tests/test_agent_modules/test_citation_extractor.py
+++ b/tests/test_agent_modules/test_citation_extractor.py
@@ -5,9 +5,17 @@ Tests individual citation extraction functions in isolation using mocks
 to ensure proper behavior without external dependencies.
 """
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
-from agents.items import MessageOutputItem
+import pytest
+from agents.items import MessageOutputItem, ToolCallItem
+from openai.types.responses.response_file_search_tool_call import (
+    ResponseFileSearchToolCall,
+    Result as FileSearchResult,
+)
+from openai.types.responses.response_output_message import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses.response_output_text import AnnotationFileCitation
 
 from agency_swarm.utils.citation_extractor import (
     display_citations,
@@ -17,36 +25,44 @@ from agency_swarm.utils.citation_extractor import (
 )
 
 
+@dataclass
+class LegacyContentItem:
+    annotations: list[dict]
+
+
+@dataclass
+class LegacyMessage:
+    id: str
+    content: list[LegacyContentItem]
+
+
 class TestExtractDirectFileAnnotations:
     """Test direct file citation extraction from message annotations."""
 
     def test_extracts_file_citations_from_annotations(self):
-        """Test extraction of file citations from message annotations."""
-        # Create mock message with file citation annotations
-        mock_annotation = MagicMock()
-        mock_annotation.type = "file_citation"
-        mock_annotation.file_id = "file-abc123"
-        mock_annotation.filename = "test_document.pdf"
-        mock_annotation.index = 42
+        """Ensure annotations backed by SDK models are captured."""
+        annotation = AnnotationFileCitation(
+            file_id="file-abc123",
+            filename="test_document.pdf",
+            index=42,
+            type="file_citation",
+        )
+        content_item = ResponseOutputText(annotations=[annotation], text="Here you go", type="output_text")
+        message = ResponseOutputMessage(
+            id="msg_123",
+            content=[content_item],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
 
-        mock_content_item = MagicMock()
-        mock_content_item.annotations = [mock_annotation]
+        msg_item = MagicMock(spec=MessageOutputItem)
+        msg_item.raw_item = message
 
-        mock_message = MagicMock()
-        mock_message.id = "msg_123"
-        mock_message.content = [mock_content_item]
-
-        mock_msg_item = MagicMock(spec=MessageOutputItem)
-        mock_msg_item.raw_item = mock_message
-
-        # Test extraction
-        result = extract_direct_file_annotations([mock_msg_item])
+        result = extract_direct_file_annotations([msg_item])
 
         assert "msg_123" in result
-        citations = result["msg_123"]
-        assert len(citations) == 1
-
-        citation = citations[0]
+        citation = result["msg_123"][0]
         assert citation["file_id"] == "file-abc123"
         assert citation["filename"] == "test_document.pdf"
         assert citation["index"] == 42
@@ -54,186 +70,153 @@ class TestExtractDirectFileAnnotations:
         assert citation["method"] == "direct_file"
 
     def test_handles_multiple_annotations_per_message(self):
-        """Test handling multiple file citations in a single message."""
-        # Create multiple annotations
-        annotations = []
-        for i in range(3):
-            mock_annotation = MagicMock()
-            mock_annotation.type = "file_citation"
-            mock_annotation.file_id = f"file-{i}"
-            mock_annotation.filename = f"doc_{i}.pdf"
-            mock_annotation.index = i * 10
-            annotations.append(mock_annotation)
+        """Handle multiple file citations within a single message."""
+        annotations = [
+            AnnotationFileCitation(
+                file_id=f"file-{i}",
+                filename=f"doc_{i}.pdf",
+                index=i * 10,
+                type="file_citation",
+            )
+            for i in range(3)
+        ]
+        content_item = ResponseOutputText(annotations=annotations, text="Multiple refs", type="output_text")
+        message = ResponseOutputMessage(
+            id="msg_multi",
+            content=[content_item],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
 
-        mock_content_item = MagicMock()
-        mock_content_item.annotations = annotations
+        msg_item = MagicMock(spec=MessageOutputItem)
+        msg_item.raw_item = message
 
-        mock_message = MagicMock()
-        mock_message.id = "msg_multi"
-        mock_message.content = [mock_content_item]
+        result = extract_direct_file_annotations([msg_item])
 
-        mock_msg_item = MagicMock(spec=MessageOutputItem)
-        mock_msg_item.raw_item = mock_message
-
-        result = extract_direct_file_annotations([mock_msg_item])
-
-        assert "msg_multi" in result
         citations = result["msg_multi"]
         assert len(citations) == 3
-
-        # Verify each citation
-        for i, citation in enumerate(citations):
-            assert citation["file_id"] == f"file-{i}"
-            assert citation["filename"] == f"doc_{i}.pdf"
-            assert citation["index"] == i * 10
+        assert {c["file_id"] for c in citations} == {"file-0", "file-1", "file-2"}
 
     def test_skips_messages_without_content(self):
-        """Test that messages without content are skipped."""
-        mock_message = MagicMock()
-        mock_message.content = None
+        """Messages with no content yield no citations."""
+        message = ResponseOutputMessage(
+            id="msg_empty",
+            content=[],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
 
-        mock_msg_item = MagicMock(spec=MessageOutputItem)
-        mock_msg_item.raw_item = mock_message
+        msg_item = MagicMock(spec=MessageOutputItem)
+        msg_item.raw_item = message
 
-        result = extract_direct_file_annotations([mock_msg_item])
-        assert result == {}
+        assert extract_direct_file_annotations([msg_item]) == {}
 
     def test_skips_non_file_citation_annotations(self):
-        """Test that non-file-citation annotations are ignored."""
-        mock_annotation = MagicMock()
-        mock_annotation.type = "image_file"  # Not a file citation
+        """Annotations of other types are ignored."""
+        content_item = LegacyContentItem(annotations=[{"type": "image_file", "url": "http://example.com"}])
+        message = LegacyMessage(id="msg_no_citations", content=[content_item])
 
-        mock_content_item = MagicMock()
-        mock_content_item.annotations = [mock_annotation]
+        msg_item = MagicMock(spec=MessageOutputItem)
+        msg_item.raw_item = message
 
-        mock_message = MagicMock()
-        mock_message.id = "msg_no_citations"
-        mock_message.content = [mock_content_item]
+        assert extract_direct_file_annotations([msg_item]) == {}
 
-        mock_msg_item = MagicMock(spec=MessageOutputItem)
-        mock_msg_item.raw_item = mock_message
+    def test_ignores_invalid_annotation_payload(self, caplog: pytest.LogCaptureFixture):
+        """Invalid annotation payloads are skipped with a warning."""
+        caplog.set_level("WARNING")
+        content_item = LegacyContentItem(annotations=[{"type": "file_citation"}])
+        message = LegacyMessage(id="msg_incomplete", content=[content_item])
 
-        result = extract_direct_file_annotations([mock_msg_item])
-        assert result == {}
+        msg_item = MagicMock(spec=MessageOutputItem)
+        msg_item.raw_item = message
 
-    def test_handles_missing_annotation_attributes(self):
-        """Test graceful handling of annotations with missing attributes."""
-        mock_annotation = MagicMock()
-        mock_annotation.type = "file_citation"
-        # Explicitly delete the attributes to simulate missing attributes
-        del mock_annotation.file_id
-        del mock_annotation.filename
-        del mock_annotation.index
-
-        mock_content_item = MagicMock()
-        mock_content_item.annotations = [mock_annotation]
-
-        mock_message = MagicMock()
-        mock_message.id = "msg_incomplete"
-        mock_message.content = [mock_content_item]
-
-        mock_msg_item = MagicMock(spec=MessageOutputItem)
-        mock_msg_item.raw_item = mock_message
-
-        result = extract_direct_file_annotations([mock_msg_item])
-
-        citations = result["msg_incomplete"]
-        citation = citations[0]
-        assert citation["file_id"] == "unknown"
-        assert citation["filename"] == "unknown"
-        assert citation["index"] == 0  # Default value
+        assert extract_direct_file_annotations([msg_item]) == {}
 
 
 class TestExtractVectorStoreCitations:
     """Test vector store citation extraction from run results."""
 
     def test_extracts_file_search_citations(self):
-        """Test extraction of FileSearch tool citations."""
-        # Create mock file search result
-        mock_search_result = MagicMock()
-        mock_search_result.file_id = "vs-file-123"
-        mock_search_result.text = "This is the retrieved text content from the file."
+        """Extract citations from a typed FileSearch tool call."""
+        tool_call = ResponseFileSearchToolCall(
+            id="call_sdk",
+            queries=["report"],
+            status="completed",
+            type="file_search_call",
+            results=[FileSearchResult(file_id="file-sdk", text="Findings content")],
+        )
 
-        # Create mock file search tool call
-        mock_tool_call = MagicMock()
-        mock_tool_call.type = "file_search_call"
-        mock_tool_call.id = "call_abc123"
-        mock_tool_call.results = [mock_search_result]
+        run_result = MagicMock()
+        run_result.new_items = [ToolCallItem(agent=MagicMock(), raw_item=tool_call)]
 
-        # Create mock run result item
-        mock_item = MagicMock()
-        mock_item.raw_item = mock_tool_call
+        result = extract_vector_store_citations(run_result)
 
-        # Create mock run result
-        mock_run_result = MagicMock()
-        mock_run_result.new_items = [mock_item]
-
-        result = extract_vector_store_citations(mock_run_result)
-
-        assert len(result) == 1
-        citation = result[0]
-        assert citation["method"] == "vector_store"
-        assert citation["file_id"] == "vs-file-123"
-        assert citation["text"] == "This is the retrieved text content from the file."
-        assert citation["tool_call_id"] == "call_abc123"
+        assert result[0]["file_id"] == "file-sdk"
+        assert result[0]["text"] == "Findings content"
+        assert result[0]["tool_call_id"] == "call_sdk"
 
     def test_handles_multiple_search_results(self):
-        """Test handling multiple search results from a single tool call."""
-        # Create multiple search results
-        search_results = []
-        for i in range(3):
-            mock_result = MagicMock()
-            mock_result.file_id = f"vs-file-{i}"
-            mock_result.text = f"Content from file {i}"
-            search_results.append(mock_result)
+        """Handle multiple search results within a single tool call."""
+        tool_call = ResponseFileSearchToolCall(
+            id="call_multi",
+            queries=["reports"],
+            status="completed",
+            type="file_search_call",
+            results=[FileSearchResult(file_id=f"vs-file-{i}", text=f"Content from file {i}") for i in range(3)],
+        )
 
-        mock_tool_call = MagicMock()
-        mock_tool_call.type = "file_search_call"
-        mock_tool_call.id = "call_multi"
-        mock_tool_call.results = search_results
+        run_result = MagicMock()
+        run_result.new_items = [ToolCallItem(agent=MagicMock(), raw_item=tool_call)]
 
-        mock_item = MagicMock()
-        mock_item.raw_item = mock_tool_call
+        citations = extract_vector_store_citations(run_result)
 
-        mock_run_result = MagicMock()
-        mock_run_result.new_items = [mock_item]
+        assert len(citations) == 3
+        assert {c["file_id"] for c in citations} == {"vs-file-0", "vs-file-1", "vs-file-2"}
 
-        result = extract_vector_store_citations(mock_run_result)
+    def test_missing_file_id_defaults_to_unknown(self):
+        """Fallback to 'unknown' when file_id is absent in the tool result."""
+        tool_call = ResponseFileSearchToolCall(
+            id="call_unknown",
+            queries=["reports"],
+            status="completed",
+            type="file_search_call",
+            results=[FileSearchResult(file_id=None, text="Content without identifier")],
+        )
 
-        assert len(result) == 3
-        for i, citation in enumerate(result):
-            assert citation["file_id"] == f"vs-file-{i}"
-            assert citation["text"] == f"Content from file {i}"
-            assert citation["tool_call_id"] == "call_multi"
+        run_result = MagicMock()
+        run_result.new_items = [ToolCallItem(agent=MagicMock(), raw_item=tool_call)]
 
-    def test_skips_non_file_search_items(self):
-        """Test that non-file-search items are ignored."""
-        mock_tool_call = MagicMock()
-        mock_tool_call.type = "function_call"  # Not a file search
+        citations = extract_vector_store_citations(run_result)
 
-        mock_item = MagicMock()
-        mock_item.raw_item = mock_tool_call
-
-        mock_run_result = MagicMock()
-        mock_run_result.new_items = [mock_item]
-
-        result = extract_vector_store_citations(mock_run_result)
-        assert result == []
+        assert len(citations) == 1
+        assert citations[0]["file_id"] == "unknown"
 
     def test_handles_missing_results(self):
-        """Test handling of file search calls without results."""
-        mock_tool_call = MagicMock()
-        mock_tool_call.type = "file_search_call"
-        mock_tool_call.results = None
+        """Gracefully handle file search calls without results."""
+        tool_call = ResponseFileSearchToolCall(
+            id="call_empty",
+            queries=["anything"],
+            status="completed",
+            type="file_search_call",
+            results=None,
+        )
 
-        mock_item = MagicMock()
-        mock_item.raw_item = mock_tool_call
+        run_result = MagicMock()
+        run_result.new_items = [ToolCallItem(agent=MagicMock(), raw_item=tool_call)]
 
-        mock_run_result = MagicMock()
-        mock_run_result.new_items = [mock_item]
+        assert extract_vector_store_citations(run_result) == []
 
-        result = extract_vector_store_citations(mock_run_result)
-        assert result == []
+    def test_skips_non_file_search_items(self):
+        """Ignore items that are not file-search tool calls."""
+        tool_call = MagicMock()
+        tool_call.type = "function_call"
+
+        run_result = MagicMock()
+        run_result.new_items = [ToolCallItem(agent=MagicMock(), raw_item=tool_call)]
+
+        assert extract_vector_store_citations(run_result) == []
 
 
 class TestExtractDirectFileCitationsFromHistory:


### PR DESCRIPTION
- src/agency_swarm/messages/message_formatter.py: consume ResponseOutput* and ResponseFileSearchResult objects directly, keeping legacy fallbacks
- src/agency_swarm/utils/citation_extractor.py: normalize file search ids via typed helpers and share validation flow
- tests/test_agent_modules/test_agui_adapter.py: rewrite fixtures to build real SDK response items
- tests/test_agent_modules/test_citation_extractor.py: assert typed citation handling and missing id fallback
