### PR TITLE
docs: clarify supported terminal features

### DIFF
--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -22,6 +22,8 @@ agency.terminal_demo()
 
 `terminal_demo()` provisions the matching terminal binary if needed, starts the local `agency-swarm` bridge automatically, and launches the terminal UI.
 
+Use `agency.terminal_demo(reload=False)` to disable hot reload on file changes.
+
 ## Connect To A Local Server
 
 Use `/connect` to:
@@ -48,7 +50,7 @@ Press `Tab` to autocomplete mentions.
 
 ## Supported Workflow
 
-The current release is intentionally narrow:
+The current release supports these features today:
 
 - local `agency-swarm` backends only
 - one connected backend path per session

--- a/docs/core-framework/agencies/running-agency.mdx
+++ b/docs/core-framework/agencies/running-agency.mdx
@@ -96,6 +96,8 @@ agency.terminal_demo()
 
 On first run, `agency-swarm` downloads the matching `agent-swarm-cli` binary automatically, caches it locally, starts the local bridge, and opens the terminal UI.
 
+Use `agency.terminal_demo(reload=False)` if you want to turn off hot reload on file changes.
+
 For the full terminal workflow, see [Agent Swarm CLI](/core-framework/agencies/agent-swarm-cli).
 
 <Tip>


### PR DESCRIPTION
## Summary
- replace the awkward "intentionally narrow" wording with a clear supported-features statement
- document `terminal_demo(reload=False)` in the terminal docs

## Verification
- `npx prettier --check docs/core-framework/agencies/agent-swarm-cli.mdx docs/core-framework/agencies/running-agency.mdx`
