### PR TITLE
chore: update default model to gpt-5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Define tools using the modern `@function_tool` decorator (recommended), or exten
         files_folder="./files", # files to be uploaded to OpenAI
         schemas_folder="./schemas", # OpenAPI schemas to be converted into tools
         tools=[my_custom_tool],  # FunctionTool returned by @function_tool (or adapt BaseTool via ToolFactory)
-        model="gpt-5",
+        model="gpt-5.1",
         model_settings=ModelSettings(
             max_tokens=25000,
         ),

--- a/docs/additional-features/azure-openai.mdx
+++ b/docs/additional-features/azure-openai.mdx
@@ -53,7 +53,7 @@ azure_agent = Agent(
     name="AzureAgent",
     instructions="You are a helpful assistant",
     model=OpenAIChatCompletionsModel(
-        model="gpt-4.1",
+        model="gpt-5.1",
         openai_client=azure_agent,
     ),
 )

--- a/docs/core-framework/tools/custom-tools/step-by-step-guide.mdx
+++ b/docs/core-framework/tools/custom-tools/step-by-step-guide.mdx
@@ -251,7 +251,7 @@ if __name__ == "__main__":
         name="MathAgent",
         instructions="You are a helpful math assistant",
         tools=[calculator_tool],  # Pass function directly
-        model="gpt-4.1"
+        model="gpt-5.1"
     )
     ```
   </Step>

--- a/docs/core-framework/tools/mcp-integration.mdx
+++ b/docs/core-framework/tools/mcp-integration.mdx
@@ -156,7 +156,7 @@ local_agent = Agent(
     description="An agent that can use local MCP tools.",
     instructions="Use the available MCP tools to help users.",
     mcp_servers=[stdio_server],  # Local servers go here
-    model="gpt-4.1",
+    model="gpt-5.1",
 )
 
 # For hosted MCP servers, use tools parameter
@@ -165,7 +165,7 @@ hosted_agent = Agent(
     description="An agent that can use hosted MCP tools.",
     instructions="Use the available hosted MCP tools to help users.",
     tools=[hosted_tool],  # Hosted tools go here
-    model="gpt-4.1",
+    model="gpt-5.1",
 )
 ```
 </Accordion>

--- a/examples/agent_file_storage.py
+++ b/examples/agent_file_storage.py
@@ -55,8 +55,8 @@ async def main():
             ),
             files_folder=str(docs_dir),
             include_search_results=True,
-            model="gpt-4.1",
-            model_settings=ModelSettings(temperature=0.0, tool_choice="file_search"),
+            model="gpt-5.1",
+            model_settings=ModelSettings(tool_choice="file_search"),
             tool_use_behavior="stop_on_first_tool",
         )
 

