### PR TITLE
fix: make sync APIs safe inside running event loop

### DIFF
--- a/tests/test_agency_modules/test_agency_completions.py
+++ b/tests/test_agency_modules/test_agency_completions.py
@@ -66,6 +66,20 @@ def test_get_completion_emits_deprecation_and_delegates(monkeypatch):
     assert out == "text"
 
 
+@pytest.mark.asyncio
+async def test_get_completion_works_inside_running_event_loop(monkeypatch):
+    async def fake_async(*args, **kwargs):  # noqa: ANN001, ANN002
+        return "text"
+
+    monkeypatch.setattr(ag_completions, "async_get_completion", fake_async)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with pytest.warns(DeprecationWarning):
+            out = ag_completions.get_completion(_make_agency(), message="hi")
+    assert out == "text"
+
+
 def test_get_completion_stream_is_not_implemented():
     with pytest.warns(DeprecationWarning):
         with pytest.raises(NotImplementedError):

--- a/tests/test_agency_modules/test_agency_responses.py
+++ b/tests/test_agency_modules/test_agency_responses.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -41,6 +42,20 @@ async def test_agency_get_response_basic(mock_agent):
     mock_agent.get_response.return_value = MagicMock(final_output="Test response")
 
     result = await agency.get_response("Test message", "MockAgent")
+
+    assert result.final_output == "Test response"
+    mock_agent.get_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_agency_get_response_sync_inside_running_event_loop(mock_agent):
+    """Ensure Agency.get_response_sync works when called from a running event loop."""
+    agency = Agency(mock_agent)
+    mock_agent.get_response.return_value = MagicMock(final_output="Test response")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = agency.get_response_sync("Test message", "MockAgent")
 
     assert result.final_output == "Test response"
     mock_agent.get_response.assert_called_once()


### PR DESCRIPTION
- Run get_response_sync in a worker thread when a loop is already running
- Make deprecated get_completion loop-safe to avoid asyncio.run crashes
- Add regression tests for both sync wrappers under a running loop
