### PR TITLE
fix: package visualization templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agency-swarm"
-version = "1.4.0"
+version = "1.4.1"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -93,6 +93,7 @@ packages = ["src/agency_swarm"]
 include = [
     "src/agency_swarm/**/*.py",
     "src/agency_swarm/**/*.ts",
+    "src/agency_swarm/ui/templates/**",
 ]
 
 [tool.ruff]

--- a/tests/test_agency_modules/test_ui.py
+++ b/tests/test_agency_modules/test_ui.py
@@ -288,7 +288,7 @@ class TestAgencyVisualizationIntegration:
         with patch("agency_swarm.agency.Agency.visualize") as mock_method:
             mock_method.side_effect = ImportError("Visualization module not available")
             with pytest.raises(ImportError, match="Visualization module not available"):
-                sample_agency.visualize()
+                sample_agency.visualize(open_browser=False)
 
     def test_get_agency_structure_basic(self, sample_agency):
         """Test basic agency structure generation."""

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "datamodel-code-generator" },


### PR DESCRIPTION
- pyproject: bump version to 1.4.1 and include html templates in sdist
- tests/test_agency_modules/test_ui.py: disable browser launch for import-error test
- uv.lock: sync dependency metadata