--- a/examples/guardrails_output.py
+++ b/examples/guardrails_output.py
@@ -22,7 +22,7 @@ async def forbid_sensitive_email(
 support_agent = Agent(
     name="SupportPilot",
     instructions="You handle customer support. Official email: support@example.com.",
-    model="gpt-5",
+    model="gpt-5.1",
     output_guardrails=[forbid_sensitive_email],
     validation_attempts=1,  # 1 is the default, set to 0 for immediate fail-fast behavior
 )

--- a/examples/interactive/third_party_models.py
+++ b/examples/interactive/third_party_models.py
@@ -64,7 +64,7 @@ strategy_agent = Agent(
 
     Be decisive, practical, and always tie recommendations back to market data.
     """,
-    model="openai/gpt-4.1",  # gpt-5 provides better results, but the example will take too long to run
+    model="openai/gpt-5.1",
 )
 
 market_research_agent = Agent(

--- a/examples/mcp_servers.py
+++ b/examples/mcp_servers.py
@@ -59,7 +59,7 @@ mcp_agent_local = Agent(
     name="local_MCP_Agent",
     instructions="You are a helpful assistant",
     description="Helpful assistant",
-    model="gpt-4.1",
+    model="gpt-5.1",
     mcp_servers=[stdio_server],  # <- local mcp server
 )
 
@@ -69,7 +69,7 @@ mcp_agent_public = Agent(
     name="public_MCP_Agent",
     instructions="You are a helpful assistant",
     description="Helpful assistant",
-    model="gpt-4.1",
+    model="gpt-5.1",
     tools=[
         HostedMCPTool(  # <- public mcp server (requires ngrok)
             tool_config={

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -31,7 +31,6 @@ from langfuse import observe  # noqa: E402
 from agency_swarm import (  # noqa: E402
     Agency,
     Agent,
-    ModelSettings,
     RunContextWrapper,
     function_tool,
     trace,
@@ -63,25 +62,22 @@ def create_agency() -> Agency:
         name="CEO",
         instructions="You are the CEO. NEVER execute tasks yourself. Instead, DELEGATE all tasks: coding tasks to Developer and data analysis to DataAnalyst.",
         description="Manages projects and coordinates between team members",
-        model="gpt-4.1",
-        model_settings=ModelSettings(temperature=0.0),
+        model="gpt-5.1",
     )
 
     developer = Agent(
         name="Developer",
         instructions="You are the Developer. Solve coding problems by implementing solutions and writing code.",
         description="Implements technical solutions and writes code",
-        model="gpt-4.1",
-        model_settings=ModelSettings(temperature=0.0),
+        model="gpt-5.1",
     )
 
     analyst = Agent(
         name="DataAnalyst",
         instructions="You are the Data Analyst. Analyze data and provide insights. Always use analyze_dataset in your response to process the dataset.",
         description="Analyzes data and provides insights",
-        model="gpt-4.1",
+        model="gpt-5.1",
         tools=[analyze_dataset],
-        model_settings=ModelSettings(temperature=0.0),
     )
 
     return Agency(

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -115,7 +115,7 @@ class Agent(BaseAgent[MasterContext]):
 
         ## OpenAI Agents SDK Parameters:
             prompt (Prompt | DynamicPromptFunction | None): Dynamic prompt configuration.
-            model (str | Model | None): Model identifier (e.g., "gpt-5") or Model instance.
+            model (str | Model | None): Model identifier (e.g., "gpt-5.1") or Model instance.
                 If not provided, the agents SDK default model will be used: https://openai.github.io/openai-agents-python/models
             model_settings (ModelSettings | None): Model configuration (temperature, max_tokens, etc.).
             tools (list[Tool] | None): Tool instances for the agent. Defaults to empty list.

--- a/src/agency_swarm/cli/main.py
+++ b/src/agency_swarm/cli/main.py
@@ -24,7 +24,7 @@ def main() -> None:
     )
     create_agent_parser.add_argument("name", help="Name of the agent (e.g., 'Data Analyst', 'Content Writer')")
     create_agent_parser.add_argument("--description", help="Description of the agent's role and responsibilities")
-    create_agent_parser.add_argument("--model", default="gpt-4.1", help="OpenAI model to use (default: gpt-4.1)")
+    create_agent_parser.add_argument("--model", default="gpt-5.1", help="OpenAI model to use (default: gpt-5.1)")
     create_agent_parser.add_argument(
         "--reasoning", choices=["low", "medium", "high"], help="Reasoning effort level for the model"
     )

--- a/src/agency_swarm/utils/create_agent_template.py
+++ b/src/agency_swarm/utils/create_agent_template.py
@@ -29,7 +29,7 @@ def _validate_temperature(temperature: float | None) -> None:
 def create_agent_template(
     agent_name=None,
     agent_description=None,
-    model="gpt-4.1",
+    model="gpt-5.1",
     reasoning=None,
     max_tokens=None,
     temperature=None,

--- a/tests/integration/fastapi/test_fastapi_file_processing.py
+++ b/tests/integration/fastapi/test_fastapi_file_processing.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 import uvicorn
 from agents import ModelSettings
+from openai.types.shared import Reasoning
 
 from agency_swarm import Agency, Agent
 
@@ -47,9 +48,9 @@ class TestFastAPIFileProcessing:
                 alternative text. If multiple phrases appear, include them all exactly as written.
                 """,
                 description="Agent that processes and analyzes file content",
-                model="gpt-4.1",
+                model="gpt-5.1",
                 model_settings=ModelSettings(
-                    temperature=0,
+                    reasoning=Reasoning(effort="low"),
                 ),
             )
 

--- a/tests/integration/fastapi/test_fastapi_metadata.py
+++ b/tests/integration/fastapi/test_fastapi_metadata.py
@@ -90,18 +90,16 @@ def test_metadata_includes_agent_capabilities():
                 WebSearchTool(),
             ],
         )
