### PR TITLE
fix: prevent concurrent download file collisions and temp file leaks

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/file_handler.py
+++ b/src/agency_swarm/integrations/fastapi_utils/file_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shutil
 import sys
 import tempfile
 from collections.abc import Sequence
@@ -198,7 +199,9 @@ async def download_file(url: str, name: str, save_dir: str) -> str:
     ext = get_extension_from_name(name) or get_extension_from_url(url)
     base = os.path.splitext(name)[0]
 
-    tmp_fd, tmp_str = tempfile.mkstemp(dir=save_dir, prefix=f"{base}_", suffix=".tmp")
+    # Truncate prefix to avoid exceeding the 255-byte filename limit on most
+    # filesystems (mkstemp appends a random suffix + ".tmp" on top of the prefix).
+    tmp_fd, tmp_str = tempfile.mkstemp(dir=save_dir, prefix=f"{base[:50]}_", suffix=".tmp")
     os.close(tmp_fd)
     tmp_path = Path(tmp_str)
 
@@ -225,8 +228,10 @@ async def download_file(url: str, name: str, save_dir: str) -> str:
         tmp_path.unlink(missing_ok=True)
         raise ValueError(f"No extension detected for {url}")
 
-    final_path = Path(save_dir) / f"{base}{ext}"
-    tmp_path.replace(final_path)
+    # Derive the final path from the unique tmp path so concurrent downloads
+    # with the same base+ext never overwrite each other's output.
+    final_path = tmp_path.with_suffix(ext)
+    shutil.move(str(tmp_path), str(final_path))
     return str(final_path)
 
 

--- a/tests/test_fastapi_utils_modules/test_file_handler.py
+++ b/tests/test_fastapi_utils_modules/test_file_handler.py
@@ -433,9 +433,109 @@ async def test_download_file_concurrent_same_base_name(tmp_path: Path) -> None:
         fh.httpx.AsyncClient = original_client
 
     # Both coroutines must complete without OSError/WinError 32 (file in use).
-    # result1 and result2 both resolve to DASDA.pdf — the last writer wins,
-    # which is acceptable. The key guarantee is no crash during concurrent rename.
+    # With unique final paths derived from mkstemp, each download gets its own
+    # output file — no content is lost.
+    assert result1 != result2, "Each download must produce a unique output path"
     assert Path(result1).exists(), "First download result must exist"
     assert Path(result2).exists(), "Second download result must exist"
-    assert Path(result1).read_bytes() in (fake_content_1, fake_content_2)
-    assert Path(result2).read_bytes() in (fake_content_1, fake_content_2)
+    contents_found = {Path(result1).read_bytes(), Path(result2).read_bytes()}
+    assert contents_found == {fake_content_1, fake_content_2}, "Each download's content must be preserved"
+
+
+@pytest.mark.asyncio
+async def test_download_file_uses_shutil_move_for_cross_device_rename(tmp_path: Path) -> None:
+    """download_file must use shutil.move instead of Path.replace so it survives
+    cross-device rename errors on deployed Linux containers (Docker overlay2 / tmpfs).
+
+    os.rename / Path.replace can fail with OSError on certain container filesystem
+    configurations. shutil.move falls back to copy+delete, which always works.
+    """
+    import agency_swarm.integrations.fastapi_utils.file_handler as fh
+
+    fake_content = b"%PDF-1.4 fake content"
+    pdf_name = "DASDA.pdf"
+
+    async def mock_aiter_bytes():
+        yield fake_content
+
+    response_obj = MagicMock()
+    response_obj.raise_for_status = MagicMock()
+    response_obj.aiter_bytes = MagicMock(return_value=mock_aiter_bytes())
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response_obj)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    client_obj = MagicMock()
+    client_obj.stream = MagicMock(return_value=stream_cm)
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=client_obj)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    original_client = fh.httpx.AsyncClient
+    original_move = fh.shutil.move
+    move_was_called = []
+
+    def tracking_move(src: str, dst: str):
+        move_was_called.append((src, dst))
+        return original_move(src, dst)
+
+    fh.httpx.AsyncClient = MagicMock(return_value=client_cm)
+    fh.shutil.move = tracking_move
+    try:
+        result = await fh.download_file("https://example.com/DASDA.pdf", pdf_name, str(tmp_path))
+    finally:
+        fh.httpx.AsyncClient = original_client
+        fh.shutil.move = original_move
+
+    assert Path(result).suffix == ".pdf"
+    assert Path(result).parent == tmp_path
+    assert Path(result).exists()
+    assert Path(result).read_bytes() == fake_content
+    assert len(move_was_called) == 1
+    src, dst = move_was_called[0]
+    assert src.endswith(".tmp")
+    assert dst.endswith(".pdf")
+    assert not list(tmp_path.glob("*.tmp")), ".tmp file should be removed after move"
+
+
+@pytest.mark.asyncio
+async def test_download_file_long_filename_does_not_crash(tmp_path: Path) -> None:
+    """A filename with a ~250-char base must not crash mkstemp with a filesystem limit error.
+
+    mkstemp appends a random suffix on top of the prefix, so passing the full
+    base unsanitised can exceed the 255-byte filename limit. The prefix must be
+    truncated before being handed to mkstemp.
+    """
+    import agency_swarm.integrations.fastapi_utils.file_handler as fh
+
+    long_name = "A" * 250 + ".pdf"
+    fake_content = b"%PDF-1.4 long name"
+
+    async def mock_aiter_bytes():
+        yield fake_content
+
+    response_obj = MagicMock()
+    response_obj.raise_for_status = MagicMock()
+    response_obj.aiter_bytes = MagicMock(return_value=mock_aiter_bytes())
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response_obj)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    client_obj = MagicMock()
+    client_obj.stream = MagicMock(return_value=stream_cm)
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=client_obj)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+
+    original_client = fh.httpx.AsyncClient
+    fh.httpx.AsyncClient = MagicMock(return_value=client_cm)
+    try:
+        result = await fh.download_file("https://example.com/long.pdf", long_name, str(tmp_path))
+    finally:
+        fh.httpx.AsyncClient = original_client
+
+    assert Path(result).exists()
+    assert Path(result).suffix == ".pdf"
+    assert len(Path(result).name) <= 255


### PR DESCRIPTION
## Summary

- Use `tempfile.mkstemp` instead of a deterministic `.tmp` path so concurrent downloads with the same base name (e.g. `DASDA` and `DASDA.pdf`) never collide on the temp file
- Derive the final output path from the unique temp path, preventing silent overwrites on the final rename
- Truncate the mkstemp prefix to 50 chars to avoid `OSError: File name too long` on names near the 255-byte filesystem limit
- Use `shutil.move` instead of `Path.replace` to handle cross-device renames in container environments (Docker overlay2 / tmpfs)
- Clean up temp files on HTTP errors and undetected extensions (no leaked fds or orphan `.tmp` files)

## Test plan

- [x] `test_download_file_cleans_up_tmp_on_http_error` — verifies temp cleanup and no fd leak on HTTP failure
- [x] `test_download_file_concurrent_same_base_name` — two concurrent downloads with same base produce unique files with correct content
- [x] `test_download_file_uses_shutil_move_for_cross_device_rename` — confirms shutil.move is used for the final rename
- [x] `test_download_file_long_filename_does_not_crash` — 250-char filename does not exceed filesystem limits