### PR TITLE
Updated metadata endpoint to output absolute paths

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -10,8 +10,8 @@ from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
-    """Return configured allowlist entries without resolving them."""
-    return [str(entry) for entry in allowed_local_dirs]
+    """Return all configured allowlist entries as resolved absolute paths."""
+    return [str(Path(entry).expanduser().resolve()) for entry in allowed_local_dirs]
 
 
 @dataclass(frozen=True)

--- a/tests/integration/fastapi/test_fastapi_metadata.py
+++ b/tests/integration/fastapi/test_fastapi_metadata.py
@@ -288,18 +288,18 @@ def test_metadata_includes_non_directory_allowed_dirs(tmp_path, agency_factory):
     assert payload["allowed_local_file_dirs"] == [str(file_entry)]
 
 
-def test_metadata_preserves_configured_allowlist_strings(tmp_path, monkeypatch, agency_factory):
-    """Metadata should return configured allowlist strings without resolving home paths."""
-    fake_home = tmp_path / "fake-home"
-    allowed_dir = fake_home / "uploads"
+def test_metadata_returns_absolute_allowlist_paths(tmp_path, monkeypatch, agency_factory):
+    """Metadata should return allowlist entries as absolute paths."""
+    from pathlib import Path
+
+    allowed_dir = tmp_path / "uploads"
     allowed_dir.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("HOME", str(fake_home))
 
     app = run_fastapi(
         agencies={"test_agency": agency_factory},
         return_app=True,
         app_token_env="",
-        allowed_local_file_dirs=["~/uploads"],
+        allowed_local_file_dirs=[str(allowed_dir)],
     )
     client = TestClient(app)
 
@@ -307,7 +307,9 @@ def test_metadata_preserves_configured_allowlist_strings(tmp_path, monkeypatch, 
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["allowed_local_file_dirs"] == ["~/uploads"]
+    expected = str(Path(allowed_dir).expanduser().resolve())
+    assert payload["allowed_local_file_dirs"] == [expected]
+    assert Path(payload["allowed_local_file_dirs"][0]).is_absolute()
 
 
 def test_tool_endpoint_handles_nested_schema():

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -38,7 +38,7 @@ def test_request_override_policy_flags() -> None:
     assert empty.has_openai_overrides is False
 
 
-def test_get_allowed_dirs_for_metadata_returns_all_entries(tmp_path) -> None:
+def test_get_allowed_dirs_for_metadata_returns_absolute_paths(tmp_path) -> None:
     allowed = tmp_path / "uploads"
     allowed.mkdir(parents=True, exist_ok=True)
     file_entry = tmp_path / "not-a-dir.txt"
@@ -56,11 +56,12 @@ def test_get_allowed_dirs_for_metadata_returns_all_entries(tmp_path) -> None:
     )
 
     assert visible == [
-        str(allowed),
-        str(file_entry),
-        str(missing_entry),
-        str(tilde_entry),
+        str(allowed.expanduser().resolve()),
+        str(file_entry.expanduser().resolve()),
+        str(missing_entry.expanduser().resolve()),
+        str(tilde_entry.expanduser().resolve()),
     ]
+    assert all(Path(p).is_absolute() for p in visible)
 
 
 def test_build_file_upload_client_uses_selected_agent_client() -> None:


### PR DESCRIPTION
Changed the paths returned in metadata from relative to absolute to simplify client-side file uploads. Clients can now use the returned paths directly in file_urls without having to resolve them manually.