-        # Agent with reasoning model
         agent3 = Agent(
             name="ReasoningAgent",
             instructions="Test",
-            model="gpt-5",
-            model_settings=ModelSettings(reasoning=Reasoning(effort="high")),
+            model="gpt-5.1",
+            model_settings=ModelSettings(reasoning=Reasoning(effort="low")),
         )
-        # Agent with all capabilities
         agent4 = Agent(
             name="FullAgent",
             instructions="Test",
-            model="o1",
+            model="gpt-5.1",
             tools=[CustomTool, FileSearchTool(vector_store_ids=["vs_456"])],
         )
         return Agency(

--- a/tests/integration/files/test_file_attachment_citation_extraction.py
+++ b/tests/integration/files/test_file_attachment_citation_extraction.py
@@ -14,7 +14,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from agents import ModelSettings
 
 from agency_swarm import Agency, Agent
 from agency_swarm.utils.citation_extractor import extract_direct_file_citations_from_history
@@ -63,8 +62,7 @@ async def test_file_attachment_citation_extraction():
                     "information from the document. Be precise and reference exact text when "
                     "providing answers."
                 ),
-                model="gpt-4.1",
-                model_settings=ModelSettings(temperature=0.0),  # DETERMINISTIC BEHAVIOR
+                model="gpt-5.1",
             )
 
             # Create agency with the agent
@@ -184,16 +182,14 @@ async def test_file_attachment_vs_vector_store_citation_distinction():
             name="VectorAgent",
             instructions="Use your FileSearch tool to answer questions.",
             files_folder=str(vector_dir),
-            model="gpt-4.1",
-            model_settings=ModelSettings(temperature=0.0),  # DETERMINISTIC
+            model="gpt-5.1",
         )
 
         # Create agent for direct file attachments
         attachment_agent = Agent(
             name="AttachmentAgent",
             instructions="Analyze attached files directly and provide specific citations.",
-            model="gpt-4.1",
-            model_settings=ModelSettings(temperature=0.0),  # DETERMINISTIC
+            model="gpt-5.1",
         )
 
         # Create agencies

--- a/tests/integration/files/test_file_handling.py
+++ b/tests/integration/files/test_file_handling.py
@@ -199,8 +199,8 @@ async def _setup_file_search_agent(real_openai_client: AsyncOpenAI, tmp_path: Pa
         instructions="""You are an agent that can read and analyze text files using FileSearch.
         When asked questions about files, always use your FileSearch tool to search through the uploaded documents.
         Be direct and specific in your answers based on what you find in the files.""",
-        model="gpt-4.1",
-        model_settings=ModelSettings(temperature=0.0, tool_choice="required"),
+        model="gpt-5.1",
+        model_settings=ModelSettings(tool_choice="required"),
         include_search_results=True,
         tool_use_behavior="stop_on_first_tool",
         files_folder=tmp_dir,
@@ -293,8 +293,8 @@ async def test_files_folder_reuse_without_missing_directory_warning(
         "instructions": "You are a document assistant who relies on FileSearch for answers.",
         "files_folder": str(files_dir),
         "include_search_results": True,
-        "model": "gpt-4.1",
-        "model_settings": ModelSettings(temperature=0.0, tool_choice="file_search"),
+        "model": "gpt-5.1",
+        "model_settings": ModelSettings(tool_choice="file_search"),
         "tool_use_behavior": "stop_on_first_tool",
     }
 
@@ -596,8 +596,8 @@ async def test_vector_store_cleanup_on_init(real_openai_client: AsyncOpenAI, tmp
         "instructions": "Use FileSearch to answer from documents.",
         "files_folder": str(files_dir),
         "include_search_results": True,
-        "model": "gpt-4.1",
-        "model_settings": ModelSettings(temperature=0.0, tool_choice="file_search"),
+        "model": "gpt-5.1",
+        "model_settings": ModelSettings(tool_choice="file_search"),
         "tool_use_behavior": "stop_on_first_tool",
     }
 
@@ -672,8 +672,8 @@ async def test_file_reupload_on_mtime_update(real_openai_client: AsyncOpenAI, tm
         "instructions": "Use FileSearch to answer from documents.",
         "files_folder": str(files_dir),
         "include_search_results": True,
-        "model": "gpt-4.1",
-        "model_settings": ModelSettings(temperature=0.0, tool_choice="file_search"),
+        "model": "gpt-5.1",
+        "model_settings": ModelSettings(tool_choice="file_search"),
         "tool_use_behavior": "stop_on_first_tool",
     }
 

--- a/tests/integration/files/test_vector_store_citation_extraction.py
+++ b/tests/integration/files/test_vector_store_citation_extraction.py
@@ -48,8 +48,8 @@ async def test_vector_store_citation_extraction():
             ),
             files_folder=str(temp_path),
             include_search_results=True,
