### PR TITLE
fix: pass uvicorn_config through run_mcp

### DIFF
--- a/examples/utils/sse_mcp_server.py
+++ b/examples/utils/sse_mcp_server.py
@@ -30,4 +30,9 @@ if __name__ == "__main__":
     if not os.getenv("APP_TOKEN") or os.getenv("APP_TOKEN") == "":
         os.environ["APP_TOKEN"] = "test_token_123"
         print("APP_TOKEN not set, using default token: test_token_123")
-    run_mcp(tools=[GetSecretWordTool, list_directory], transport="sse")
+    run_mcp(
+        tools=[GetSecretWordTool, list_directory],
+        transport="sse",
+        # FastMCP defaults this to 0, which reliably produces a scary shutdown error log.
+        uvicorn_config={"timeout_graceful_shutdown": 1},
+    )

--- a/src/agency_swarm/integrations/mcp_server.py
+++ b/src/agency_swarm/integrations/mcp_server.py
@@ -48,6 +48,7 @@ def run_mcp(
     server_name: str = "mcp-tools-server",
     return_app: bool = False,
     transport: Transport = "streamable-http",
+    uvicorn_config: dict[str, Any] | None = None,
 ):
     """
     Launch a FastMCP server exposing BaseTool and FunctionTool instances.
@@ -59,6 +60,7 @@ def run_mcp(
         server_name: Name identifier for the MCP server
         return_app: If True, returns the FastMCP instance instead of running it.
         transport: Mcp transport protocol to use.
+        uvicorn_config: Optional Uvicorn config overrides (HTTP/SSE transports only).
     Returns:
         FastMCP instance if return_app=True, otherwise None
     """
@@ -180,4 +182,4 @@ def run_mcp(
     if transport == "stdio":
         mcp.run(transport=transport)
     else:
-        mcp.run(transport=transport, host=host, port=port)
+        mcp.run(transport=transport, host=host, port=port, uvicorn_config=uvicorn_config)

--- a/tests/integration/mcp/test_mcp_server.py
+++ b/tests/integration/mcp/test_mcp_server.py
@@ -238,6 +238,25 @@ def test_mcp_stdio_with_auth_warning(caplog):
         del os.environ["TEST_STDIO_TOKEN"]
 
 
+def test_run_mcp_passes_uvicorn_config_to_fastmcp_run():
+    """Test run_mcp forwards uvicorn_config for HTTP/SSE transports."""
+
+    from agency_swarm import run_mcp
+
+    with patch("agency_swarm.integrations.mcp_server.FastMCP.run") as run_mock:
+        run_mcp(
+            tools=[sample_tool],
+            app_token_env="",  # no auth middleware
+            transport="sse",
+            uvicorn_config={"timeout_graceful_shutdown": 1},
+        )
+
+    run_mock.assert_called_once()
+    _, kwargs = run_mock.call_args
+    assert kwargs["transport"] == "sse"
+    assert kwargs["uvicorn_config"] == {"timeout_graceful_shutdown": 1}
+
+
 def test_mcp_unsupported_tool_type():
     """Test unsupported tool type error."""
 


### PR DESCRIPTION
- src/agency_swarm/integrations/mcp_server.py: forward uvicorn_config to FastMCP.run
- examples/utils/sse_mcp_server.py: set timeout_graceful_shutdown to avoid noisy shutdown
- tests/integration/mcp/test_mcp_server.py: add regression test for uvicorn_config passthrough
- examples/mcp_servers.py: make MCP example runnable (no hardcoded ngrok URL, venv python)
