### PR TITLE
docs: link starter template across quick starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you hit environment issues, see the [Installation guide](https://agency-swarm
 
 ## Getting Started
 
+> **Recommended**: Follow the [Agency Templates guide](https://agency-swarm.ai/welcome/getting-started/agency-templates)—it walks you through cloning the Agency Starter Template or adapting the Agency Code example before you customize anything.
+
 1. **Set Your OpenAI Key**:
     - Create a `.env` file with `OPENAI_API_KEY=your_key` (auto-loaded), or export it in your shell:
     ```bash
@@ -130,7 +132,7 @@ Define tools using the modern `@function_tool` decorator (recommended), or exten
     )
     ```
 
-    Working from examples and templates:
+    Working from examples:
 
     - Browse `./examples` for runnable demos and patterns you can adapt.
     - Use the `.cursorrules` file at the repo root with your AI coding agent (Cursor, Claude Code, etc.).
@@ -218,6 +220,7 @@ This structure ensures that each agent has its dedicated space with all necessar
 - Agencies overview: https://agency-swarm.ai/core-framework/agencies/overview
 - Communication flows: https://agency-swarm.ai/core-framework/agencies/communication-flows
 - Running an agency: https://agency-swarm.ai/core-framework/agencies/running-agency
+- Agency Templates guide (Starter Template + Agency Code): https://agency-swarm.ai/welcome/getting-started/agency-templates
 - Observability: https://agency-swarm.ai/additional-features/observability
 
 ## Contributing

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -56,4 +56,6 @@ Source: [Agencii Roadmap Notion](https://vrsen-ai.notion.site/Agencii-Roadmap-15
 
 To get started with the Agencii Platform, please sign up for a free account [here](https://agencii.ai/signup).
 
+Start with the [Agency Starter Template](https://github.com/agency-ai-solutions/agency-starter-template) for an Agencii-compatible setup.
+
 **Happy building!**

--- a/docs/welcome/getting-started/agency-templates.mdx
+++ b/docs/welcome/getting-started/agency-templates.mdx
@@ -7,33 +7,37 @@ icon: "layer-group"
 Use these production-ready templates to start faster. Pick one below and follow the steps to run locally, then customize.
 
 <CardGroup cols={2}>
-  <Card title="Agency Code" icon="code" href="https://github.com/VRSEN/Agency-Code">
-    Fully open-sourced Claude Code-style agency built with Agency Swarm. Includes Developer and Planner agents and 14 production tools.
-  </Card>
   <Card title="Agency Starter Template" icon="rocket" href="https://github.com/agency-ai-solutions/agency-starter-template">
-    Opinionated starter with CI, Docker, and deployment hooks. A clean base to build your own agency.
+    Agencii-compatible production template with Docker config and Cursor workflow guidance.
+  </Card>
+  <Card title="Agency Code" icon="code" href="https://github.com/VRSEN/Agency-Code">
+    Agency Code example repository you can explore or customize after cloning.
   </Card>
 </CardGroup>
+
+<Tip>
+Watch the [Agency Code walkthrough](https://www.youtube.com/watch?v=VziscdcEQuI) for an overview of that repository before you customize it.
+</Tip>
 
 ## Use a Template
 
 <Steps>
   <Step title="Choose a template">
-    Select either **Agency Code** or **Agency Starter Template** above based on your needs.
+    Select the **Agency Starter Template** when you need the Agencii-compatible setup with Docker. Use **Agency Code** when you want to experiment with or extend that example repository.
   </Step>
 
   <Step title="Clone the repository">
     Clone your chosen template repository to your local machine.
 
     <CodeGroup>
-    ```bash Agency Code
-    git clone https://github.com/VRSEN/Agency-Code.git
-    cd Agency-Code
-    ```
-
     ```bash Agency Starter Template
     git clone https://github.com/agency-ai-solutions/agency-starter-template.git
     cd agency-starter-template
+    ```
+
+    ```bash Agency Code
+    git clone https://github.com/VRSEN/Agency-Code.git
+    cd Agency-Code
     ```
     </CodeGroup>
   </Step>

--- a/docs/welcome/getting-started/from-scratch.mdx
+++ b/docs/welcome/getting-started/from-scratch.mdx
@@ -3,6 +3,11 @@ title: "From Scratch"
 description: "Quick start guide to building an Agency from scratch."
 icon: "code"
 ---
+
+<Note>
+Use this guide when you need to build everything manually. Otherwise, follow the [Agency Templates guide](/welcome/getting-started/agency-templates) to start from the Agencii-compatible Starter Template or the Agency Code example.
+</Note>
+
 <Steps>
   <Step title="Set Your OpenAI Key">
     Begin by setting your OpenAI API key in the `.env` file. It will be loaded automatically on agency initialization


### PR DESCRIPTION
## Summary
- link the Agency Starter Template from the README getting started section
- reference the starter template across all quick start docs, including from-scratch, templates, widget, and tutorials pages
