### PR TITLE
Preserve configured allowlist strings in FastAPI metadata

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -10,8 +10,8 @@ from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
-    """Return all configured allowlist entries as resolved absolute paths."""
-    return [str(Path(entry).expanduser().resolve()) for entry in allowed_local_dirs]
+    """Return configured allowlist entries without resolving them."""
+    return [str(entry) for entry in allowed_local_dirs]
 
 
 @dataclass(frozen=True)

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -38,7 +38,7 @@ def test_request_override_policy_flags() -> None:
     assert empty.has_openai_overrides is False
 
 
-def test_get_allowed_dirs_for_metadata_returns_absolute_paths(tmp_path) -> None:
+def test_get_allowed_dirs_for_metadata_returns_all_entries(tmp_path) -> None:
     allowed = tmp_path / "uploads"
     allowed.mkdir(parents=True, exist_ok=True)
     file_entry = tmp_path / "not-a-dir.txt"
@@ -56,12 +56,11 @@ def test_get_allowed_dirs_for_metadata_returns_absolute_paths(tmp_path) -> None:
     )
 
     assert visible == [
-        str(allowed.expanduser().resolve()),
-        str(file_entry.expanduser().resolve()),
-        str(missing_entry.expanduser().resolve()),
-        str(tilde_entry.expanduser().resolve()),
+        str(allowed),
+        str(file_entry),
+        str(missing_entry),
+        str(tilde_entry),
     ]
-    assert all(Path(p).is_absolute() for p in visible)
 
 
 def test_build_file_upload_client_uses_selected_agent_client() -> None:


### PR DESCRIPTION
## Summary
- Keep allowed_local_file_dirs values unchanged in metadata responses.
- Fixed /get_metadata regression where values like ~/uploads were expanded before returning.
- Runtime file access behavior is unchanged; only metadata formatting is preserved as configured.