-            model="gpt-4.1",
-            model_settings=ModelSettings(temperature=0.0, tool_choice="file_search"),
+            model="gpt-5.1",
+            model_settings=ModelSettings(tool_choice="file_search"),
             tool_use_behavior="stop_on_first_tool",
         )
 

--- a/tests/integration/fin_agency/financial_research_agency/PortfolioManager/PortfolioManager.py
+++ b/tests/integration/fin_agency/financial_research_agency/PortfolioManager/PortfolioManager.py
@@ -8,5 +8,5 @@ portfolio_manager = Agent(
     ),
     instructions="./instructions.md",
     tools_folder="./tools",
-    model="gpt-4.1",
+    model="gpt-5.1",
 )

--- a/tests/integration/fin_agency/financial_research_agency/ReportGenerator/ReportGenerator.py
+++ b/tests/integration/fin_agency/financial_research_agency/ReportGenerator/ReportGenerator.py
@@ -8,5 +8,5 @@ report_generator = Agent(
     ),
     instructions="./instructions.md",
     tools_folder="./tools",
-    model="gpt-4.1",
+    model="gpt-5.1",
 )

--- a/tests/integration/fin_agency/financial_research_agency/RiskAnalyst/RiskAnalyst.py
+++ b/tests/integration/fin_agency/financial_research_agency/RiskAnalyst/RiskAnalyst.py
@@ -9,5 +9,5 @@ risk_analyst = Agent(
     ),
     instructions="./instructions.md",
     tools_folder="./tools",
-    model="gpt-4.1",
+    model="gpt-5.1",
 )

--- a/tests/integration/litellm/test_litellm_models.py
+++ b/tests/integration/litellm/test_litellm_models.py
@@ -27,7 +27,7 @@ def coordinator_agent():
             "When delegating, only relay the exact task text and never include unrelated user information."
         ),
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="openai/gpt-4.1", api_key=os.getenv("OPENAI_API_KEY")),
+        model=LitellmModel(model="openai/gpt-5.1", api_key=os.getenv("OPENAI_API_KEY")),
         send_message_tool_class=SendMessageHandoff,
     )
 
@@ -38,7 +38,7 @@ def worker_agent():
         name="Worker",
         instructions=("You perform tasks. When you receive a task, "),
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="openai/gpt-4.1", api_key=os.getenv("OPENAI_API_KEY")),
+        model=LitellmModel(model="openai/gpt-5.1", api_key=os.getenv("OPENAI_API_KEY")),
     )
 
 
@@ -51,7 +51,7 @@ def data_agent():
         ),
         description="Has information about the user.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="openai/gpt-4.1", api_key=os.getenv("OPENAI_API_KEY")),
+        model=LitellmModel(model="openai/gpt-5.1", api_key=os.getenv("OPENAI_API_KEY")),
     )
 
 

--- a/tests/integration/litellm/test_litellm_visualization.py
+++ b/tests/integration/litellm/test_litellm_visualization.py
@@ -17,7 +17,7 @@ def test_visualize_redacts_litellm_credentials(tmp_path):
         name="Visualizer",
         instructions="Visualize the agency safely.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="openai/gpt-4.1", api_key=api_key),
+        model=LitellmModel(model="openai/gpt-5.1", api_key=api_key),
     )
     agency = Agency(agent)
 

--- a/tests/integration/test_responses_api_tools.py
+++ b/tests/integration/test_responses_api_tools.py
@@ -87,7 +87,7 @@ async def test_tool_cycle_with_sdk_and_responses_api():
 
     # Explicitly create an AsyncOpenAI client
     client = AsyncOpenAI(api_key=OPENAI_API_KEY)
