### PR TITLE
Fix OpenAI default_headers fallback when no baseline client exists

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -178,6 +178,10 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
             continue
 
         client = _build_openai_client_for_agent(agent, config)
+        if client is None:
+            if config.default_headers is not None:
+                _apply_default_headers_to_agent_model_settings(agent, config.default_headers)
+            continue
         _apply_client_to_agent(agent, client, config)
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config.py
@@ -107,8 +107,8 @@ def test_request_api_key_allows_client_build_without_env(monkeypatch) -> None:
     assert str(client.base_url).startswith("http://example.invalid")
 
 
-def test_default_headers_only_without_baseline_client_does_not_raise(monkeypatch) -> None:
-    """Headers-only config should not fail when there is no existing OpenAI client to copy."""
+def test_default_headers_only_without_baseline_client_falls_back_to_model_settings(monkeypatch) -> None:
+    """When there is no baseline client, default_headers must still reach model_settings.extra_headers."""
     pytest.importorskip("agents")
 
     from agency_swarm.integrations.fastapi_utils import endpoint_handlers
@@ -131,7 +131,10 @@ def test_default_headers_only_without_baseline_client_does_not_raise(monkeypatch
 
     apply_openai_client_config(agency, ClientConfig(default_headers={"x-request-id": "req-1"}))
 
+    # Model stays a string — no client was built — but headers must reach model_settings.
     assert agency.agents["A"].model == "gpt-4o-mini"
+    assert agency.agents["A"].model_settings is not None
+    assert agency.agents["A"].model_settings.extra_headers == {"x-request-id": "req-1"}
 
 
 def test_default_headers_only_does_not_override_litellm_model_settings() -> None:


### PR DESCRIPTION
## Summary
- apply `default_headers` to `model_settings.extra_headers` when an OpenAI agent has no baseline/default client to copy
- keep existing behavior for client replacement when `api_key` / `base_url` are available
- preserve LiteLLM path behavior

## Why
This closes the unresolved behavior from https://github.com/VRSEN/agency-swarm/pull/518#discussion_r2879395241 where headers-only request config could be silently dropped for common OpenAI string-model agents.

## Validation
- updated unit test: `test_default_headers_only_without_baseline_client_falls_back_to_model_settings`
- local run: `uv run pytest tests/test_fastapi_utils_modules/test_openai_client_config.py -q` (31 passed, 3 skipped)
