### PR TITLE
docs: update n8n integration documentation to include notes on self-h…

### DIFF
--- a/docs/platform/integrations/n8n-integration.mdx
+++ b/docs/platform/integrations/n8n-integration.mdx
@@ -15,7 +15,7 @@ n8n is a flexible workflow automation platform that lets you connect dozens of s
 - **n8n instance** with permissions to install **Community Nodes**.
 
 <Note>
-Existing users currently need to use a self-hosted n8n instance to install the Agencii community node, as the `n8n-nodes-agencii` npm package is in the process of verification.
+Existing users currently need to use a self-hosted n8n instance to install the Agencii community node, as the `n8n-nodes-agencii` npm package is in the process of verification. For more details on how this works in n8n, see the n8n community nodes installation guide at https://docs.n8n.io/integrations/community-nodes/installation/.
 </Note>
 
 ## Step 1: Set up n8n Integration in Agencii
@@ -62,7 +62,7 @@ Existing users currently need to use a self-hosted n8n instance to install the A
 <Steps>
   <Step title="Install the node">
     ![Install community node modal with n8n-nodes-agencii package name](/images/integrations/n8n-integration/n8n-install-community-node-modal.png)
-    1. In your n8n instance, go to **Settings → Community Nodes**.
+    1. In your n8n instance, go to **Settings → Community Nodes**. You can learn more about installing and managing community nodes in the official n8n docs at https://docs.n8n.io/integrations/community-nodes/installation/.
     2. Click **Install** and enter the package name:
 
        ```bash


### PR DESCRIPTION
…osted instances and installation steps for Agencii community node

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates n8n integration docs to note self-hosted requirement and add guidance/links for installing the Agencii community node.
> 
> - **Docs** (`docs/platform/integrations/n8n-integration.mdx`):
>   - Add Note on needing a self-hosted n8n instance while `n8n-nodes-agencii` undergoes verification, with link to n8n community node installation guide.
>   - Add Note in the copy step explaining how to install the NPM package via n8n Community Nodes and where to find Agencii node usage docs.
>   - Update install step to include link to official n8n community nodes installation/management docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24ce68a6fae94e247bdbc1c0e64b4b9ba2bbd82e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->