### PR TITLE
refactor: make streaming_context a public field

### DIFF
--- a/src/agency_swarm/agency/responses.py
+++ b/src/agency_swarm/agency/responses.py
@@ -216,7 +216,7 @@ def get_response_stream(
         try:
             async with agency.event_stream_merger.create_streaming_context() as streaming_context:
                 enhanced_context = context_override.copy() if context_override else {}
-                enhanced_context["_streaming_context"] = streaming_context
+                enhanced_context["streaming_context"] = streaming_context
 
                 agency_context = agency_context_override or get_agent_context(agency, target_agent.name)
 

--- a/src/agency_swarm/agent/execution.py
+++ b/src/agency_swarm/agent/execution.py
@@ -168,7 +168,7 @@ class Execution:
                 self.agent.quick_replies,
             )
             has_user_context_override = bool(
-                context_override and any(key != "_streaming_context" for key in context_override)
+                context_override and any(key != "streaming_context" for key in context_override)
             )
             if (
                 sender_name is None
@@ -505,7 +505,7 @@ class Execution:
                     self.agent.quick_replies,
                 )
                 has_user_context_override = bool(
-                    context_override and any(key != "_streaming_context" for key in context_override)
+                    context_override and any(key != "streaming_context" for key in context_override)
                 )
                 if (
                     sender_name is None

--- a/src/agency_swarm/agent/execution_streaming.py
+++ b/src/agency_swarm/agent/execution_streaming.py
@@ -186,7 +186,7 @@ def run_stream_with_guardrails(
             from agency_swarm.streaming import StreamingContext
 
             streaming_context = StreamingContext()
-            master_context_for_run._streaming_context = streaming_context
+            master_context_for_run.streaming_context = streaming_context
 
             event_queue: asyncio.Queue[StreamEvent | dict[str, Any]] = asyncio.Queue(maxsize=10)
             guardrail_exception: BaseException | None = None

--- a/src/agency_swarm/context.py
+++ b/src/agency_swarm/context.py
@@ -38,7 +38,7 @@ class MasterContext:
     _current_agent_run_id: str | None = None  # Current agent run ID for tracking
     _parent_run_id: str | None = None  # Parent run ID for nested agent calls
     _is_streaming: bool = False  # Flag to indicate if we're in streaming mode
-    _streaming_context: "StreamingContext | None" = None  # Streaming context for passing state
+    streaming_context: "StreamingContext | None" = None  # Streaming context for passing state
     # Internal: tuples of (model_name, response) from sub-agents for per-model cost calculation
     _sub_agent_raw_responses: list[tuple[str | None, "ModelResponse"]] = field(default_factory=list)
 

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -338,7 +338,7 @@ class SendMessage(FunctionTool):
                     f"Calling target agent '{recipient_name_for_call}'.get_response_stream (streaming mode)..."
                 )
 
-                streaming_context = wrapper.context._streaming_context if wrapper.context else None
+                streaming_context = wrapper.context.streaming_context if wrapper.context else None
 
                 # Use streaming and collect the final output
                 final_output_text = ""

--- a/tests/integration/fastapi/test_fastapi_user_context.py
+++ b/tests/integration/fastapi/test_fastapi_user_context.py
@@ -206,8 +206,8 @@ def test_streaming_user_context(recording_agency_factory: RecordingAgencyFactory
 
     stream_context = recording_agency_factory.tracker.last_stream_context
     assert stream_context is not None
-    assert {k: v for k, v in stream_context.items() if k != "_streaming_context"} == {"plan": "pro"}
-    assert "_streaming_context" in stream_context
+    assert {k: v for k, v in stream_context.items() if k != "streaming_context"} == {"plan": "pro"}
+    assert "streaming_context" in stream_context
 
     messages_payload = _extract_last_messages_payload(lines)
     usage = messages_payload["usage"]
@@ -245,11 +245,11 @@ def test_agui_user_context(recording_agency_factory: RecordingAgencyFactory):
 
     stream_context = recording_agency_factory.tracker.last_stream_context
     assert stream_context is not None
-    assert {k: v for k, v in stream_context.items() if k != "_streaming_context"} == {
+    assert {k: v for k, v in stream_context.items() if k != "streaming_context"} == {
         "plan": "pro",
         "customer_tier": "gold",
     }
-    assert "_streaming_context" in stream_context
+    assert "streaming_context" in stream_context
 
 
 def test_user_context_defaults_to_none(recording_agency_factory: RecordingAgencyFactory):

--- a/tests/test_agency_modules/test_agency_responses.py
+++ b/tests/test_agency_modules/test_agency_responses.py
@@ -254,10 +254,10 @@ async def test_agency_get_response_stream_does_not_mutate_context_override(mock_
     # Streaming still works while the user's dict stays clean
     assert stream.final_result is not None
     assert context_override == {"test_key": "test_value"}
-    assert "_streaming_context" not in context_override
+    assert "streaming_context" not in context_override
     assert capturing_agent.last_context_override is not None
     assert capturing_agent.last_context_override is not context_override
-    assert "_streaming_context" in capturing_agent.last_context_override
+    assert "streaming_context" in capturing_agent.last_context_override
     assert isinstance(events, list)
 
 

--- a/tests/test_agent_modules/send_message/test_extra_params.py
+++ b/tests/test_agent_modules/send_message/test_extra_params.py
@@ -58,7 +58,7 @@ def _wrapper_with_recipient(recipient: StubAgent) -> Any:
             agent_runtime_state: dict[str, Any] = {}
             _current_agent_run_id = None
             _is_streaming = False
-            _streaming_context = None
+            streaming_context = None
 
         context = Context()
 

--- a/tests/test_tools_modules/test_tool_system.py
+++ b/tests/test_tools_modules/test_tool_system.py
@@ -106,7 +106,7 @@ def mock_context(mock_sender_agent, mock_recipient_agent):
     context.shared_instructions = None
     context._current_agent_run_id = None
     context._is_streaming = True
-    context._streaming_context = None
+    context.streaming_context = None
     context._sub_agent_raw_responses = []
     return context
 


### PR DESCRIPTION
## Summary
- Renames `_streaming_context` → `streaming_context` on `MasterContext` so the tool streaming API doesn't expose private fields
- Updates all source files (`context.py`, `execution.py`, `execution_streaming.py`, `responses.py`, `send_message.py`) and test fixtures to match
- Prerequisite for the tool streaming documentation PR (#556)
