### PR TITLE
Persist FastAPI file_urls provenance in history

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -453,6 +453,8 @@ The response includes `file_ids_map` with the uploaded file IDs:
 }
 ```
 
+When `file_urls` is used, Agency Swarm also prepends a `system` message for that turn that records the original source string for each attached file. That system message is included in `new_messages`, so if your client persists `new_messages` as chat history, later turns will keep the original attachment source URL or local path in model context.
+
 **Supported filetypes:** `.pdf`, `.jpeg`, `.jpg`, `.gif`, `.png`, `.c`, `.cs`, `.cpp`, `.csv`, `.html`, `.java`, `.json`, `.php`, `.py`, `.rb`, `.css`, `.js`, `.sh`, `.ts`, `.pkl`, `.tar`, `.xlsx`, `.xml`, `.zip`, `.doc`, `.docx`, `.md`, `.pptx`, `.tex`, `.txt`
 
 <Accordion title="Local file paths" defaultOpen={false}>

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -518,7 +518,7 @@ def _build_agui_snapshot_messages(
 ) -> list[dict[str, Any]]:
     """Seed AG-UI snapshots with the synthetic file_urls context when present."""
     snapshot_messages = [message.model_dump() for message in request_messages]
-    if not snapshot_messages or not isinstance(message_input, list) or not message_input:
+    if not isinstance(message_input, list) or not message_input:
         return snapshot_messages
 
     file_urls_message = message_input[0]

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -461,7 +461,6 @@ def _build_message_with_file_urls_context(
     if not file_urls:
         return message
 
-    user_content = message if isinstance(message, str) else copy.deepcopy(message)
     system_message = cast(
         TResponseInputItem,
         {
@@ -469,11 +468,14 @@ def _build_message_with_file_urls_context(
             "content": _format_file_urls_context(file_urls),
         },
     )
+    if isinstance(message, list):
+        return [system_message, *copy.deepcopy(message)]
+
     user_message = cast(
         TResponseInputItem,
         {
             "role": "user",
-            "content": user_content,
+            "content": message,
         },
     )
     return [

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -453,6 +453,13 @@ def _format_file_urls_context(file_urls: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
+def _is_file_urls_context_message(message: TResponseInputItem) -> bool:
+    """Return True when a message is the synthetic persisted file_urls context item."""
+    return message.get("role") == "system" and str(message.get("content", "")).startswith(
+        "The user has provided file attachments in their message."
+    )
+
+
 def _build_message_with_file_urls_context(
     message: str | list[TResponseInputItem],
     file_urls: dict[str, str] | None,
@@ -482,6 +489,36 @@ def _build_message_with_file_urls_context(
         system_message,
         user_message,
     ]
+
+
+def _build_chat_name_messages(messages: list[TResponseInputItem]) -> list[TResponseInputItem]:
+    """Drop synthetic file_urls metadata before generating a chat title."""
+    return [message for message in messages if not _is_file_urls_context_message(message)]
+
+
+def _build_agui_snapshot_messages(
+    request_messages: list[Any],
+    message_input: str | list[TResponseInputItem],
+) -> list[dict[str, Any]]:
+    """Seed AG-UI snapshots with the synthetic file_urls context when present."""
+    snapshot_messages = [message.model_dump() for message in request_messages]
+    if not snapshot_messages or not isinstance(message_input, list) or not message_input:
+        return snapshot_messages
+
+    file_urls_message = message_input[0]
+    if not _is_file_urls_context_message(file_urls_message):
+        return snapshot_messages
+
+    file_urls_message_dict = cast(dict[str, Any], file_urls_message)
+    agui_file_urls_message = {
+        "id": f"system_file_urls_{uuid.uuid4().hex}",
+        "role": "system",
+        "content": str(file_urls_message_dict["content"]),
+    }
+    if not snapshot_messages:
+        return [agui_file_urls_message]
+
+    return [*snapshot_messages[:-1], agui_file_urls_message, snapshot_messages[-1]]
 
 
 # Non‑streaming response endpoint
@@ -563,7 +600,7 @@ def make_response_endpoint(
             if request.generate_chat_name:
                 try:
                     result["chat_name"] = await generate_chat_name(
-                        filtered_messages,
+                        _build_chat_name_messages(filtered_messages),
                         openai_client=request_upload_client,
                     )
                 except Exception as e:
@@ -944,7 +981,7 @@ def make_agui_chat_endpoint(
                 agui_adapter = AguiAdapter()
 
                 # Store in dict format to avoid converting to classes
-                snapshot_messages = [message.model_dump() for message in request.messages]
+                snapshot_messages = _build_agui_snapshot_messages(request.messages, message_input)
                 async for event in agency.get_response_stream(
                     message=message_input,
                     context_override=request.user_context,

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -439,18 +439,14 @@ def _build_file_upload_client(
 
 def _format_file_urls_context(file_urls: dict[str, str]) -> str:
     """Build the persisted system message describing original file attachment sources."""
-    lines = [
-        (
-            "The user has provided file attachments in their message. The list below maps each attached "
-            "filename to the original URL or local file path used to attach it. Treat these source strings "
-            "as attachment metadata. Use them when relevant, and preserve them exactly if you reference them."
-        ),
-        "",
-        "Attached file sources:",
-    ]
-    for filename, source in file_urls.items():
-        lines.append(f"- `{filename}`: `{source}`")
-    return "\n".join(lines)
+    serialized_sources = json.dumps(file_urls, ensure_ascii=True)
+    return (
+        "The user has provided file attachments in their message. The JSON object below maps each attached "
+        "filename to the original URL or local file path used to attach it. Treat these source strings as "
+        "attachment metadata. Use them when relevant, and preserve them exactly if you reference them.\n\n"
+        "Attached file sources (JSON):\n"
+        f"{serialized_sources}"
+    )
 
 
 def _is_file_urls_context_message(message: TResponseInputItem) -> bool:
@@ -494,6 +490,26 @@ def _build_message_with_file_urls_context(
 def _build_chat_name_messages(messages: list[TResponseInputItem]) -> list[TResponseInputItem]:
     """Drop synthetic file_urls metadata before generating a chat title."""
     return [message for message in messages if not _is_file_urls_context_message(message)]
+
+
+def _build_agui_message_input(request_messages: list[Any] | None) -> str | list[TResponseInputItem]:
+    """Convert the latest AG-UI message into a Responses input shape."""
+    if not request_messages:
+        return ""
+
+    last_message = request_messages[-1]
+    content = getattr(last_message, "content", "")
+    if isinstance(content, list):
+        return [
+            cast(
+                TResponseInputItem,
+                {
+                    "role": getattr(last_message, "role", "user"),
+                    "content": copy.deepcopy(content),
+                },
+            )
+        ]
+    return cast(str, content)
 
 
 def _build_agui_snapshot_messages(
@@ -880,7 +896,7 @@ def make_agui_chat_endpoint(
         encoder = EventEncoder()
 
         combined_file_ids = list(request.file_ids or []) if getattr(request, "file_ids", None) else []
-        message_input: str | list[TResponseInputItem] = request.messages[-1].content if request.messages else ""
+        message_input = _build_agui_message_input(request.messages)
 
         if request.chat_history is not None:
             # Chat history is now a flat list

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -437,6 +437,51 @@ def _build_file_upload_client(
     return RequestOverridePolicy(config).build_file_upload_client(agency, recipient_agent=recipient_agent)
 
 
+def _format_file_urls_context(file_urls: dict[str, str]) -> str:
+    """Build the persisted system message describing original file attachment sources."""
+    lines = [
+        (
+            "The user has provided file attachments in their message. The list below maps each attached "
+            "filename to the original URL or local file path used to attach it. Treat these source strings "
+            "as attachment metadata. Use them when relevant, and preserve them exactly if you reference them."
+        ),
+        "",
+        "Attached file sources:",
+    ]
+    for filename, source in file_urls.items():
+        lines.append(f"- `{filename}`: `{source}`")
+    return "\n".join(lines)
+
+
+def _build_message_with_file_urls_context(
+    message: str | list[TResponseInputItem],
+    file_urls: dict[str, str] | None,
+) -> str | list[TResponseInputItem]:
+    """Prepend a synthetic system message so original file_urls persist in thread history."""
+    if not file_urls:
+        return message
+
+    user_content = message if isinstance(message, str) else copy.deepcopy(message)
+    system_message = cast(
+        TResponseInputItem,
+        {
+            "role": "system",
+            "content": _format_file_urls_context(file_urls),
+        },
+    )
+    user_message = cast(
+        TResponseInputItem,
+        {
+            "role": "user",
+            "content": user_content,
+        },
+    )
+    return [
+        system_message,
+        user_message,
+    ]
+
+
 # Non‑streaming response endpoint
 def make_response_endpoint(
     request_model,
@@ -461,6 +506,7 @@ def make_response_endpoint(
 
         combined_file_ids = request.file_ids
         file_ids_map = None
+        message_input: str | list[TResponseInputItem] = request.message
 
         try:
             await override_session.acquire()
@@ -479,6 +525,7 @@ def make_response_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
+                    message_input = _build_message_with_file_urls_context(request.message, request.file_urls)
                 except Exception as e:
                     return {"error": f"Error downloading file from provided urls: {e}"}
 
@@ -489,7 +536,7 @@ def make_response_endpoint(
             initial_message_count = len(agency_instance.thread_manager.get_all_messages())
 
             response = await agency_instance.get_response(
-                message=request.message,
+                message=message_input,
                 recipient_agent=request.recipient_agent,
                 context_override=request.user_context,
                 additional_instructions=request.additional_instructions,
@@ -556,6 +603,7 @@ def make_stream_endpoint(
 
         combined_file_ids = request.file_ids
         file_ids_map = None
+        message_input: str | list[TResponseInputItem] = request.message
 
         async def cleanup_setup_context() -> None:
             await override_session.cleanup()
@@ -576,6 +624,7 @@ def make_stream_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
+                    message_input = _build_message_with_file_urls_context(request.message, request.file_urls)
                 except Exception as e:
                     error_msg = str(e)
                     await cleanup_setup_context()
@@ -623,7 +672,7 @@ def make_stream_endpoint(
             active_run: ActiveRun | None = None
             try:
                 stream = agency_instance.get_response_stream(
-                    message=request.message,
+                    message=message_input,
                     recipient_agent=request.recipient_agent,
                     context_override=request.user_context,
                     additional_instructions=request.additional_instructions,
@@ -792,6 +841,7 @@ def make_agui_chat_endpoint(
         encoder = EventEncoder()
 
         combined_file_ids = list(request.file_ids or []) if getattr(request, "file_ids", None) else []
+        message_input: str | list[TResponseInputItem] = request.messages[-1].content if request.messages else ""
 
         if request.chat_history is not None:
             # Chat history is now a flat list
@@ -842,6 +892,7 @@ def make_agui_chat_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = combined_file_ids + list(file_ids_map.values())
+                    message_input = _build_message_with_file_urls_context(message_input, request.file_urls)
                 except Exception as exc:
                     error_message = f"Error downloading file from provided urls: {exc}"
                     await cleanup_setup_context()
@@ -893,7 +944,7 @@ def make_agui_chat_endpoint(
                 # Store in dict format to avoid converting to classes
                 snapshot_messages = [message.model_dump() for message in request.messages]
                 async for event in agency.get_response_stream(
-                    message=request.messages[-1].content,
+                    message=message_input,
                     context_override=request.user_context,
                     additional_instructions=request.additional_instructions,
                     file_ids=combined_file_ids or None,

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -437,13 +437,27 @@ def _build_file_upload_client(
     return RequestOverridePolicy(config).build_file_upload_client(agency, recipient_agent=recipient_agent)
 
 
-def _format_file_urls_context(file_urls: dict[str, str]) -> str:
+def _format_file_urls_context(
+    file_urls: dict[str, str],
+    file_ids_map: dict[str, str] | None = None,
+) -> str:
     """Build the persisted system message describing original file attachment sources."""
-    serialized_sources = json.dumps(file_urls, ensure_ascii=True)
+    sources = {
+        name: {
+            "url": source,
+            **({"oai_file_id": file_ids_map[name]} if file_ids_map and name in file_ids_map else {}),
+        }
+        for name, source in file_urls.items()
+    }
+    serialized_sources = json.dumps(sources, ensure_ascii=True)
     return (
         "The user has provided file attachments in their message. The JSON object below maps each attached "
-        "filename to the original URL or local file path used to attach it. Treat these source strings as "
-        "attachment metadata. Use them when relevant, and preserve them exactly if you reference them.\n\n"
+        "filename to attachment metadata: the original URL or local file path used to upload it, and the "
+        "OpenAI file_id when available. Treat this metadata as authoritative and preserve it exactly if you "
+        "reference it.\n\n"
+        "IMPORTANT: The `url` field is upload provenance only. It is not necessarily the runtime location that "
+        "tools use to access the file. If a file is exposed through OpenAI's code interpreter, it may appear "
+        "under a separate sandbox path such as `/mnt/data/<file_id>-<filename>` instead.\n\n"
         "Attached file sources (JSON):\n"
         f"{serialized_sources}"
     )
@@ -459,6 +473,7 @@ def _is_file_urls_context_message(message: TResponseInputItem) -> bool:
 def _build_message_with_file_urls_context(
     message: str | list[TResponseInputItem],
     file_urls: dict[str, str] | None,
+    file_ids_map: dict[str, str] | None = None,
 ) -> str | list[TResponseInputItem]:
     """Prepend a synthetic system message so original file_urls persist in thread history."""
     if not file_urls:
@@ -468,7 +483,7 @@ def _build_message_with_file_urls_context(
         TResponseInputItem,
         {
             "role": "system",
-            "content": _format_file_urls_context(file_urls),
+            "content": _format_file_urls_context(file_urls, file_ids_map),
         },
     )
     if isinstance(message, list):
@@ -580,7 +595,11 @@ def make_response_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
-                    message_input = _build_message_with_file_urls_context(request.message, request.file_urls)
+                    message_input = _build_message_with_file_urls_context(
+                        request.message,
+                        request.file_urls,
+                        file_ids_map,
+                    )
                 except Exception as e:
                     return {"error": f"Error downloading file from provided urls: {e}"}
 
@@ -679,7 +698,11 @@ def make_stream_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = (combined_file_ids or []) + list(file_ids_map.values())
-                    message_input = _build_message_with_file_urls_context(request.message, request.file_urls)
+                    message_input = _build_message_with_file_urls_context(
+                        request.message,
+                        request.file_urls,
+                        file_ids_map,
+                    )
                 except Exception as e:
                     error_msg = str(e)
                     await cleanup_setup_context()
@@ -947,7 +970,11 @@ def make_agui_chat_endpoint(
                         openai_client=request_upload_client,
                     )
                     combined_file_ids = combined_file_ids + list(file_ids_map.values())
-                    message_input = _build_message_with_file_urls_context(message_input, request.file_urls)
+                    message_input = _build_message_with_file_urls_context(
+                        message_input,
+                        request.file_urls,
+                        file_ids_map,
+                    )
                 except Exception as exc:
                     error_message = f"Error downloading file from provided urls: {exc}"
                     await cleanup_setup_context()

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -786,7 +786,7 @@ def make_stream_endpoint(
                     if request.generate_chat_name:
                         try:
                             result["chat_name"] = await generate_chat_name(
-                                filtered_messages,
+                                _build_chat_name_messages(filtered_messages),
                                 openai_client=request_upload_client,
                             )
                         except Exception as e:

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,10 +9,22 @@ from openai import AsyncOpenAI
 from agency_swarm import Agency, Agent
 from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 
+logger = logging.getLogger(__name__)
+
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
-    """Return all configured allowlist entries as resolved absolute paths."""
-    return [str(Path(entry).expanduser().resolve()) for entry in allowed_local_dirs]
+    """Return only usable local upload directories for metadata responses."""
+    normalized: list[str] = []
+    for entry in allowed_local_dirs:
+        path = Path(entry).expanduser().resolve()
+        if not path.exists():
+            logger.warning("Allowed directory not found (skipping metadata entry): %s", entry)
+            continue
+        if not path.is_dir():
+            logger.warning("Allowed path is not a directory (skipping metadata entry): %s", entry)
+            continue
+        normalized.append(str(path))
+    return normalized
 
 
 @dataclass(frozen=True)

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -7,24 +6,14 @@ from agents.models._openai_shared import get_default_openai_client
 from openai import AsyncOpenAI
 
 from agency_swarm import Agency, Agent
+from agency_swarm.integrations.fastapi_utils.file_handler import _normalize_allowed_dirs
 from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
-
-logger = logging.getLogger(__name__)
 
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
-    """Return only usable local upload directories for metadata responses."""
-    normalized: list[str] = []
-    for entry in allowed_local_dirs:
-        path = Path(entry).expanduser().resolve()
-        if not path.exists():
-            logger.warning("Allowed directory not found (skipping metadata entry): %s", entry)
-            continue
-        if not path.is_dir():
-            logger.warning("Allowed path is not a directory (skipping metadata entry): %s", entry)
-            continue
-        normalized.append(str(path))
-    return normalized
+    """Return upload-usable local directories for metadata responses."""
+    normalized = _normalize_allowed_dirs(allowed_local_dirs, skip_missing=True)
+    return [] if normalized is None else [str(path) for path in normalized]
 
 
 @dataclass(frozen=True)

--- a/tests/integration/fastapi/test_fastapi_file_processing.py
+++ b/tests/integration/fastapi/test_fastapi_file_processing.py
@@ -270,6 +270,26 @@ class TestFastAPIFileProcessing:
         response_text = response_data["response"].lower()
         assert "local secret phrase" in response_text
 
+        new_messages = response_data["new_messages"]
+        source_message = next(
+            msg
+            for msg in new_messages
+            if isinstance(msg, dict) and msg.get("role") == "system" and str(file_path) in str(msg.get("content", ""))
+        )
+        assert "The user has provided file attachments in their message." in str(source_message["content"])
+
+        follow_up_payload = {
+            "message": "What exact attachment source string was used for local-file.txt? Reply with only that string.",
+            "chat_history": new_messages,
+        }
+
+        async with self.get_http_client(timeout_seconds=120) as client:
+            follow_up_response = await client.post(url, json=follow_up_payload, headers=headers)
+
+        assert follow_up_response.status_code == 200
+        follow_up_data = follow_up_response.json()
+        assert str(file_path) in str(follow_up_data["response"])
+
     @pytest.mark.asyncio
     async def test_local_allowlist_created_after_start(self, tmp_path, agency_factory):
         """Allowlist entries should activate when created after server start."""

--- a/tests/integration/fastapi/test_fastapi_file_processing.py
+++ b/tests/integration/fastapi/test_fastapi_file_processing.py
@@ -272,12 +272,16 @@ class TestFastAPIFileProcessing:
         assert "local secret phrase" in response_text
 
         new_messages = response_data["new_messages"]
+        file_path_json_fragment = json.dumps(str(file_path))[1:-1]
         source_message = next(
             msg
             for msg in new_messages
-            if isinstance(msg, dict) and msg.get("role") == "system" and str(file_path) in str(msg.get("content", ""))
+            if isinstance(msg, dict)
+            and msg.get("role") == "system"
+            and file_path_json_fragment in str(msg.get("content", ""))
         )
         assert "The user has provided file attachments in their message." in str(source_message["content"])
+        assert "upload provenance only" in str(source_message["content"])
 
         follow_up_payload = {
             "message": "What exact attachment source string was used for local-file.txt? Reply with only that string.",

--- a/tests/integration/fastapi/test_fastapi_file_processing.py
+++ b/tests/integration/fastapi/test_fastapi_file_processing.py
@@ -8,6 +8,7 @@ containing the expected file content.
 
 import asyncio
 import json
+import re
 import socket
 import subprocess
 import sys
@@ -288,7 +289,12 @@ class TestFastAPIFileProcessing:
 
         assert follow_up_response.status_code == 200
         follow_up_data = follow_up_response.json()
-        assert str(file_path) in str(follow_up_data["response"])
+        normalized_follow_up_response = re.sub(
+            r"(?<=[/\\\\])\s+",
+            "",
+            str(follow_up_data["response"]).strip("` \n"),
+        )
+        assert str(file_path) in normalized_follow_up_response
 
     @pytest.mark.asyncio
     async def test_local_allowlist_created_after_start(self, tmp_path, agency_factory):

