### PR TITLE
Terminal demo improvements

### DIFF
--- a/src/agency_swarm/ui/demos/terminal.py
+++ b/src/agency_swarm/ui/demos/terminal.py
@@ -368,6 +368,7 @@ def start_terminal(
             mouse_support=False,
             style=dropdown_style,
             full_screen=False,
+            erase_when_done=True,
         )
 
         dropdown_menu.update_invalidator(application.invalidate)
@@ -485,6 +486,12 @@ def start_terminal(
             message_text = cast(str, message)
             if message_text.strip():
                 history.append_string(message_text)
+
+            current_prompt = ""
+            application.invalidate()
+
+            if message_text:
+                event_converter.console.print(f"👤 USER -> 🤖 {active_recipient}: {message_text}")
 
             event_converter.console.rule()
             should_exit = await handle_message(message_text)


### PR DESCRIPTION
1. Added dropdown for agent selection in terminal demo
2. Added autocomplete to terminal demo commands
3. Updated dropdown styling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Application-based input with a keyboard-navigable dropdown for slash commands and agent mentions, improves @agent parsing/behavior, and updates tests accordingly.
> 
> - **Terminal UI**:
>   - Replace `PromptSession` completer with `Application` + `Buffer` and a custom dropdown for `"/"` commands and `"@"` agent mentions.
>   - Add key bindings: `"/"`, `"@"`, arrow keys to navigate, `Tab` to apply, `Esc` to dismiss, `Enter` to submit/apply.
>   - Show active recipient in prompt; allow agent-only mentions to switch handoff without sending; clear handoff on explicit target.
>   - Improve `@agent` parsing (longest-match, punctuation boundaries) and error logging for unknown agents.
> - **Styling**:
>   - Add dropdown styles (`class:dropdown.*`) and framed container.
> - **Tests**:
>   - Update integration tests to stub `Application`, validate dropdown population and CLI behaviors (`/help`, `/status`, `/new`, `/resume`, `/compact`, mentions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bec2189fa6507a756d93a0be7271423230df91f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->