-    forced_responses_model = OpenAIResponsesModel(model="gpt-4.1", openai_client=client)
+    forced_responses_model = OpenAIResponsesModel(model="gpt-5.1", openai_client=client)
 
     agent = Agent(
         name="SDK Responses API Test Agent",
@@ -95,7 +95,6 @@ async def test_tool_cycle_with_sdk_and_responses_api():
         tools=[simple_processor_tool],
         tool_use_behavior="run_llm_again",  # Send tool output back to LLM for final response
         model=forced_responses_model,
-        model_settings=ModelSettings(temperature=0.1),
     )
 
     logger.info("Testing tool cycle with SDK Agent using OpenAIResponsesModel")
@@ -168,7 +167,7 @@ async def test_tool_output_conversion_bug_two_turn_conversation():
     agent = AgencySwarmAgent(
         name="Calculator Agent",
         instructions="You are a calculator assistant. Use the calculator tool for arithmetic operations.",
-        model="gpt-4.1",
+        model="gpt-5.1",
     )
 
     # Add the calculator tool to the agent
@@ -302,8 +301,8 @@ Product Sales:
                 "You are a data search assistant. You MUST use the FileSearch tool to find information. "
                 "Always search files before answering. Be concise in your initial responses."
             ),
-            model="gpt-4.1",
-            model_settings=ModelSettings(temperature=0.0, tool_choice="file_search"),
+            model="gpt-5.1",
+            model_settings=ModelSettings(tool_choice="file_search"),
             files_folder=str(temp_dir),
             include_search_results=True,
         )

--- a/tests/test_agency_modules/test_agency_helpers.py
+++ b/tests/test_agency_modules/test_agency_helpers.py
@@ -4,7 +4,7 @@ from agency_swarm.tools import SendMessage
 
 
 def test_run_fastapi_creates_new_agency_instance(mocker):
-    agent = Agent(name="HelperAgent", instructions="test", model="gpt-4.1")
+    agent = Agent(name="HelperAgent", instructions="test", model="gpt-5.1")
     agency = Agency(agent)
 
     captured = {}
@@ -36,8 +36,8 @@ class CustomSendMessage(SendMessage):
 
 
 def test_run_fastapi_preserves_custom_tool_mappings(mocker):
-    sender = Agent(name="A", instructions="test", model="gpt-4.1")
-    recipient = Agent(name="B", instructions="test", model="gpt-4.1")
+    sender = Agent(name="A", instructions="test", model="gpt-5.1")
+    recipient = Agent(name="B", instructions="test", model="gpt-5.1")
     agency = Agency(sender, recipient, communication_flows=[(sender, recipient, CustomSendMessage)])
 
     captured = {}

--- a/tests/test_agent_modules/test_agent_capabilities.py
+++ b/tests/test_agent_modules/test_agent_capabilities.py
@@ -115,9 +115,9 @@ def test_agent_with_reasoning_model_o3():
     assert "reasoning" in capabilities
 
 
-def test_agent_with_reasoning_model_gpt5():
-    """Agent with gpt-5 model has 'reasoning' capability."""
-    agent = Agent(name="ReasoningAgent", instructions="Test", model="gpt-5")
+def test_agent_with_reasoning_model_gpt51():
+    """Agent with gpt-5.1 model has 'reasoning' capability."""
+    agent = Agent(name="ReasoningAgent", instructions="Test", model="gpt-5.1")
     capabilities = get_agent_capabilities(agent)
     assert "reasoning" in capabilities
 
@@ -134,7 +134,7 @@ def test_agent_with_reasoning_parameter():
     agent = Agent(
         name="ReasoningAgent",
         instructions="Test",
-        model="gpt-5",
+        model="gpt-5.1",
         model_settings=ModelSettings(reasoning=Reasoning(effort="high")),
     )
     capabilities = get_agent_capabilities(agent)