--- a/tests/integration/fastapi/test_fastapi_metadata.py
+++ b/tests/integration/fastapi/test_fastapi_metadata.py
@@ -285,7 +285,7 @@ def test_metadata_includes_tool_input_schema():
 
 
 def test_metadata_includes_missing_allowed_dirs(tmp_path, agency_factory):
-    """Missing allowed local file directories should still appear in metadata."""
+    """Missing allowed local file directories should be omitted from metadata."""
     missing_dir = tmp_path / "missing-uploads"
 
     app = run_fastapi(
@@ -300,11 +300,11 @@ def test_metadata_includes_missing_allowed_dirs(tmp_path, agency_factory):
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["allowed_local_file_dirs"] == [str(missing_dir)]
+    assert payload["allowed_local_file_dirs"] == []
 
 
 def test_metadata_includes_non_directory_allowed_dirs(tmp_path, agency_factory):
-    """Non-directory allowlist entries should appear in metadata as configured."""
+    """Non-directory allowlist entries should be omitted from metadata."""
     file_entry = tmp_path / "not-a-directory.txt"
     file_entry.write_text("x", encoding="utf-8")
 
@@ -320,21 +320,21 @@ def test_metadata_includes_non_directory_allowed_dirs(tmp_path, agency_factory):
     assert response.status_code == 200
     payload = response.json()
 
-    assert payload["allowed_local_file_dirs"] == [str(file_entry)]
+    assert payload["allowed_local_file_dirs"] == []
 
 
-def test_metadata_returns_absolute_allowlist_paths(tmp_path, monkeypatch, agency_factory):
-    """Metadata should return allowlist entries as absolute paths."""
-    from pathlib import Path
-
-    allowed_dir = tmp_path / "uploads"
+def test_metadata_preserves_configured_allowlist_strings(tmp_path, monkeypatch, agency_factory):
+    """Metadata should return only usable allowlist directories as resolved paths."""
+    fake_home = tmp_path / "fake-home"
+    allowed_dir = fake_home / "uploads"
     allowed_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
 
     app = run_fastapi(
         agencies={"test_agency": agency_factory},
         return_app=True,
         app_token_env="",
-        allowed_local_file_dirs=[str(allowed_dir)],
+        allowed_local_file_dirs=["~/uploads"],
     )
     client = TestClient(app)
 
@@ -342,9 +342,7 @@ def test_metadata_returns_absolute_allowlist_paths(tmp_path, monkeypatch, agency
     assert response.status_code == 200
     payload = response.json()
 
-    expected = str(Path(allowed_dir).expanduser().resolve())
-    assert payload["allowed_local_file_dirs"] == [expected]
-    assert Path(payload["allowed_local_file_dirs"][0]).is_absolute()
+    assert payload["allowed_local_file_dirs"] == [str(allowed_dir.resolve())]
 
 
 def test_tool_endpoint_handles_nested_schema():

--- a/tests/integration/fastapi/test_fastapi_metadata.py
+++ b/tests/integration/fastapi/test_fastapi_metadata.py
@@ -304,7 +304,7 @@ def test_metadata_includes_missing_allowed_dirs(tmp_path, agency_factory):
 
 
 def test_metadata_includes_non_directory_allowed_dirs(tmp_path, agency_factory):
-    """Non-directory allowlist entries should be omitted from metadata."""
+    """Non-directory allowlist entries should fail metadata the same way uploads do."""
     file_entry = tmp_path / "not-a-directory.txt"
     file_entry.write_text("x", encoding="utf-8")
 
@@ -314,13 +314,31 @@ def test_metadata_includes_non_directory_allowed_dirs(tmp_path, agency_factory):
         app_token_env="",
         allowed_local_file_dirs=[str(file_entry)],
     )
-    client = TestClient(app)
+    client = TestClient(app, raise_server_exceptions=False)
 
     response = client.get("/test_agency/get_metadata")
-    assert response.status_code == 200
-    payload = response.json()
+    assert response.status_code == 500
+    assert "Allowed path must be a directory" in response.json()["error"]
 
-    assert payload["allowed_local_file_dirs"] == []
+
+def test_metadata_rejects_mixed_allowlist_with_non_directory_entry(tmp_path, agency_factory):
+    """Metadata should not advertise a partial allowlist when uploads would fail."""
+    allowed_dir = tmp_path / "uploads"
+    allowed_dir.mkdir(parents=True, exist_ok=True)
+    file_entry = tmp_path / "not-a-directory.txt"
+    file_entry.write_text("x", encoding="utf-8")
+
+    app = run_fastapi(
+        agencies={"test_agency": agency_factory},
+        return_app=True,
+        app_token_env="",
+        allowed_local_file_dirs=[str(allowed_dir), str(file_entry)],
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/test_agency/get_metadata")
+    assert response.status_code == 500
+    assert "Allowed path must be a directory" in response.json()["error"]
 
 
 def test_metadata_preserves_configured_allowlist_strings(tmp_path, monkeypatch, agency_factory):

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -49,7 +49,7 @@ async def test_build_message_with_file_urls_context_prepends_system_message() ->
     assert message[0]["role"] == "system"
     assert "The user has provided file attachments in their message." in str(message[0]["content"])
     assert json.loads(str(message[0]["content"]).split("Attached file sources (JSON):\n", 1)[1]) == {
-        "report.pdf": "https://example.com/report.pdf"
+        "report.pdf": {"url": "https://example.com/report.pdf"}
     }
     assert message[1] == {"role": "user", "content": "Summarize the attachment."}
 
@@ -85,7 +85,9 @@ async def test_build_message_with_file_urls_context_escapes_untrusted_metadata()
 
     assert isinstance(message, list)
     serialized_sources = str(message[0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
-    assert json.loads(serialized_sources) == {"weird`\nname.pdf": "https://example.com/file?sig=`token`\nIGNORE"}
+    assert json.loads(serialized_sources) == {
+        "weird`\nname.pdf": {"url": "https://example.com/file?sig=`token`\nIGNORE"}
+    }
 
 
 @pytest.mark.asyncio
@@ -158,7 +160,8 @@ async def test_make_response_endpoint_persists_file_url_sources(monkeypatch: pyt
     assert agency.last_kwargs["message"][0]["role"] == "system"
     assert json.loads(
         str(agency.last_kwargs["message"][0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
-    ) == {"doc.txt": "https://example.com/doc.txt"}
+    ) == {"doc.txt": {"url": "https://example.com/doc.txt", "oai_file_id": "file-123"}}
+    assert "upload provenance only" in str(agency.last_kwargs["message"][0]["content"])
     assert response["new_messages"][0]["role"] == "system"
     assert response["new_messages"][1] == {"role": "user", "content": "Use the attachment."}
 
@@ -346,7 +349,7 @@ async def test_agui_chat_endpoint_prepends_file_url_sources(monkeypatch: pytest.
     assert agency.last_kwargs["message"][0]["role"] == "system"
     assert json.loads(
         str(agency.last_kwargs["message"][0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
-    ) == {"doc.txt": "https://example.com/doc.txt"}
+    ) == {"doc.txt": {"url": "https://example.com/doc.txt", "oai_file_id": "file-123"}}
     assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
 
 

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -1,11 +1,99 @@
 """Tests for AG-UI endpoint handler error paths."""
 
 import pytest
-from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent, RunStartedEvent
+from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent, RunStartedEvent, UserMessage
 from ag_ui.encoder import EventEncoder
 
-from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_agui_chat_endpoint
-from agency_swarm.integrations.fastapi_utils.request_models import RunAgentInputCustom
+from agency_swarm.integrations.fastapi_utils.endpoint_handlers import (
+    _build_message_with_file_urls_context,
+    make_agui_chat_endpoint,
+    make_response_endpoint,
+)
+from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, RunAgentInputCustom
+
+
+class _ThreadManagerStub:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    def get_all_messages(self) -> list[dict]:
+        return list(self.messages)
+
+
+class _ResponseStub:
+    def __init__(self, final_output: str) -> None:
+        self.final_output = final_output
+
+
+@pytest.mark.asyncio
+async def test_build_message_with_file_urls_context_prepends_system_message() -> None:
+    """file_urls should prepend one system message before the user turn."""
+
+    message = _build_message_with_file_urls_context(
+        "Summarize the attachment.",
+        {"report.pdf": "https://example.com/report.pdf"},
+    )
+
+    assert isinstance(message, list)
+    assert message[0]["role"] == "system"
+    assert "The user has provided file attachments in their message." in str(message[0]["content"])
+    assert "`report.pdf`: `https://example.com/report.pdf`" in str(message[0]["content"])
+    assert message[1] == {"role": "user", "content": "Summarize the attachment."}
+
+
+@pytest.mark.asyncio
+async def test_make_response_endpoint_persists_file_url_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-streaming requests should persist file_urls source context via a system message."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+
+    class _AgencyStub:
+        def __init__(self) -> None:
+            self.thread_manager = _ThreadManagerStub()
+            self.last_kwargs = None
+
+        async def get_response(self, **kwargs):
+            self.last_kwargs = kwargs
+            message = kwargs["message"]
+            assert isinstance(message, list)
+            self.thread_manager.messages.extend(message)
+            self.thread_manager.messages.append({"role": "assistant", "content": "ok", "type": "message"})
+            return _ResponseStub("ok")
+
+    agency = _AgencyStub()
+    handler = make_response_endpoint(BaseRequest, lambda **_: agency, verify_token=lambda: None)
+
+    response = await handler(
+        BaseRequest(
+            message="Use the attachment.",
+            file_urls={"doc.txt": "https://example.com/doc.txt"},
+        ),
+        token=None,
+    )
+
+    assert response["response"] == "ok"
+    assert response["file_ids_map"] == {"doc.txt": "file-123"}
+    assert agency.last_kwargs is not None
+    assert agency.last_kwargs["file_ids"] == ["file-123"]
+    assert isinstance(agency.last_kwargs["message"], list)
+    assert agency.last_kwargs["message"][0]["role"] == "system"
+    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert response["new_messages"][0]["role"] == "system"
+    assert response["new_messages"][1] == {"role": "user", "content": "Use the attachment."}
 
 
 @pytest.mark.asyncio
@@ -61,3 +149,74 @@ async def test_agui_file_urls_error_emits_lifecycle_events(tmp_path):
 
     assert chunks == expected_chunks
     assert response.media_type == encoder.get_content_type()
+
+
+@pytest.mark.asyncio
+async def test_agui_chat_endpoint_prepends_file_url_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AG-UI requests should prepend the persisted source-context system message."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+
+    class _StreamStub:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _AgentStub:
+        name = "A"
+
+    class _AgencyStub:
+        def __init__(self):
+            self.entry_points = [_AgentStub()]
+            self.agents = {"A": _AgentStub()}
+            self.last_kwargs = None
+
+        def get_response_stream(self, **kwargs):
+            self.last_kwargs = kwargs
+            return _StreamStub()
+
+    agency = _AgencyStub()
+    handler = make_agui_chat_endpoint(
+        RunAgentInputCustom,
+        agency_factory=lambda **_: agency,
+        verify_token=lambda: None,
+        allowed_local_dirs=None,
+    )
+
+    request = RunAgentInputCustom(
+        thread_id="thread-1",
+        run_id="run-1",
+        state=None,
+        messages=[UserMessage(id="u1", role="user", content="hello")],
+        tools=[],
+        context=[],
+        forwarded_props=None,
+        file_urls={"doc.txt": "https://example.com/doc.txt"},
+        file_ids=None,
+    )
+
+    response = await handler(request, token=None)
+    _ = [chunk async for chunk in response.body_iterator]
+
+    assert agency.last_kwargs is not None
+    assert agency.last_kwargs["file_ids"] == ["file-123"]
+    assert isinstance(agency.last_kwargs["message"], list)
+    assert agency.last_kwargs["message"][0]["role"] == "system"
+    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -42,6 +42,26 @@ async def test_build_message_with_file_urls_context_prepends_system_message() ->
 
 
 @pytest.mark.asyncio
+async def test_build_message_with_file_urls_context_preserves_structured_input_items() -> None:
+    """Structured input lists should stay top-level after prepending the source-context message."""
+
+    message = _build_message_with_file_urls_context(
+        [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "Earlier reply"},
+            {"role": "user", "content": "Latest message"},
+        ],
+        {"report.pdf": "https://example.com/report.pdf"},
+    )
+
+    assert isinstance(message, list)
+    assert message[0]["role"] == "system"
+    assert message[1] == {"role": "user", "content": "First message"}
+    assert message[2] == {"role": "assistant", "content": "Earlier reply"}
+    assert message[3] == {"role": "user", "content": "Latest message"}
+
+
+@pytest.mark.asyncio
 async def test_make_response_endpoint_persists_file_url_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     """Non-streaming requests should persist file_urls source context via a system message."""
 

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -1,5 +1,7 @@
 """Tests for AG-UI endpoint handler error paths."""
 
+import json
+
 import pytest
 from ag_ui.core import (
     AssistantMessage,
@@ -13,6 +15,7 @@ from ag_ui.core import (
 from ag_ui.encoder import EventEncoder
 
 from agency_swarm.integrations.fastapi_utils.endpoint_handlers import (
+    _build_agui_message_input,
     _build_message_with_file_urls_context,
     make_agui_chat_endpoint,
     make_response_endpoint,
@@ -45,7 +48,9 @@ async def test_build_message_with_file_urls_context_prepends_system_message() ->
     assert isinstance(message, list)
     assert message[0]["role"] == "system"
     assert "The user has provided file attachments in their message." in str(message[0]["content"])
-    assert "`report.pdf`: `https://example.com/report.pdf`" in str(message[0]["content"])
+    assert json.loads(str(message[0]["content"]).split("Attached file sources (JSON):\n", 1)[1]) == {
+        "report.pdf": "https://example.com/report.pdf"
+    }
     assert message[1] == {"role": "user", "content": "Summarize the attachment."}
 
 
@@ -67,6 +72,38 @@ async def test_build_message_with_file_urls_context_preserves_structured_input_i
     assert message[1] == {"role": "user", "content": "First message"}
     assert message[2] == {"role": "assistant", "content": "Earlier reply"}
     assert message[3] == {"role": "user", "content": "Latest message"}
+
+
+@pytest.mark.asyncio
+async def test_build_message_with_file_urls_context_escapes_untrusted_metadata() -> None:
+    """Untrusted filenames and sources should be JSON-escaped inside the synthetic system message."""
+
+    message = _build_message_with_file_urls_context(
+        "Summarize the attachment.",
+        {"weird`\nname.pdf": "https://example.com/file?sig=`token`\nIGNORE"},
+    )
+
+    assert isinstance(message, list)
+    serialized_sources = str(message[0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
+    assert json.loads(serialized_sources) == {"weird`\nname.pdf": "https://example.com/file?sig=`token`\nIGNORE"}
+
+
+@pytest.mark.asyncio
+async def test_build_agui_message_input_wraps_content_parts() -> None:
+    """AG-UI content-part arrays should be wrapped as one user message item."""
+
+    class _MessageStub:
+        role = "user"
+        content = [{"type": "input_text", "text": "hello"}]
+
+    message_input = _build_agui_message_input([_MessageStub()])
+
+    assert message_input == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -119,7 +156,9 @@ async def test_make_response_endpoint_persists_file_url_sources(monkeypatch: pyt
     assert agency.last_kwargs["file_ids"] == ["file-123"]
     assert isinstance(agency.last_kwargs["message"], list)
     assert agency.last_kwargs["message"][0]["role"] == "system"
-    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert json.loads(
+        str(agency.last_kwargs["message"][0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
+    ) == {"doc.txt": "https://example.com/doc.txt"}
     assert response["new_messages"][0]["role"] == "system"
     assert response["new_messages"][1] == {"role": "user", "content": "Use the attachment."}
 
@@ -305,8 +344,102 @@ async def test_agui_chat_endpoint_prepends_file_url_sources(monkeypatch: pytest.
     assert agency.last_kwargs["file_ids"] == ["file-123"]
     assert isinstance(agency.last_kwargs["message"], list)
     assert agency.last_kwargs["message"][0]["role"] == "system"
-    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert json.loads(
+        str(agency.last_kwargs["message"][0]["content"]).split("Attached file sources (JSON):\n", 1)[1]
+    ) == {"doc.txt": "https://example.com/doc.txt"}
     assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_agui_chat_endpoint_wraps_content_arrays_before_prepending_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AG-UI content-part arrays should be wrapped as one user message before source metadata is prepended."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.AguiAdapter.agui_messages_to_chat_history",
+        lambda _messages: [],
+    )
+
+    class _ContentArrayMessage:
+        role = "user"
+        content = [{"type": "input_text", "text": "hello"}]
+
+        def model_dump(self):
+            return {"id": "u1", "role": "user", "content": self.content}
+
+    class _StreamStub:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _AgentStub:
+        name = "A"
+
+    class _AgencyStub:
+        def __init__(self):
+            self.entry_points = [_AgentStub()]
+            self.agents = {"A": _AgentStub()}
+            self.last_kwargs = None
+
+        def get_response_stream(self, **kwargs):
+            self.last_kwargs = kwargs
+            return _StreamStub()
+
+    agency = _AgencyStub()
+    handler = make_agui_chat_endpoint(
+        RunAgentInputCustom,
+        agency_factory=lambda **_: agency,
+        verify_token=lambda: None,
+        allowed_local_dirs=None,
+    )
+
+    class _RequestStub:
+        thread_id = "thread-1"
+        run_id = "run-1"
+        state = None
+        messages = [_ContentArrayMessage()]
+        tools = []
+        context = []
+        forwarded_props = None
+        file_urls = {"doc.txt": "https://example.com/doc.txt"}
+        file_ids = None
+        client_config = None
+        chat_history = None
+        user_context = None
+        additional_instructions = None
+
+    response = await handler(_RequestStub(), token=None)
+    _ = [chunk async for chunk in response.body_iterator]
+
+    assert agency.last_kwargs is not None
+    assert agency.last_kwargs["message"] == [
+        {
+            "role": "system",
+            "content": str(agency.last_kwargs["message"][0]["content"]),
+        },
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hello"}],
+        },
+    ]
 
 
 @pytest.mark.asyncio
@@ -388,4 +521,5 @@ async def test_agui_chat_endpoint_snapshot_includes_file_url_sources(monkeypatch
     payload = "".join(chunks)
 
     assert "The user has provided file attachments in their message." in payload
-    assert "`doc.txt`: `https://example.com/doc.txt`" in payload
+    assert "doc.txt" in payload
+    assert "https://example.com/doc.txt" in payload

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -1,7 +1,15 @@
 """Tests for AG-UI endpoint handler error paths."""
 
 import pytest
-from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent, RunStartedEvent, UserMessage
+from ag_ui.core import (
+    AssistantMessage,
+    EventType,
+    MessagesSnapshotEvent,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    UserMessage,
+)
 from ag_ui.encoder import EventEncoder
 
 from agency_swarm.integrations.fastapi_utils.endpoint_handlers import (
@@ -114,6 +122,65 @@ async def test_make_response_endpoint_persists_file_url_sources(monkeypatch: pyt
     assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
     assert response["new_messages"][0]["role"] == "system"
     assert response["new_messages"][1] == {"role": "user", "content": "Use the attachment."}
+
+
+@pytest.mark.asyncio
+async def test_make_response_endpoint_excludes_file_url_context_from_chat_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chat-name generation should use the user's prompt, not the synthetic file_urls metadata."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    async def _fake_generate_chat_name(messages, openai_client=None):
+        del openai_client
+        assert messages[0] == {"role": "user", "content": "Use the attachment."}
+        assert all(
+            "The user has provided file attachments in their message." not in str(message.get("content", ""))
+            for message in messages
+            if isinstance(message, dict)
+        )
+        return "attachment title"
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.generate_chat_name",
+        _fake_generate_chat_name,
+    )
+
+    class _AgencyStub:
+        def __init__(self) -> None:
+            self.thread_manager = _ThreadManagerStub()
+
+        async def get_response(self, **kwargs):
+            self.thread_manager.messages.extend(kwargs["message"])
+            self.thread_manager.messages.append({"role": "assistant", "content": "ok", "type": "message"})
+            return _ResponseStub("ok")
+
+    handler = make_response_endpoint(BaseRequest, lambda **_: _AgencyStub(), verify_token=lambda: None)
+
+    response = await handler(
+        BaseRequest(
+            message="Use the attachment.",
+            file_urls={"doc.txt": "https://example.com/doc.txt"},
+            generate_chat_name=True,
+        ),
+        token=None,
+    )
+
+    assert response["chat_name"] == "attachment title"
 
 
 @pytest.mark.asyncio
@@ -240,3 +307,85 @@ async def test_agui_chat_endpoint_prepends_file_url_sources(monkeypatch: pytest.
     assert agency.last_kwargs["message"][0]["role"] == "system"
     assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
     assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_agui_chat_endpoint_snapshot_includes_file_url_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AG-UI snapshots should persist the synthetic file_urls context for replay on later turns."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+
+    class _AdapterStub:
+        def openai_to_agui_events(self, _event, run_id=None):
+            del run_id
+            return MessagesSnapshotEvent(
+                type=EventType.MESSAGES_SNAPSHOT,
+                messages=[AssistantMessage(id="a1", role="assistant", content="ok")],
+            )
+
+    monkeypatch.setattr("agency_swarm.integrations.fastapi_utils.endpoint_handlers.AguiAdapter", _AdapterStub)
+
+    class _StreamStub:
+        def __aiter__(self):
+            self._done = False
+            return self
+
+        async def __anext__(self):
+            if self._done:
+                raise StopAsyncIteration
+            self._done = True
+            return {"type": "dummy"}
+
+    class _AgentStub:
+        name = "A"
+
+    class _AgencyStub:
+        def __init__(self):
+            self.entry_points = [_AgentStub()]
+            self.agents = {"A": _AgentStub()}
+
+        def get_response_stream(self, **kwargs):
+            del kwargs
+            return _StreamStub()
+
+    handler = make_agui_chat_endpoint(
+        RunAgentInputCustom,
+        agency_factory=lambda **_: _AgencyStub(),
+        verify_token=lambda: None,
+        allowed_local_dirs=None,
+    )
+
+    response = await handler(
+        RunAgentInputCustom(
+            thread_id="thread-1",
+            run_id="run-1",
+            state=None,
+            messages=[UserMessage(id="u1", role="user", content="hello")],
+            tools=[],
+            context=[],
+            forwarded_props=None,
+            file_urls={"doc.txt": "https://example.com/doc.txt"},
+            file_ids=None,
+        ),
+        token=None,
+    )
+
+    chunks = [chunk async for chunk in response.body_iterator]
+    payload = "".join(chunks)
+
+    assert "The user has provided file attachments in their message." in payload
+    assert "`doc.txt`: `https://example.com/doc.txt`" in payload

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers.py
@@ -523,3 +523,88 @@ async def test_agui_chat_endpoint_snapshot_includes_file_url_sources(monkeypatch
     assert "The user has provided file attachments in their message." in payload
     assert "doc.txt" in payload
     assert "https://example.com/doc.txt" in payload
+
+
+@pytest.mark.asyncio
+async def test_agui_chat_endpoint_snapshot_includes_file_url_sources_when_messages_start_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AG-UI snapshots should persist file_urls context even when the incoming snapshot is empty."""
+
+    async def _noop_attach(_agency):
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+
+    class _AdapterStub:
+        def openai_to_agui_events(self, _event, run_id=None):
+            del run_id
+            return MessagesSnapshotEvent(
+                type=EventType.MESSAGES_SNAPSHOT,
+                messages=[AssistantMessage(id="a1", role="assistant", content="ok")],
+            )
+
+    monkeypatch.setattr("agency_swarm.integrations.fastapi_utils.endpoint_handlers.AguiAdapter", _AdapterStub)
+
+    class _StreamStub:
+        def __aiter__(self):
+            self._done = False
+            return self
+
+        async def __anext__(self):
+            if self._done:
+                raise StopAsyncIteration
+            self._done = True
+            return {"type": "dummy"}
+
+    class _AgentStub:
+        name = "A"
+
+    class _AgencyStub:
+        def __init__(self):
+            self.entry_points = [_AgentStub()]
+            self.agents = {"A": _AgentStub()}
+
+        def get_response_stream(self, **kwargs):
+            del kwargs
+            return _StreamStub()
+
+    handler = make_agui_chat_endpoint(
+        RunAgentInputCustom,
+        agency_factory=lambda **_: _AgencyStub(),
+        verify_token=lambda: None,
+        allowed_local_dirs=None,
+    )
+
+    response = await handler(
+        RunAgentInputCustom(
+            thread_id="thread-1",
+            run_id="run-1",
+            state=None,
+            messages=[],
+            tools=[],
+            context=[],
+            forwarded_props=None,
+            file_urls={"doc.txt": "https://example.com/doc.txt"},
+            file_ids=None,
+        ),
+        token=None,
+    )
+
+    chunks = [chunk async for chunk in response.body_iterator]
+    payload = "".join(chunks)
+
+    assert "The user has provided file attachments in their message." in payload
+    assert "doc.txt" in payload
+    assert "https://example.com/doc.txt" in payload

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
@@ -43,8 +43,10 @@ class _StubAgency:
         self.agents = {}
         self.entry_points = []
         self._stream = stream
+        self.last_kwargs: dict[str, Any] | None = None
 
     def get_response_stream(self, **_kwargs: Any) -> StreamingRunResponse:
+        self.last_kwargs = dict(_kwargs)
         return self._stream
 
 
@@ -80,6 +82,52 @@ def _parse_sse_stream_events(chunks: list[str]) -> list[dict[str, Any]]:
             if isinstance(data, dict) and isinstance(data.get("type"), str):
                 events.append(data)
     return events
+
+
+@pytest.mark.asyncio
+async def test_stream_endpoint_prepends_file_url_source_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Streaming FastAPI requests should prepend persisted file_urls source context."""
+
+    async def _noop_attach(_agency: Any) -> None:
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+
+    async def _stream() -> AsyncGenerator[dict[str, Any]]:
+        if False:
+            yield {}
+
+    thread_manager = _StubThreadManager()
+    agency = _StubAgency(StreamingRunResponse(_stream()), thread_manager)
+
+    def agency_factory(**_kwargs: Any) -> _StubAgency:
+        return agency
+
+    handler = make_stream_endpoint(BaseRequest, agency_factory, lambda: None, ActiveRunRegistry())
+    response = await handler(
+        http_request=_StubRequest(),
+        request=BaseRequest(message="hello", file_urls={"doc.txt": "https://example.com/doc.txt"}),
+        token=None,
+    )
+    _ = [chunk async for chunk in response.body_iterator]
+
+    assert agency.last_kwargs is not None
+    assert agency.last_kwargs["file_ids"] == ["file-123"]
+    assert isinstance(agency.last_kwargs["message"], list)
+    assert agency.last_kwargs["message"][0]["role"] == "system"
+    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
@@ -84,6 +84,10 @@ def _parse_sse_stream_events(chunks: list[str]) -> list[dict[str, Any]]:
     return events
 
 
+def _parse_file_urls_context(content: str) -> dict[str, str]:
+    return json.loads(content.split("Attached file sources (JSON):\n", 1)[1])
+
+
 @pytest.mark.asyncio
 async def test_stream_endpoint_excludes_file_url_context_from_chat_name(
     monkeypatch: pytest.MonkeyPatch,
@@ -196,7 +200,9 @@ async def test_stream_endpoint_prepends_file_url_source_context(monkeypatch: pyt
     assert agency.last_kwargs["file_ids"] == ["file-123"]
     assert isinstance(agency.last_kwargs["message"], list)
     assert agency.last_kwargs["message"][0]["role"] == "system"
-    assert "`doc.txt`: `https://example.com/doc.txt`" in str(agency.last_kwargs["message"][0]["content"])
+    assert _parse_file_urls_context(str(agency.last_kwargs["message"][0]["content"])) == {
+        "doc.txt": "https://example.com/doc.txt"
+    }
     assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
 
 

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
@@ -85,6 +85,76 @@ def _parse_sse_stream_events(chunks: list[str]) -> list[dict[str, Any]]:
 
 
 @pytest.mark.asyncio
+async def test_stream_endpoint_excludes_file_url_context_from_chat_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming chat names should use the user prompt, not synthetic file_urls metadata."""
+
+    async def _noop_attach(_agency: Any) -> None:
+        return None
+
+    async def _fake_upload_from_urls(_file_urls, allowed_local_dirs=None, openai_client=None):
+        del allowed_local_dirs, openai_client
+        return {"doc.txt": "file-123"}
+
+    async def _fake_generate_chat_name(messages, openai_client=None):
+        del openai_client
+        assert messages[0] == {"role": "user", "content": "hello"}
+        assert all(
+            "The user has provided file attachments in their message." not in str(message.get("content", ""))
+            for message in messages
+            if isinstance(message, dict)
+        )
+        return "stream title"
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.attach_persistent_mcp_servers",
+        _noop_attach,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.upload_from_urls",
+        _fake_upload_from_urls,
+    )
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.endpoint_handlers.generate_chat_name",
+        _fake_generate_chat_name,
+    )
+
+    async def _stream() -> AsyncGenerator[dict[str, Any]]:
+        if False:
+            yield {}
+
+    thread_manager = _StubThreadManager()
+    agency = _StubAgency(StreamingRunResponse(_stream()), thread_manager)
+
+    def get_response_stream(**kwargs: Any) -> StreamingRunResponse:
+        agency.last_kwargs = dict(kwargs)
+        thread_manager._messages.extend(cast(list[dict[str, Any]], kwargs["message"]))
+        thread_manager._messages.append({"role": "assistant", "content": "ok", "type": "message"})
+        return agency._stream
+
+    agency.get_response_stream = get_response_stream  # type: ignore[method-assign]
+
+    def agency_factory(**_kwargs: Any) -> _StubAgency:
+        return agency
+
+    handler = make_stream_endpoint(BaseRequest, agency_factory, lambda: None, ActiveRunRegistry())
+    response = await handler(
+        http_request=_StubRequest(),
+        request=BaseRequest(
+            message="hello",
+            file_urls={"doc.txt": "https://example.com/doc.txt"},
+            generate_chat_name=True,
+        ),
+        token=None,
+    )
+    chunks = [chunk async for chunk in response.body_iterator]
+
+    payload = _parse_sse_messages_payload(chunks)
+    assert payload["chat_name"] == "stream title"
+
+
+@pytest.mark.asyncio
 async def test_stream_endpoint_prepends_file_url_source_context(monkeypatch: pytest.MonkeyPatch) -> None:
     """Streaming FastAPI requests should prepend persisted file_urls source context."""
 

--- a/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
+++ b/tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py
@@ -84,7 +84,7 @@ def _parse_sse_stream_events(chunks: list[str]) -> list[dict[str, Any]]:
     return events
 
 
-def _parse_file_urls_context(content: str) -> dict[str, str]:
+def _parse_file_urls_context(content: str) -> dict[str, Any]:
     return json.loads(content.split("Attached file sources (JSON):\n", 1)[1])
 
 
@@ -201,7 +201,7 @@ async def test_stream_endpoint_prepends_file_url_source_context(monkeypatch: pyt
     assert isinstance(agency.last_kwargs["message"], list)
     assert agency.last_kwargs["message"][0]["role"] == "system"
     assert _parse_file_urls_context(str(agency.last_kwargs["message"][0]["content"])) == {
-        "doc.txt": "https://example.com/doc.txt"
+        "doc.txt": {"url": "https://example.com/doc.txt", "oai_file_id": "file-123"}
     }
     assert agency.last_kwargs["message"][1] == {"role": "user", "content": "hello"}
 

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -42,28 +42,29 @@ def test_request_override_policy_flags() -> None:
     assert empty.has_openai_overrides is False
 
 
-def test_get_allowed_dirs_for_metadata_returns_absolute_paths(tmp_path) -> None:
+def test_get_allowed_dirs_for_metadata_returns_only_existing_directories(tmp_path, monkeypatch) -> None:
     allowed = tmp_path / "uploads"
     allowed.mkdir(parents=True, exist_ok=True)
     file_entry = tmp_path / "not-a-dir.txt"
     file_entry.write_text("x", encoding="utf-8")
     missing_entry = tmp_path / "missing"
-    tilde_entry = Path("~") / "custom"
+    fake_home = tmp_path / "fake-home"
+    tilde_entry = fake_home / "custom"
+    tilde_entry.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(fake_home))
 
     visible = get_allowed_dirs_for_metadata(
         [
             str(allowed),
             str(file_entry),
             str(missing_entry),
-            tilde_entry,
+            Path("~") / "custom",
         ]
     )
 
     assert visible == [
-        str(allowed.expanduser().resolve()),
-        str(file_entry.expanduser().resolve()),
-        str(missing_entry.expanduser().resolve()),
-        str(tilde_entry.expanduser().resolve()),
+        str(allowed.resolve()),
+        str(tilde_entry.resolve()),
     ]
     assert all(Path(p).is_absolute() for p in visible)
 

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 from openai import AsyncOpenAI
 
 from agency_swarm.integrations.fastapi_utils.override_policy import (
@@ -42,11 +43,9 @@ def test_request_override_policy_flags() -> None:
     assert empty.has_openai_overrides is False
 
 
-def test_get_allowed_dirs_for_metadata_returns_only_existing_directories(tmp_path, monkeypatch) -> None:
+def test_get_allowed_dirs_for_metadata_returns_existing_directories(tmp_path, monkeypatch) -> None:
     allowed = tmp_path / "uploads"
     allowed.mkdir(parents=True, exist_ok=True)
-    file_entry = tmp_path / "not-a-dir.txt"
-    file_entry.write_text("x", encoding="utf-8")
     missing_entry = tmp_path / "missing"
     fake_home = tmp_path / "fake-home"
     tilde_entry = fake_home / "custom"
@@ -56,7 +55,6 @@ def test_get_allowed_dirs_for_metadata_returns_only_existing_directories(tmp_pat
     visible = get_allowed_dirs_for_metadata(
         [
             str(allowed),
-            str(file_entry),
             str(missing_entry),
             Path("~") / "custom",
         ]
@@ -67,6 +65,16 @@ def test_get_allowed_dirs_for_metadata_returns_only_existing_directories(tmp_pat
         str(tilde_entry.resolve()),
     ]
     assert all(Path(p).is_absolute() for p in visible)
+
+
+def test_get_allowed_dirs_for_metadata_rejects_non_directory_entry(tmp_path) -> None:
+    allowed = tmp_path / "uploads"
+    allowed.mkdir(parents=True, exist_ok=True)
+    file_entry = tmp_path / "not-a-dir.txt"
+    file_entry.write_text("x", encoding="utf-8")
+
+    with pytest.raises(NotADirectoryError, match="Allowed path must be a directory"):
+        get_allowed_dirs_for_metadata([str(allowed), str(file_entry)])
 
 
 def test_build_file_upload_client_uses_selected_agent_client() -> None:


### PR DESCRIPTION
## Summary
- Persists original FastAPI `file_urls` provenance in chat history so later turns can answer where an attachment came from.
- Keeps the existing attachment flow unchanged: `file_urls` are uploaded, mapped to OpenAI `file_id`s, and attached through the existing `file_ids` path.
- Applies the provenance context to non-streaming, streaming, and AG-UI FastAPI endpoints.
- Stores the provenance as one synthetic `role="system"` history message per `file_urls` turn, using JSON metadata keyed by attached filename.
- Documents the behavior and prevents generated chat names from using the synthetic provenance message.

## Why the provenance message is `role="system"`
- Current clients persist conversation state from `new_messages`.
- Current UIs hide `role="system"` messages, but they do not filter by `message_origin`.
- If this metadata used `role="user"`, the original URL/path strings could show up in chat UIs.
- If this metadata were removed from `new_messages`, it would not persist into later turns.
- So this PR intentionally uses the existing hidden-history path: a persisted system message.

The message content is JSON-serialized provenance metadata, not a new user instruction. This still has a model-authority tradeoff because filenames and URLs are request-controlled. Artem reviewed this tradeoff and considered it acceptable for this thread-scoped feature.

## Extra scope: FastAPI metadata allowlist contract
This PR also tightens `allowed_local_file_dirs` metadata so `/get_metadata` matches the upload path:
- missing configured dirs are omitted from advertised metadata
- non-directory configured entries fail instead of advertising a partial usable allowlist

This was added to fix a review-found mismatch where metadata could claim local uploads were usable even though uploads would fail with the same config.

## Validation
- Rebased onto current `origin/main` on head `33aedc88`.
- Local validation after the latest rebase:
  - `make format`
  - `make check`
  - `uv run pytest tests/test_fastapi_utils_modules/test_endpoint_handlers.py tests/test_fastapi_utils_modules/test_endpoint_handlers_final_messages_payload.py tests/test_fastapi_utils_modules/test_override_policy.py tests/integration/fastapi/test_fastapi_metadata.py`
  - `uv run pytest tests/integration/fastapi/test_fastapi_file_processing.py -k 'local_file_attachment or streaming_response'`
- Fresh GitHub CI is running on head `33aedc88`.
