### PR TITLE
docs: size OpenClaw workspace screenshot

### DIFF
--- a/docs/platform/marketplace/openclaw.mdx
+++ b/docs/platform/marketplace/openclaw.mdx
@@ -83,7 +83,12 @@ To replace them:
 3. Open `/app/mnt/openclaw/workspace`
 4. Upload the replacement file
 
-![Agent Swarm persistent file storage view for OpenClaw workspace](/images/platform/openclaw-persistent-storage-live.png)
+<img
+  src="/images/platform/openclaw-persistent-storage-live.png"
+  alt="Agent Swarm persistent file storage view for OpenClaw workspace"
+  width="64%"
+  style={{ display: "block", margin: "0 auto" }}
+/>
 
 <Note>
 If OpenClaw starts behaving strangely, check both the onboarding instructions and the workspace files. They are both part of the final behavior.


### PR DESCRIPTION
## Summary
- reduce the oversized OpenClaw workspace screenshot
- center the image so the section is easier to scan
 