@@ -170,7 +170,7 @@ def test_agent_with_all_capabilities():
     agent = Agent(
         name="FullAgent",
         instructions="Test",
-        model="gpt-5",
+        model="gpt-5.1",
         tools=[
             SampleTool,
             FileSearchTool(vector_store_ids=["vs_123"]),
@@ -199,7 +199,7 @@ def test_capabilities_order_is_consistent():
     agent = Agent(
         name="Agent",
         instructions="Test",
-        model="gpt-5",
+        model="gpt-5.1",
         tools=[WebSearchTool(), SampleTool, CodeInterpreterTool(tool_config=CodeInterpreter())],
     )
     capabilities = get_agent_capabilities(agent)

--- a/tests/test_agent_modules/test_agent_initialization.py
+++ b/tests/test_agent_modules/test_agent_initialization.py
@@ -137,7 +137,7 @@ def test_agent_initialization_with_all_parameters():
                 agent = Agent(
                     name="CompleteAgent",
                     instructions="Complete agent with all params",
-                    model="gpt-4.1",
+                    model="gpt-5.1",
                     tools=[tool1],
                     response_validator=validator,
                     output_type=TaskOutput,
@@ -149,7 +149,7 @@ def test_agent_initialization_with_all_parameters():
 
         assert agent.name == "CompleteAgent"
         assert agent.instructions == "Complete agent with all params"
-        assert agent.model == "gpt-4.1"
+        assert agent.model == "gpt-5.1"
         assert len(agent.tools) == 2
         assert agent.tools[0] == tool1
         assert agent.tools[1].__class__.__name__ == "FileSearchTool"

--- a/tests/test_cli_modules/test_migrate_agent.py
+++ b/tests/test_cli_modules/test_migrate_agent.py
@@ -210,7 +210,7 @@ def test_generate_agent_script_escapes_strings(tmp_path: Path) -> None:
         "name": 'Quote "Tester"',
         "description": 'Says "hello" often',
         "instructions": "Be helpful",
-        "model": "gpt-4.1",
+        "model": "gpt-5.1",
     }
 
     settings_path = tmp_path / "settings.json"

--- a/tests/test_utils_modules/test_create_agent_template.py
+++ b/tests/test_utils_modules/test_create_agent_template.py
@@ -85,9 +85,10 @@ class TestCreateAgentTemplate:
         assert 'instructions="./instructions.md"' in agent_content
         assert 'files_folder="./files"' in agent_content
         assert 'tools_folder="./tools"' in agent_content
-        assert 'model="gpt-4.1"' in agent_content  # Updated default model
+        assert 'model="gpt-5.1"' in agent_content  # Updated default model
         assert "ModelSettings(" in agent_content
-        assert "temperature=0.3" in agent_content  # Should have default temperature for non-reasoning model
+        # gpt-5.1 is a reasoning model - no temperature
+        assert "temperature=" not in agent_content
 
     def test_instructions_file_content(self, tmp_path: Path) -> None:
         """Test that instructions file has correct structured template content."""

--- a/tests/test_utils_modules/test_model_utils.py
+++ b/tests/test_utils_modules/test_model_utils.py
@@ -5,11 +5,7 @@ from agency_swarm.utils.model_utils import is_reasoning_model
 
 def test_is_reasoning_model_with_o_series():
     """O-series models are reasoning models."""
-    assert is_reasoning_model("o1") is True
-    assert is_reasoning_model("o1-preview") is True
-    assert is_reasoning_model("o1-mini") is True
     assert is_reasoning_model("o3") is True
-    assert is_reasoning_model("o3-mini") is True
     assert is_reasoning_model("o4-mini") is True
 
 
@@ -22,11 +18,9 @@ def test_is_reasoning_model_with_gpt5():
 
 def test_is_reasoning_model_with_gpt4():
     """GPT-4 series models are NOT reasoning models."""
-    assert is_reasoning_model("gpt-4") is False
     assert is_reasoning_model("gpt-4o") is False
     assert is_reasoning_model("gpt-4o-mini") is False
     assert is_reasoning_model("gpt-4.1") is False
-    assert is_reasoning_model("gpt-4-turbo") is False
 
 
 def test_is_reasoning_model_with_other_models():


### PR DESCRIPTION
- Update CLI and create_agent_template default model to gpt-5.1
- Replace gpt-4.1 and gpt-5 references with gpt-5.1 across codebase
- Remove temperature from ModelSettings where gpt-5.1 is used (reasoning models don't support temperature)
- Add Reasoning parameter where deterministic behavior was needed
- Update tests to match new model defaults
