### PR TITLE
fix: restore gpt-5.4 as default for production code

### DIFF
--- a/.claude/agents/agent-creator.md
+++ b/.claude/agents/agent-creator.md
@@ -46,7 +46,7 @@ agent_name = Agent(
     description="[Agent role from PRD]",
     instructions="./instructions.md",
     tools_folder="./tools",
-    model="gpt-5.4-mini",
+    model="gpt-5.4",
     model_settings=ModelSettings(
         max_tokens=25000,
     ),

--- a/.claude/agents/tools-creator.md
+++ b/.claude/agents/tools-creator.md
@@ -47,7 +47,7 @@ agent_name = Agent(
     instructions="./instructions.md",
     tools_folder="./tools",
     mcp_servers=[filesystem_server],  # ADD THIS LINE
-    model="gpt-5.4-mini",
+    model="gpt-5.4",
     model_settings=ModelSettings(
         max_tokens=25000,
     ),

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -139,7 +139,7 @@ class Agent(BaseAgent[MasterContext]):
 
         ## OpenAI Agents SDK Parameters:
             prompt (Prompt | DynamicPromptFunction | None): Dynamic prompt configuration.
-            model (str | Model | None): Model identifier (e.g., "gpt-5.4-mini") or Model instance.
+            model (str | Model | None): Model identifier (e.g., "gpt-5.4") or Model instance.
                 If not provided, the agents SDK default model will be used: https://openai.github.io/openai-agents-python/models
             model_settings (ModelSettings | None): Model configuration (temperature, max_tokens, etc.).
             tools (list[Tool] | None): Tool instances for the agent. Defaults to empty list.

--- a/src/agency_swarm/cli/main.py
+++ b/src/agency_swarm/cli/main.py
@@ -24,9 +24,7 @@ def main() -> None:
     )
     create_agent_parser.add_argument("name", help="Name of the agent (e.g., 'Data Analyst', 'Content Writer')")
     create_agent_parser.add_argument("--description", help="Description of the agent's role and responsibilities")
-    create_agent_parser.add_argument(
-        "--model", default="gpt-5.4-mini", help="OpenAI model to use (default: gpt-5.4-mini)"
-    )
+    create_agent_parser.add_argument("--model", default="gpt-5.4", help="OpenAI model to use (default: gpt-5.4)")
     create_agent_parser.add_argument(
         "--reasoning", choices=["low", "medium", "high"], help="Reasoning effort level for the model"
     )

--- a/src/agency_swarm/integrations/README.md
+++ b/src/agency_swarm/integrations/README.md
@@ -48,7 +48,7 @@ Agency Swarm still needs a stable model string for the Responses model client, s
 Runtime mapping:
 
 - External alias used by Agency Swarm agent config: `openclaw:main`
-- Upstream provider model used by OpenClaw gateway: `OPENCLAW_PROVIDER_MODEL` (default `openai/gpt-5.4-mini`)
+- Upstream provider model used by OpenClaw gateway: `OPENCLAW_PROVIDER_MODEL` (default `openai/gpt-5.4`)
 
 When the proxy receives `model=openclaw:main`, it rewrites that value to the configured provider model before forwarding upstream.
 

--- a/src/agency_swarm/integrations/openclaw.py
+++ b/src/agency_swarm/integrations/openclaw.py
@@ -242,7 +242,7 @@ class OpenClawIntegrationConfig:
             startup_timeout_seconds=float(os.getenv("OPENCLAW_STARTUP_TIMEOUT_SECONDS", "60")),
             proxy_timeout_seconds=float(os.getenv("OPENCLAW_PROXY_TIMEOUT_SECONDS", "120")),
             default_model=os.getenv("OPENCLAW_DEFAULT_MODEL", DEFAULT_OPENCLAW_MODEL),
-            provider_model=os.getenv("OPENCLAW_PROVIDER_MODEL", "openai/gpt-5.4-mini"),
+            provider_model=os.getenv("OPENCLAW_PROVIDER_MODEL", "openai/gpt-5.4"),
             gateway_command=gateway_command,
             profile=os.getenv("OPENCLAW_PROFILE"),
             tool_mode=_read_openclaw_tool_mode_env(),

--- a/src/agency_swarm/integrations/openclaw_model.py
+++ b/src/agency_swarm/integrations/openclaw_model.py
@@ -12,7 +12,7 @@ from openai import AsyncOpenAI
 
 DEFAULT_OPENCLAW_MODEL = "openclaw:main"
 DEFAULT_OPENCLAW_PROXY_API_PATH = "/openclaw/v1"
-DEFAULT_OPENCLAW_PROVIDER_MODEL = "openai/gpt-5.4-mini"
+DEFAULT_OPENCLAW_PROVIDER_MODEL = "openai/gpt-5.4"
 DEFAULT_OPENCLAW_LOCAL_GATEWAY_TOKEN = "openclaw-local-token"
 
 

--- a/src/agency_swarm/utils/create_agent_template.py
+++ b/src/agency_swarm/utils/create_agent_template.py
@@ -9,7 +9,7 @@ from .model_utils import is_reasoning_model
 def create_agent_template(
     agent_name=None,
     agent_description=None,
-    model="gpt-5.4-mini",
+    model="gpt-5.4",
     reasoning=None,
     max_tokens=None,
     temperature=None,

--- a/tests/test_utils_modules/test_create_agent_template.py
+++ b/tests/test_utils_modules/test_create_agent_template.py
@@ -85,9 +85,9 @@ class TestCreateAgentTemplate:
         assert 'instructions="./instructions.md"' in agent_content
         assert 'files_folder="./files"' in agent_content
         assert 'tools_folder="./tools"' in agent_content
-        assert 'model="gpt-5.4-mini"' in agent_content  # Updated default model
+        assert 'model="gpt-5.4"' in agent_content  # Updated default model
         assert "ModelSettings(" in agent_content
-        # gpt-5.4-mini is a reasoning model - no temperature
+        # gpt-5.4 is a reasoning model - no temperature
         assert "temperature=" not in agent_content
 
     def test_instructions_file_content(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR #578 standardized on `gpt-5.4-mini` for tests (cheaper API calls), but swept up production-facing defaults that should remain `gpt-5.4`:

- **CLI** (`cli/main.py`): `create-agent-template --model` default
- **Agent template generator** (`create_agent_template.py`): default model parameter
- **OpenClaw provider model** (`openclaw_model.py`, `openclaw.py`, `README.md`): upstream gateway default
- **Agent core docstring** (`core.py`): model identifier example
- **Claude Code agent templates** (`.claude/agents/`): agent-creator and tools-creator scaffolds

Tests and examples correctly use `gpt-5.4-mini` for cost savings — no changes there.
