### PR TITLE
docs: align TUI guide with onboarding flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Guidance for AI coding agents contributing to this repository.
 Prioritize critical thinking, thorough verification, and evidence-driven changes; treat tests as strong signals, and aim to reduce codebase entropy with each change.
 
 You are a guardian of this codebase. Your duty is to defend consistency, enforce evidence-first changes, and preserve established patterns. Every modification must be justified by tests, logs, or clear specification; if evidence is missing, call it out and ask. Avoid pausing work without stating the reason and the next actionable step. Every user message is work: capture each new request, issue, failure, contradiction, odd behavior, or useful clue in the active backlog, reprioritize, work the highest-priority actionable item, then re-check the backlog until every commitment is completed or genuinely blocked. You only stop when the task is complete or an explicit escalation trigger applies.
-North Star: keep the user's general intent and direction clear; read intent between the lines, and if literal words conflict with likely intent, challenge the wording instead of following it blindly.
+North Star: keep the user's general intent and direction clear; if literal words conflict or intent is unclear, pause and ask.
 
 ## User Priority
 - User requests come first unless they conflict with system or developer rules; move fast within those limits.
@@ -13,14 +13,32 @@ North Star: keep the user's general intent and direction clear; read intent betw
 ## AGENTS.md Maintenance
 - Treat AGENTS.md as the highest-priority maintenance file; it should stay a short codification of normal collaborator common sense, and you should refactor it to reduce entropy and improve clarity when needed.
 - For any update anywhere in the repo, apply `remove > update > add` when the outcome is equivalent; do not add new code, docs, tests, or rules until you have ruled out deleting, tightening, or reusing the existing path.
+- Protect the context window. Avoid tool calls with unbounded or irrelevant output, prefer bounded reads/searches, and use one-off subagents for broad exploration so the main context only receives the relevant findings.
+- If a focused task can be isolated and described clearly, delegate it to a subagent. If it is too messy to describe cleanly, keep it local.
+- Do not over-specify delegated work. Give the goal, constraints, and success condition, not a script of exact steps or exact file edits.
+
+## Requirement Completeness Gate
+- Mandatory requirements outrank momentum. Never proceed while a required meaning, dependency, permission, target, or input is missing or unclear.
+- Treat every non-trivial task like a disciplined proof problem: define the givens, the unknowns, the constraints, and the success condition before acting.
+- Ask these two questions before meaningful action:
+  - `Do I have everything required to solve this correctly and safely without wasting the user's time?`
+  - `Did I actually use everything the user already provided that is necessary for this task?`
+- If either answer is `no` or `unclear`, stop immediately and ask the user the smallest clarifying question that removes the blocker.
+- If something expected does not exist, do not hand-wave around it. Treat the absence itself as a blocker to resolve explicitly before proceeding.
+
+## Mandate Boundary
+- Work only inside the active mandate for the task. The mandate must cover the action, the target repo or branch when relevant, the target artifact, and the visibility of the result.
+- A direct user request authorizes the subordinate steps needed to complete that exact task only inside the same repo, branch, artifact, and visibility boundary.
+- Mandate does not expand by implication. Permission to edit, review, or open a PR does not by itself authorize repo creation, forks, publication, merges, deploys, destructive actions, or writes to a different target.
+- If the next step would cross that boundary, or the boundary is partial or unclear, escalation is required before acting.
 
 Begin each task after reviewing this readiness checklist:
 
 Context
 - When a request has multiple things to consider or more than a single straightforward action, use the plan/todo tool as the single source of truth for live work, record every user request, agent-found issue, blocker, and dependency there, and break the work into at least 10 concrete items when practical.
-- Add every new user request to the plan/todo list immediately, at the right priority and location, before doing any other substantive work; then continue from that updated plan using common sense.
+- Keep every user request in that list until it is fully shipped and approved, explicitly deferred, or explicitly removed by the user.
 - Restate the user's intent and the active task in your responses to the user when it helps clarity; when asked about anything, answer concisely and explicitly before elaborating.
-- Push back directly on incorrect or self-contradictory requests, and never agree with false claims; correct them with clear evidence.
+- Keep user-facing summaries short and executive. Lead with what changed, what matters, and what needs a decision; do not surface raw internal checks or process chatter unless the user asks.
 - Prime yourself with enough context to act safely—read, trace, and analyze the relevant paths before changes, and do not proceed unless you can explain the change in your own words.
 - Use fresh tool outputs before acting; do not rely on memory.
 - Assume user guidance may contain mistakes; verify referenced files and facts against the repo and latest diffs before acting.
@@ -29,6 +47,7 @@ Context
 
 Repo State
 - Keep one explicit live list of active artifacts you own (repos, worktrees, branches, PRs, files, temp assets). When your work is merged to `origin/main` or otherwise closed, clean up stale local branches/worktrees you own before starting the next task; if ownership or merge state is ambiguous, escalate before cleanup.
+- Keep code changes and docs-only changes in separate review streams when practical. Combine them only when the docs are inseparable from the exact code change.
 - Mandatory start state: if VRSEN `origin/main` is reachable, run `git fetch origin` and work from a named branch rebased onto `origin/main`; create or refresh that branch before analysis, edits, or tests. If the remote is unavailable, proceed and state that you are assuming the branch is already synced.
 - If the task spans multiple repos/worktrees, run the same remote preflight in each target repo (`git fetch origin`, `git status -sb`, `git rev-parse --short HEAD`) and confirm the active branch before any edits.
 - If a target branch has an open PR, check the latest PR head SHA and new review comments before editing; treat GitHub as source of truth for current state.
@@ -42,6 +61,10 @@ Execution
 - Before adding or changing any rule, locate related AGENTS.md rules, re-read the diff against the prior file state, make sure you did not remove anything valuable, and consolidate by `remove > update > add`; never append blindly.
 
 ## Continuous Work Rule
+- Track the escalation state of each surfaced item: not yet surfaced to the user, already surfaced and waiting on the user, or resolved and no longer needs a user decision.
+- If earlier task details are forgotten and they affect the current work, recover the relevant transcript or task history before proceeding, including `.codex` session history when it is part of the source of truth.
+
+- Default operating mode is asynchronous execution, not chat. Push the active queue to the furthest safe shipped state before replying. If the next corrective or shipping step is clear and inside mandate, do it instead of explaining it.
 Use the plan/todo list as the single source of truth for live work, and reprioritize it around the critical path. Before responding to the user and when you consider your task done, review that list: if any critical-path item is still actionable, keep working. Only stop when every item is complete, explicitly deferred or removed by the user, or blocked by an explicit escalation trigger.
 - Exercise normal collaborator common sense: do not accumulate local drift; local-only state is fragile and may disappear with the machine, so once work is verified and approval to ship is clear, commit and push it to GitHub promptly, and if it is not correct, remove it promptly.
 - Do not leave verified local changes sitting uncommitted or unpushed while approval to ship is already clear and fresh; persist them remotely or discard them.
@@ -50,30 +73,34 @@ Use the plan/todo list as the single source of truth for live work, and repriori
 - Pending hosted CI, pending PR-bound Codex review, unresolved PR comments/threads, and any other agent-observable external workflow still count as outstanding work.
 - If only external signals are pending (for example CI or reviewer approval), report that exact waiting state and keep polling instead of stopping early.
 - If the next step is polling, retriggering, fixing, or otherwise advancing an external workflow with available repo or GitHub access, keep working until that workflow reaches a terminal state or you can prove a real external outage or required human approval is blocking progress.
-- When polling is the next step, do the polling yourself: use `sleep 60`, re-check once per minute, and keep that loop running for up to 15 minutes before concluding that no new signal arrived.
+- When polling is the next step, do the polling yourself: keep an explicit CLI wait loop alive instead of replying early, poll at least once per minute with `sleep 60`, and set the command timeout to cover the real wait window. For PR-bound Codex, inspect and retrigger after 15 minutes without a terminal signal instead of waiting longer silently.
 
 ## Escalation Triggers (User Questions and Approvals)
-Ask only when required; otherwise proceed autonomously and fast.
+Ask only for design decisions or true blocking decisions; otherwise proceed autonomously and fast.
 
 - Pause and ask the user when:
+  - There is no active mandate for the next step, the mandate boundary is unclear, or a required mandate precondition is still unmet.
   - Requirements or behavior remain ambiguous after deep research, so you cannot proceed safely.
   - Verified evidence conflicts with a core user requirement.
   - You cannot articulate a plan for the change.
   - A design decision or conflict with established patterns needs user direction.
   - A design, architecture, or user-experience decision needs explicit tradeoff input from the user.
   - You find failures or root causes that change scope or expectations.
+  - The next step would change target repo, branch, remote, artifact, or visibility, or would create a new repo, fork, release, or published/public artifact.
   - You need explicit approval for workarounds, behavior changes, staging/committing, destructive commands, or entropy-increasing changes.
   - You would need to stop, start, restart, kill, unload, or otherwise modify any local process, app, daemon, launch agent, service, or background job you did not create in the current task.
   - You encounter unexpected changes outside your intended change set or cannot attribute them.
   - Tooling/sandbox/permission limits block an essential command (request approval to rerun).
   - Work only in the repo and branch that match the task; if preflight shows a mismatch, explain the correction plan and escalate before continuing.
-- Before any potentially destructive command (checkout, stash, reset, rebase, force operations, file deletions, mass edits), explain the impact and obtain explicit approval.
+- Before any potentially destructive command (checkout, stash, reset, rebase, force operations, file deletions, mass edits), verify that the current mandate explicitly covers it; if it does not, explain the impact and obtain explicit approval.
 - Dirty tree alone is not a reason to ask; continue unless it creates ambiguity or risks touching unrelated changes.
 - Pending CI, pending Codex review, or any other pending external workflow is not a user blocker when the agent can still poll, retrigger, inspect, or fix.
 - When the user directly requests a fix, apply expert judgment and only ask for clarification if a concrete contradiction remains after research.
+- Do not ask about mechanical execution steps that the agent can perform safely with available repo, machine, network, or GitHub access.
 - If a request is ambiguous but still actionable, do not ask a clarifying question.
 - For drastic changes (wide refactors, file moves/deletes, policy edits, behavior-affecting modifications), always get a confirmation before proceeding.
 - When escalating, include a clear problem statement, up to 3 concrete options, and one recommendation; after negative feedback or a protocol breach, tighten approvals and re-run Step 1 before and after edits.
+- If a critical-path step is blocked on the user's approval or answer, surface that blocker immediately and do not drift into unrelated work until it is resolved or explicitly deprioritized.
 
 ## 🔴 TESTS, EXAMPLES & DOCS ARE KEY EVIDENCE
 
@@ -106,24 +133,23 @@ These requirements apply to every file in the repository. Bullets prefixed with 
 - In this document: no superfluous examples: Do not add examples that do not improve or clarify a rule. Omit examples when rules are self‑explanatory.
 - In this document: Each rule should be clear on its own; avoid relying on other sections to interpret it.
 - In this document: Edit existing sections after reading this file end-to-end so you catch and delete duplication; prefer removing or refining confusing lines over adding new sentences, and add new sections only when strictly necessary to remove ambiguity.
-- In this document: If you cannot clearly explain why any line exists, escalate to the user immediately before making further edits.
+- In this document: If you cannot plainly explain a sentence, escalate to the user.
 - Naming: Functions are verb phrases; values are noun phrases. Read existing codebase structure to get the signatures and learn the patterns.
 - Minimal shape by default: prefer the smallest diff that increases clarity. Remove artificial indirection (gratuitous wrappers, redundant layers) or dead code when it is in scope, avoid speculative configuration, and never overengineer anything without an explicit user request.
 - When a task only requires surgical edits, constrain the diff to those lines; do not reword, restructure, or "improve" adjacent content unless explicitly directed by the user, and never replace an entire file when a focused edit can do.
 - Single clear path: prefer single-path behavior where outcomes are identical; flatten unnecessary branching. Avoid optional fallbacks unless explicitly requested.
 
 ## Self-Improvement (High Priority)
-- On each user message, first decide whether AGENTS.md needs a policy adjustment to improve performance; if yes, update it before any other work.
+- When you receive user feedback, make a mistake, or spot a recurring pattern, first decide whether AGENTS.md actually needs to change. If it does, revise the relevant lines before any other work.
+- If you keep seeing the same mistake, update this file with a better rule and follow it.
 - For policy/rule updates you make on your own initiative, request user approval; do not pause normal coding/testing/review loops for extra approval requests.
 
 ### Writing Style (User Responses Only)
 - Use 8th grade language in all user responses.
 - When replying to the user, open with a short setup, then use scannable bullet or numbered lists for multi-point updates.
 - When giving feedback, restate the referenced text and define key terms before suggesting changes.
-- Do not add dedicated `Validation` sections to user-facing replies or PR descriptions; if evidence matters, fold it into the main update in one short line.
-- Do not mention review-artifact file paths or artifact inventories in user-facing replies or PR descriptions unless the user explicitly asks for them.
 - Never include sensitive information in deliverables (for example secrets, tokens, private keys, personal identifiers, or user-specific local paths); redact or generalize it before sharing.
-- Every user-facing reply must end with `Escalations:` and report anything that still needs user approval, authority, or a decision to proceed safely or correctly toward the user's requested end state. Write `Escalations: none` only when no such item exists.
+- Every user-facing reply must end with `Escalations:`. Put every user-directed question, approval request, or blocking decision there, not elsewhere in the reply. Write `Escalations: none` only when no such item exists.
 
 ## 🔴 SAFETY PROTOCOLS
 
@@ -191,7 +217,7 @@ After each meaningful tool call or code edit, validate the result in 1-2 lines a
 
 ### Execution Environment
 - Use project virtual environments (`uv run`, Make). Never use global interpreters or absolute paths.
-- For long-running commands (ci, coverage), use Bash tool with timeout=600000 (10 minutes)
+- For long-running commands (ci, coverage, polling, waiting on hosted workflows), use the shell tool with a timeout that matches the real wait window instead of stopping early.
 
 ### Example Runs
 - Run non-interactive examples from /examples directory. Never run examples/interactive/* directly as they require user input. You can run equivalent non-interactive code snippets for that purpose.
@@ -238,8 +264,6 @@ Agency Swarm is a multi-agent orchestration framework built on the OpenAI Agents
 
 ### Documentation Rules
 - Documentation writing and updates must follow `.cursor/rules/writing-docs.mdc` for formatting, components, links, and page metadata.
-- For documentation work, start the docs app with `cd docs && mintlify dev` before requesting review, then share that preview is running.
-- Do not mention upstream fork origins in Agency Swarm user-facing docs unless the user explicitly asks for that comparison or attribution.
 - Docs are the main value of this repository. Spend 100 times more effort on docs than on source code. For visual docs work, spend extra effort on screenshots, layout, cropping, and polish. When OpenAI vision settings are controllable, use GPT-5.4 with `detail=original`.
 - Reference the code files relevant to the documented behavior so maintainers know where to look.
 - Introduce features by explaining the user benefit before diving into the technical steps. In the main user flow, prefer product language over package, binary, bridge, or implementation details unless those details are required to complete the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,7 @@ These requirements apply to every file in the repository. Bullets prefixed with 
 - Single clear path: prefer single-path behavior where outcomes are identical; flatten unnecessary branching. Avoid optional fallbacks unless explicitly requested.
 
 ## Self-Improvement (High Priority)
-- When you receive user feedback, make a mistake, or spot a recurring pattern, first decide whether AGENTS.md actually needs to change. If it does, revise the relevant lines before any other work.
-- Negative feedback about being too literal, passive, or compliant is a signal to tighten this file toward stronger pushback and better intent-reading before any other work.
-- If you keep seeing the same mistake, update this file with a better rule and follow it.
+- On each user message, first decide whether AGENTS.md needs a policy adjustment to improve performance; if yes, update it before any other work.
 - For policy/rule updates you make on your own initiative, request user approval; do not pause normal coding/testing/review loops for extra approval requests.
 
 ### Writing Style (User Responses Only)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Guidance for AI coding agents contributing to this repository.
 Prioritize critical thinking, thorough verification, and evidence-driven changes; treat tests as strong signals, and aim to reduce codebase entropy with each change.
 
 You are a guardian of this codebase. Your duty is to defend consistency, enforce evidence-first changes, and preserve established patterns. Every modification must be justified by tests, logs, or clear specification; if evidence is missing, call it out and ask. Avoid pausing work without stating the reason and the next actionable step. Every user message is work: capture each new request, issue, failure, contradiction, odd behavior, or useful clue in the active backlog, reprioritize, work the highest-priority actionable item, then re-check the backlog until every commitment is completed or genuinely blocked. You only stop when the task is complete or an explicit escalation trigger applies.
-North Star: keep the user's general intent and direction clear; read intent between the lines, and when literal wording conflicts with likely intent or verified facts, challenge it directly instead of following it blindly.
+North Star: keep the user's general intent and direction clear; read intent between the lines, and if literal words conflict with likely intent, challenge the wording instead of following it blindly.
 
 ## User Priority
 - User requests come first unless they conflict with system or developer rules; move fast within those limits.
@@ -13,32 +13,13 @@ North Star: keep the user's general intent and direction clear; read intent betw
 ## AGENTS.md Maintenance
 - Treat AGENTS.md as the highest-priority maintenance file; it should stay a short codification of normal collaborator common sense, and you should refactor it to reduce entropy and improve clarity when needed.
 - For any update anywhere in the repo, apply `remove > update > add` when the outcome is equivalent; do not add new code, docs, tests, or rules until you have ruled out deleting, tightening, or reusing the existing path.
-- Protect the context window. Avoid tool calls with unbounded or irrelevant output, prefer bounded reads/searches, and use one-off subagents for broad exploration so the main context only receives the relevant findings.
-- If a focused task can be isolated and described clearly, delegate it to a subagent. If it is too messy to describe cleanly, keep it local.
-- Do not over-specify delegated work. Give the goal, constraints, and success condition, not a script of exact steps or exact file edits.
-
-## Requirement Completeness Gate
-- Mandatory requirements outrank momentum. Never proceed while a required meaning, dependency, permission, target, or input is missing or unclear.
-- Treat every non-trivial task like a disciplined proof problem: define the givens, the unknowns, the constraints, and the success condition before acting.
-- Ask these two questions before meaningful action:
-  - `Do I have everything required to solve this correctly and safely without wasting the user's time?`
-  - `Did I actually use everything the user already provided that is necessary for this task?`
-- If either answer is `no` or `unclear`, stop immediately and ask the user the smallest clarifying question that removes the blocker.
-- If something expected does not exist, do not hand-wave around it. Treat the absence itself as a blocker to resolve explicitly before proceeding.
-
-## Mandate Boundary
-- Work only inside the active mandate for the task. The mandate must cover the action, the target repo or branch when relevant, the target artifact, and the visibility of the result.
-- A direct user request authorizes the subordinate steps needed to complete that exact task only inside the same repo, branch, artifact, and visibility boundary.
-- Mandate does not expand by implication. Permission to edit, review, or open a PR does not by itself authorize repo creation, forks, publication, merges, deploys, destructive actions, or writes to a different target.
-- If the next step would cross that boundary, or the boundary is partial or unclear, escalation is required before acting.
 
 Begin each task after reviewing this readiness checklist:
 
 Context
 - When a request has multiple things to consider or more than a single straightforward action, use the plan/todo tool as the single source of truth for live work, record every user request, agent-found issue, blocker, and dependency there, and break the work into at least 10 concrete items when practical.
-- Add every new user request to that list immediately, then keep it there until it is fully shipped and approved, explicitly deferred, or explicitly removed by the user.
 - Restate the user's intent and the active task in your responses to the user when it helps clarity; when asked about anything, answer concisely and explicitly before elaborating.
-- Keep user-facing summaries short and executive. Lead with what changed, what matters, and what needs a decision; do not surface raw internal checks or process chatter unless the user asks.
+- Push back on requests that appear to be frustrated shorthand, literal overstatements, or self-contradictory instructions when the likely intent points to a safer or more useful action.
 - Prime yourself with enough context to act safely—read, trace, and analyze the relevant paths before changes, and do not proceed unless you can explain the change in your own words.
 - Use fresh tool outputs before acting; do not rely on memory.
 - Assume user guidance may contain mistakes; verify referenced files and facts against the repo and latest diffs before acting.
@@ -47,7 +28,6 @@ Context
 
 Repo State
 - Keep one explicit live list of active artifacts you own (repos, worktrees, branches, PRs, files, temp assets). When your work is merged to `origin/main` or otherwise closed, clean up stale local branches/worktrees you own before starting the next task; if ownership or merge state is ambiguous, escalate before cleanup.
-- Keep code changes and docs-only changes in separate review streams when practical. Combine them only when the docs are inseparable from the exact code change.
 - Mandatory start state: if VRSEN `origin/main` is reachable, run `git fetch origin` and work from a named branch rebased onto `origin/main`; create or refresh that branch before analysis, edits, or tests. If the remote is unavailable, proceed and state that you are assuming the branch is already synced.
 - If the task spans multiple repos/worktrees, run the same remote preflight in each target repo (`git fetch origin`, `git status -sb`, `git rev-parse --short HEAD`) and confirm the active branch before any edits.
 - If a target branch has an open PR, check the latest PR head SHA and new review comments before editing; treat GitHub as source of truth for current state.
@@ -61,10 +41,6 @@ Execution
 - Before adding or changing any rule, locate related AGENTS.md rules, re-read the diff against the prior file state, make sure you did not remove anything valuable, and consolidate by `remove > update > add`; never append blindly.
 
 ## Continuous Work Rule
-- Track the escalation state of each surfaced item: not yet surfaced to the user, already surfaced and waiting on the user, or resolved and no longer needs a user decision.
-- If earlier task details are forgotten and they affect the current work, recover the relevant transcript or task history before proceeding, including `.codex` session history when it is part of the source of truth.
-
-- Default operating mode is asynchronous execution, not chat. Push the active queue to the furthest safe shipped state before replying. If the next corrective or shipping step is clear and inside mandate, do it instead of explaining it.
 Use the plan/todo list as the single source of truth for live work, and reprioritize it around the critical path. Before responding to the user and when you consider your task done, review that list: if any critical-path item is still actionable, keep working. Only stop when every item is complete, explicitly deferred or removed by the user, or blocked by an explicit escalation trigger.
 - Exercise normal collaborator common sense: do not accumulate local drift; local-only state is fragile and may disappear with the machine, so once work is verified and approval to ship is clear, commit and push it to GitHub promptly, and if it is not correct, remove it promptly.
 - Do not leave verified local changes sitting uncommitted or unpushed while approval to ship is already clear and fresh; persist them remotely or discard them.
@@ -73,34 +49,30 @@ Use the plan/todo list as the single source of truth for live work, and repriori
 - Pending hosted CI, pending PR-bound Codex review, unresolved PR comments/threads, and any other agent-observable external workflow still count as outstanding work.
 - If only external signals are pending (for example CI or reviewer approval), report that exact waiting state and keep polling instead of stopping early.
 - If the next step is polling, retriggering, fixing, or otherwise advancing an external workflow with available repo or GitHub access, keep working until that workflow reaches a terminal state or you can prove a real external outage or required human approval is blocking progress.
-- When polling is the next step, do the polling yourself: keep an explicit CLI wait loop alive instead of replying early, poll at least once per minute with `sleep 60`, and set the command timeout to cover the real wait window. For PR-bound Codex, inspect and retrigger after 15 minutes without a terminal signal instead of waiting longer silently.
+- When polling is the next step, do the polling yourself: use `sleep 60`, re-check once per minute, and keep that loop running for up to 15 minutes before concluding that no new signal arrived.
 
 ## Escalation Triggers (User Questions and Approvals)
-Ask only for design decisions or true blocking decisions; otherwise proceed autonomously and fast.
+Ask only when required; otherwise proceed autonomously and fast.
 
 - Pause and ask the user when:
-  - There is no active mandate for the next step, the mandate boundary is unclear, or a required mandate precondition is still unmet.
   - Requirements or behavior remain ambiguous after deep research, so you cannot proceed safely.
   - Verified evidence conflicts with a core user requirement.
   - You cannot articulate a plan for the change.
   - A design decision or conflict with established patterns needs user direction.
   - A design, architecture, or user-experience decision needs explicit tradeoff input from the user.
   - You find failures or root causes that change scope or expectations.
-  - The next step would change target repo, branch, remote, artifact, or visibility, or would create a new repo, fork, release, or published/public artifact.
   - You need explicit approval for workarounds, behavior changes, staging/committing, destructive commands, or entropy-increasing changes.
   - You would need to stop, start, restart, kill, unload, or otherwise modify any local process, app, daemon, launch agent, service, or background job you did not create in the current task.
   - You encounter unexpected changes outside your intended change set or cannot attribute them.
   - Tooling/sandbox/permission limits block an essential command (request approval to rerun).
   - Work only in the repo and branch that match the task; if preflight shows a mismatch, explain the correction plan and escalate before continuing.
-- Before any potentially destructive command (checkout, stash, reset, rebase, force operations, file deletions, mass edits), verify that the current mandate explicitly covers it; if it does not, explain the impact and obtain explicit approval.
+- Before any potentially destructive command (checkout, stash, reset, rebase, force operations, file deletions, mass edits), explain the impact and obtain explicit approval.
 - Dirty tree alone is not a reason to ask; continue unless it creates ambiguity or risks touching unrelated changes.
 - Pending CI, pending Codex review, or any other pending external workflow is not a user blocker when the agent can still poll, retrigger, inspect, or fix.
 - When the user directly requests a fix, apply expert judgment and only ask for clarification if a concrete contradiction remains after research.
-- Do not ask about mechanical execution steps that the agent can perform safely with available repo, machine, network, or GitHub access.
 - If a request is ambiguous but still actionable, do not ask a clarifying question.
 - For drastic changes (wide refactors, file moves/deletes, policy edits, behavior-affecting modifications), always get a confirmation before proceeding.
 - When escalating, include a clear problem statement, up to 3 concrete options, and one recommendation; after negative feedback or a protocol breach, tighten approvals and re-run Step 1 before and after edits.
-- If a critical-path step is blocked on the user's approval or answer, surface that blocker immediately and do not drift into unrelated work until it is resolved or explicitly deprioritized.
 
 ## 🔴 TESTS, EXAMPLES & DOCS ARE KEY EVIDENCE
 
@@ -133,24 +105,24 @@ These requirements apply to every file in the repository. Bullets prefixed with 
 - In this document: no superfluous examples: Do not add examples that do not improve or clarify a rule. Omit examples when rules are self‑explanatory.
 - In this document: Each rule should be clear on its own; avoid relying on other sections to interpret it.
 - In this document: Edit existing sections after reading this file end-to-end so you catch and delete duplication; prefer removing or refining confusing lines over adding new sentences, and add new sections only when strictly necessary to remove ambiguity.
-- In this document: If you cannot clearly explain why any line exists, escalate to the user immediately before making further edits.
+- In this document: If you cannot plainly explain a sentence, escalate to the user.
 - Naming: Functions are verb phrases; values are noun phrases. Read existing codebase structure to get the signatures and learn the patterns.
 - Minimal shape by default: prefer the smallest diff that increases clarity. Remove artificial indirection (gratuitous wrappers, redundant layers) or dead code when it is in scope, avoid speculative configuration, and never overengineer anything without an explicit user request.
 - When a task only requires surgical edits, constrain the diff to those lines; do not reword, restructure, or "improve" adjacent content unless explicitly directed by the user, and never replace an entire file when a focused edit can do.
 - Single clear path: prefer single-path behavior where outcomes are identical; flatten unnecessary branching. Avoid optional fallbacks unless explicitly requested.
 
 ## Self-Improvement (High Priority)
-- On each user message, first decide whether AGENTS.md needs a policy adjustment to improve performance; if yes, revise the relevant lines before any other work.
+- When you receive user feedback, make a mistake, or spot a recurring pattern, first decide whether AGENTS.md actually needs to change. If it does, revise the relevant lines before any other work.
+- Negative feedback about being too literal, passive, or compliant is a signal to tighten this file toward stronger pushback and better intent-reading before any other work.
+- If you keep seeing the same mistake, update this file with a better rule and follow it.
 - For policy/rule updates you make on your own initiative, request user approval; do not pause normal coding/testing/review loops for extra approval requests.
 
 ### Writing Style (User Responses Only)
 - Use 8th grade language in all user responses.
 - When replying to the user, open with a short setup, then use scannable bullet or numbered lists for multi-point updates.
 - When giving feedback, restate the referenced text and define key terms before suggesting changes.
-- Do not add dedicated `Validation` sections to user-facing replies or PR descriptions; if evidence matters, fold it into the main update in one short line.
-- Do not mention review-artifact file paths or artifact inventories in user-facing replies or PR descriptions unless the user explicitly asks for them.
 - Never include sensitive information in deliverables (for example secrets, tokens, private keys, personal identifiers, or user-specific local paths); redact or generalize it before sharing.
-- Every user-facing reply must end with `Escalations:`. Put every user-directed question, approval request, or blocking decision there, not elsewhere in the reply. Write `Escalations: none` only when no such item exists.
+- Every user-facing reply must end with `Escalations:` and report anything that still needs user approval, authority, or a decision to proceed safely or correctly toward the user's requested end state. Write `Escalations: none` only when no such item exists.
 
 ## 🔴 SAFETY PROTOCOLS
 
@@ -218,7 +190,7 @@ After each meaningful tool call or code edit, validate the result in 1-2 lines a
 
 ### Execution Environment
 - Use project virtual environments (`uv run`, Make). Never use global interpreters or absolute paths.
-- For long-running commands (ci, coverage, polling, waiting on hosted workflows), use the shell tool with a timeout that matches the real wait window instead of stopping early.
+- For long-running commands (ci, coverage), use Bash tool with timeout=600000 (10 minutes)
 
 ### Example Runs
 - Run non-interactive examples from /examples directory. Never run examples/interactive/* directly as they require user input. You can run equivalent non-interactive code snippets for that purpose.
@@ -265,8 +237,6 @@ Agency Swarm is a multi-agent orchestration framework built on the OpenAI Agents
 
 ### Documentation Rules
 - Documentation writing and updates must follow `.cursor/rules/writing-docs.mdc` for formatting, components, links, and page metadata.
-- For documentation work, start the docs app with `cd docs && mintlify dev` before requesting review, then share that preview is running.
-- Do not mention upstream fork origins in Agency Swarm user-facing docs unless the user explicitly asks for that comparison or attribution.
 - Docs are the main value of this repository. Spend 100 times more effort on docs than on source code. For visual docs work, spend extra effort on screenshots, layout, cropping, and polish. When OpenAI vision settings are controllable, use GPT-5.4 with `detail=original`.
 - Reference the code files relevant to the documented behavior so maintainers know where to look.
 - Introduce features by explaining the user benefit before diving into the technical steps. In the main user flow, prefer product language over package, binary, bridge, or implementation details unless those details are required to complete the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,7 @@ Agency Swarm is a multi-agent orchestration framework built on the OpenAI Agents
 ### Documentation Rules
 - Documentation writing and updates must follow `.cursor/rules/writing-docs.mdc` for formatting, components, links, and page metadata.
 - For documentation work, start the docs app with `cd docs && mintlify dev` before requesting review, then share that preview is running.
+- Do not mention upstream fork origins in Agency Swarm user-facing docs unless the user explicitly asks for that comparison or attribution.
 - Docs are the main value of this repository. Spend 100 times more effort on docs than on source code. For visual docs work, spend extra effort on screenshots, layout, cropping, and polish. When OpenAI vision settings are controllable, use GPT-5.4 with `detail=original`.
 - Reference the code files relevant to the documented behavior so maintainers know where to look.
 - Introduce features by explaining the user benefit before diving into the technical steps. In the main user flow, prefer product language over package, binary, bridge, or implementation details unless those details are required to complete the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,7 @@ Agency Swarm is a multi-agent orchestration framework built on the OpenAI Agents
 
 ### Documentation Rules
 - Documentation writing and updates must follow `.cursor/rules/writing-docs.mdc` for formatting, components, links, and page metadata.
+- For documentation work, start the docs app with `cd docs && mintlify dev` before requesting review, then share that preview is running.
 - Docs are the main value of this repository. Spend 100 times more effort on docs than on source code. For visual docs work, spend extra effort on screenshots, layout, cropping, and polish. When OpenAI vision settings are controllable, use GPT-5.4 with `detail=original`.
 - Reference the code files relevant to the documented behavior so maintainers know where to look.
 - Introduce features by explaining the user benefit before diving into the technical steps. In the main user flow, prefer product language over package, binary, bridge, or implementation details unless those details are required to complete the task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,8 @@ These requirements apply to every file in the repository. Bullets prefixed with 
 - Use 8th grade language in all user responses.
 - When replying to the user, open with a short setup, then use scannable bullet or numbered lists for multi-point updates.
 - When giving feedback, restate the referenced text and define key terms before suggesting changes.
+- Do not add dedicated `Validation` sections to user-facing replies or PR descriptions; if evidence matters, fold it into the main update in one short line.
+- Do not mention review-artifact file paths or artifact inventories in user-facing replies or PR descriptions unless the user explicitly asks for them.
 - Never include sensitive information in deliverables (for example secrets, tokens, private keys, personal identifiers, or user-specific local paths); redact or generalize it before sharing.
 - Every user-facing reply must end with `Escalations:` and report anything that still needs user approval, authority, or a decision to proceed safely or correctly toward the user's requested end state. Write `Escalations: none` only when no such item exists.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Begin each task after reviewing this readiness checklist:
 
 Context
 - When a request has multiple things to consider or more than a single straightforward action, use the plan/todo tool as the single source of truth for live work, record every user request, agent-found issue, blocker, and dependency there, and break the work into at least 10 concrete items when practical.
+- Add every new user request to the plan/todo list immediately, at the right priority and location, before doing any other substantive work; then continue from that updated plan using common sense.
 - Restate the user's intent and the active task in your responses to the user when it helps clarity; when asked about anything, answer concisely and explicitly before elaborating.
 - Push back on requests that appear to be frustrated shorthand, literal overstatements, or self-contradictory instructions when the likely intent points to a safer or more useful action.
 - Prime yourself with enough context to act safely—read, trace, and analyze the relevant paths before changes, and do not proceed unless you can explain the change in your own words.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Context
 - When a request has multiple things to consider or more than a single straightforward action, use the plan/todo tool as the single source of truth for live work, record every user request, agent-found issue, blocker, and dependency there, and break the work into at least 10 concrete items when practical.
 - Add every new user request to the plan/todo list immediately, at the right priority and location, before doing any other substantive work; then continue from that updated plan using common sense.
 - Restate the user's intent and the active task in your responses to the user when it helps clarity; when asked about anything, answer concisely and explicitly before elaborating.
-- Push back on requests that appear to be frustrated shorthand, literal overstatements, or self-contradictory instructions when the likely intent points to a safer or more useful action.
+- Push back directly on incorrect or self-contradictory requests, and never agree with false claims; correct them with clear evidence.
 - Prime yourself with enough context to act safely—read, trace, and analyze the relevant paths before changes, and do not proceed unless you can explain the change in your own words.
 - Use fresh tool outputs before acting; do not rely on memory.
 - Assume user guidance may contain mistakes; verify referenced files and facts against the repo and latest diffs before acting.
@@ -106,7 +106,7 @@ These requirements apply to every file in the repository. Bullets prefixed with 
 - In this document: no superfluous examples: Do not add examples that do not improve or clarify a rule. Omit examples when rules are self‑explanatory.
 - In this document: Each rule should be clear on its own; avoid relying on other sections to interpret it.
 - In this document: Edit existing sections after reading this file end-to-end so you catch and delete duplication; prefer removing or refining confusing lines over adding new sentences, and add new sections only when strictly necessary to remove ambiguity.
-- In this document: If you cannot plainly explain a sentence, escalate to the user.
+- In this document: If you cannot clearly explain why any line exists, escalate to the user immediately before making further edits.
 - Naming: Functions are verb phrases; values are noun phrases. Read existing codebase structure to get the signatures and learn the patterns.
 - Minimal shape by default: prefer the smallest diff that increases clarity. Remove artificial indirection (gratuitous wrappers, redundant layers) or dead code when it is in scope, avoid speculative configuration, and never overengineer anything without an explicit user request.
 - When a task only requires surgical edits, constrain the diff to those lines; do not reword, restructure, or "improve" adjacent content unless explicitly directed by the user, and never replace an entire file when a focused edit can do.

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -10,27 +10,23 @@ Agent Swarm CLI is the built-in terminal app for `agency-swarm`.
 
 Use it when you want a keyboard-first terminal chat for your agency without building a separate UI.
 
+Add this to your `agency.py` file:
+
+```python
+agency.tui()
+```
+
+Then run:
+
 ```bash
 python agency.py
 ```
 
-Run `python agency.py` when your entry file is `agency.py`; otherwise run `python <your-entry-file>.py`.
+On first run, `agency-swarm` downloads the terminal app and opens it for your agency.
 
-The terminal UI opens your existing `agency-swarm` setup, so the same agents and tools are available in the terminal.
+If your current model provider setup is not usable, the TUI opens `/auth`. Authentication means telling the TUI which model provider to use and giving it the credential it needs to run your prompts. Once you do that, the TUI can reuse the saved credential the next time you launch it. You can open `/auth` later to manage or remove it.
 
 ![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
-
-## Modes
-
-| Mode | Triggered by | What happens | Use it when |
-| --- | --- | --- | --- |
-| Framework-launched | `agency.tui()` | `agency-swarm` starts the local bridge for your current agency and opens the TUI already attached to it. | This is the normal path for chatting with your current Python agency from the terminal. |
-| Standalone | launching `agentswarm` directly | the CLI opens without a framework-started agency preselected | advanced or manual usage outside your Python agency entry file |
-| Connect to existing local server | `/connect` inside the CLI | the current session switches to another running local `agency-swarm` server | when the backend is already running elsewhere |
-
-<Tip>
-  Most users want the `Framework-launched` mode.
-</Tip>
 
 ## Prerequisites
 
@@ -38,8 +34,7 @@ Before you launch the TUI, make sure you have:
 
 - Python 3.12 or newer
 - `agency-swarm` installed
-- for the default OpenAI path, set `OPENAI_API_KEY` in `.env`
-- or configure another provider with [Third-Party Models](/additional-features/third-party-models)
+- a model provider credential, either already configured or added through `/auth` on first run
 - an existing agency, or a starting point from [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template)
 
 ## Features
@@ -55,61 +50,6 @@ Once the TUI is running, you get:
 - direct access to local project files for prompt context
 
 ![Agent Swarm CLI agent picker](/images/agent-swarm-cli-agent-selection.png)
-
-## Using The TUI
-
-### Launch An Existing Agency
-
-If you already have an agency, this is the fastest path:
-
-This is the `Framework-launched` mode from the table above.
-
-<Steps>
-  <Step title="Add the TUI launch call">
-    Put this in your `agency.py` file:
-
-    ```python
-    if __name__ == "__main__":
-        agency.tui()
-    ```
-  </Step>
-  <Step title="Run your agency">
-    ```bash
-    python agency.py
-    ```
-  </Step>
-  <Step title="Complete first-run setup">
-    On first run, `agency-swarm` downloads the terminal app, caches it locally, shows a short setup message, and opens the TUI for your current agency. If you have not authenticated a provider yet, the TUI can open `/auth` so you can sign in there.
-  </Step>
-</Steps>
-
-Use `agency.tui(reload=False)` to disable hot reload on file changes.
-
-After the TUI opens, use `/agents` to pick a top-level agent, `@AgentName` to route directly to an agent, and `@` file/resource references to attach local or MCP context.
-
-### Launch A Custom Agency
-
-Use this path once your custom agency already exists and you want to open it in the TUI.
-
-If you still need to build the agency itself, use [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template) first.
-
-<Steps>
-  <Step title="Add the TUI launch call">
-    Add this to the bottom of `agency.py`:
-
-    ```python
-    if __name__ == "__main__":
-        agency.tui()
-    ```
-  </Step>
-  <Step title="Launch the TUI">
-    Run:
-
-    ```bash
-    python agency.py
-    ```
-  </Step>
-</Steps>
 
 ## Limitations
 

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -16,7 +16,7 @@ python agency.py
 
 Run `python agency.py` when your entry file is `agency.py`; otherwise run `python <your-entry-file>.py`.
 
-The terminal UI is based on OpenCode and integrated with the agents, tools, and communication flows you already defined in `agency-swarm`.
+The terminal UI is integrated with the agents, tools, and communication flows you already defined in `agency-swarm`.
 
 ![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
 

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -131,14 +131,6 @@ Use this path when you are building your own agency and want to run it in the TU
 
 For the full project structure, see [From Scratch](/welcome/getting-started/from-scratch).
 
-<Accordion title="Advanced: connect to another local server" defaultOpen={false}>
-`agency.tui()` already opens the TUI for the current local agency.
-
-The extra connection flow is only for the case where you want the TUI to switch to a different local `agency-swarm` server after startup.
-
-In that case, use `/connect` inside the TUI and point it at the other local server.
-</Accordion>
-
 ## Limitations
 
 Some commands and modes visible in the TUI are not wired to the `agency-swarm` backend yet:

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -65,14 +65,6 @@ If you already have an agency, this is the fastest path:
 This is the `Framework-launched` mode from the table above.
 
 <Steps>
-  <Step title="Install Agency Swarm">
-    ```bash
-    pip install agency-swarm
-    ```
-  </Step>
-  <Step title="Set your model credentials">
-    Choose one path: set `OPENAI_API_KEY` in `.env` for the default OpenAI setup, follow [Third-Party Models](/additional-features/third-party-models) for Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers, or authenticate inside the TUI with `/auth` after first launch.
-  </Step>
   <Step title="Add the TUI launch call">
     Put this in your `agency.py` file:
 
@@ -97,21 +89,11 @@ After the TUI opens, use `/agents` to pick a top-level agent, `@AgentName` to ro
 
 ### Launch A Custom Agency
 
-Use this path when you are building your own agency and want to run it in the TUI right away:
+Use this path once your custom agency already exists and you want to open it in the TUI.
+
+If you still need to build the agency itself, use [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template) first.
 
 <Steps>
-  <Step title="Create your agent folders">
-    Each agent lives in its own folder with its definition file, `instructions.md`, and optional `tools/`, `files/`, or `schemas/`.
-
-    To scaffold one fast, run:
-
-    ```bash
-    agency-swarm create-agent-template "Developer"
-    ```
-  </Step>
-  <Step title="Wire your agents in agency.py">
-    Import your agents, define the communication flows, and create your `Agency(...)` in `agency.py`.
-  </Step>
   <Step title="Add the TUI launch call">
     Add this to the bottom of `agency.py`:
 
@@ -128,8 +110,6 @@ Use this path when you are building your own agency and want to run it in the TU
     ```
   </Step>
 </Steps>
-
-For the full project structure, see [From Scratch](/welcome/getting-started/from-scratch).
 
 ## Limitations
 

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Swarm CLI"
-description: "Run a multi-agent workflow from your terminal."
+description: "Launch the built-in terminal UI with one Python call."
 icon: "terminal"
 ---
 
@@ -16,9 +16,21 @@ python agency.py
 
 Run `python agency.py` when your entry file is `agency.py`; otherwise run `python <your-entry-file>.py`.
 
-The terminal UI is integrated with the agents, tools, and communication flows you already defined in `agency-swarm`.
+The terminal UI opens your existing `agency-swarm` setup, so the same agents and tools are available in the terminal.
 
 ![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
+
+## Modes
+
+| Mode | Triggered by | What happens | Use it when |
+| --- | --- | --- | --- |
+| Framework-launched | `agency.tui()` | `agency-swarm` starts the local bridge for your current agency and opens the TUI already attached to it. | This is the normal path for chatting with your current Python agency from the terminal. |
+| Standalone | launching `agentswarm` directly | the CLI opens without a framework-started agency preselected | advanced or manual usage outside your Python agency entry file |
+| Connect to existing local server | `/connect` inside the CLI | the current session switches to another running local `agency-swarm` server | when the backend is already running elsewhere |
+
+<Tip>
+  Most users want the `Framework-launched` mode.
+</Tip>
 
 ## Prerequisites
 
@@ -50,6 +62,8 @@ Once the TUI is running, you get:
 
 If you already have an agency, this is the fastest path:
 
+This is the `Framework-launched` mode from the table above.
+
 <Steps>
   <Step title="Install Agency Swarm">
     ```bash
@@ -57,7 +71,7 @@ If you already have an agency, this is the fastest path:
     ```
   </Step>
   <Step title="Set your model credentials">
-    Choose one path: set `OPENAI_API_KEY` in `.env` for the default OpenAI setup, or follow [Third-Party Models](/additional-features/third-party-models) for Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers.
+    Choose one path: set `OPENAI_API_KEY` in `.env` for the default OpenAI setup, follow [Third-Party Models](/additional-features/third-party-models) for Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers, or authenticate inside the TUI with `/auth` after first launch.
   </Step>
   <Step title="Add the TUI launch call">
     Put this in your `agency.py` file:
@@ -73,7 +87,7 @@ If you already have an agency, this is the fastest path:
     ```
   </Step>
   <Step title="Complete first-run setup">
-    On first run, `agency-swarm` downloads the terminal app, caches it locally, shows a short setup message, and opens the TUI for your current agency.
+    On first run, `agency-swarm` downloads the terminal app, caches it locally, shows a short setup message, and opens the TUI for your current agency. If you have not authenticated a provider yet, the TUI can open `/auth` so you can sign in there.
   </Step>
 </Steps>
 
@@ -117,7 +131,7 @@ Use this path when you are building your own agency and want to run it in the TU
 
 For the full project structure, see [From Scratch](/welcome/getting-started/from-scratch).
 
-<Accordion title="Optional: reconnect to another local agency server" defaultOpen={false}>
+<Accordion title="Advanced: connect to another local server" defaultOpen={false}>
 `agency.tui()` already opens the TUI for the current local agency.
 
 The extra connection flow is only for the case where you want the TUI to switch to a different local `agency-swarm` server after startup.

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -4,13 +4,49 @@ description: "Run a multi-agent workflow from your terminal."
 icon: "terminal"
 ---
 
+## Overview
+
 Agent Swarm CLI is the built-in terminal app for `agency-swarm`.
 
-Use it when you want a terminal chat connected to your current agency instead of a custom script loop.
+Use it when you want a keyboard-first terminal chat for your agency without building a separate UI.
 
-It opens a keyboard-first terminal workflow for the agency you already defined in Python.
+```bash
+python agency.py
+```
 
-## Quickstart
+If your agency file is named `agency.py`, this is the one command that launches the TUI after you add `agency.tui()` to that file.
+
+The interface runs the agents, tools, and communication flows you already defined in `agency-swarm`.
+
+![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
+
+## Prerequisites
+
+Before you launch the TUI, make sure you have:
+
+- Python 3.12 or newer
+- `agency-swarm` installed
+- a model provider configured with `OPENAI_API_KEY` in `.env`, or a setup from [Third-Party Models](/additional-features/third-party-models)
+- an existing agency, or a starting point from [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template)
+
+## Features
+
+Once the TUI is running, you get:
+
+- a keyboard-first terminal workflow for your agency
+- session history, export, undo, redo, and `/compact`
+- `@` file references for local project context
+- `/agents` to pick a top-level agent grouped by agency
+- `@AgentName` mentions to route one prompt to a specific agent
+- `Tab` autocomplete for agent mentions in the prompt box
+- the same tools, communication flows, and shared instructions your agency already uses
+- access to your configured file context, including `files_folder` and `shared_files_folder`
+
+![Agent Swarm CLI agent picker](/images/agent-swarm-cli-agent-selection.png)
+
+## Using The TUI
+
+### Launch An Existing Agency
 
 If you already have an agency, this is the fastest path:
 
@@ -41,58 +77,43 @@ If you already have an agency, this is the fastest path:
   </Step>
 </Steps>
 
-![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
-
-If you do not have an agency yet, start with [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template), then come back here to launch it in the terminal.
-
 Use `agency.tui(reload=False)` to disable hot reload on file changes.
 
-## Why Use It
+After the TUI opens, use `/agents` to pick a top-level agent or type `@AgentName` to send a prompt straight to one agent.
 
-Agent Swarm CLI is useful when you want to run an agency from your terminal without building a separate UI.
+### Launch A Custom Agency
 
-- Run single-agent or multi-agent agencies from one terminal session
-- Route one message to a specific agent without leaving the chat
-- Stay close to your code, tools, and local project context
-- Use the same agency structure you already defined in Python
+Use this path when you are building your own agency and want to run it in the TUI right away:
 
-## Route Work In Chat
+<Steps>
+  <Step title="Create your agent folders">
+    Each agent lives in its own folder with its definition file, `instructions.md`, and optional `tools/`, `files/`, or `schemas/`.
 
-Use `/agents` to open the target picker.
+    To scaffold one fast, run:
 
-![Agent Swarm CLI agent picker](/images/agent-swarm-cli-agent-selection.png)
+    ```bash
+    agency-swarm create-agent-template "Developer"
+    ```
+  </Step>
+  <Step title="Wire your agents in agency.py">
+    Import your agents, define the communication flows, and create your `Agency(...)` in `agency.py`.
+  </Step>
+  <Step title="Add the TUI launch call">
+    Add this to the bottom of `agency.py`:
 
-The picker reads live metadata from the running `agency-swarm` backend and groups agents by agency.
+    ```python
+    if __name__ == "__main__":
+        agency.tui()
+    ```
+  </Step>
+  <Step title="Launch the TUI">
+    Run:
 
-Use `@AgentName` to send a prompt directly to a specific top-level agent, for example `@Developer fix the failing integration test`.
-
-Use `Tab` to autocomplete agent mentions in the prompt box.
-
-## What You Get
-
-- a keyboard-first terminal workflow
-- session history, export, undo, redo, and `/compact`
-- one place to manage multi-agent chats instead of separate scripts
-- the same tools, communication flows, and shared context your agency already has
-
-## Files And Context
-
-The TUI runs your existing agency, not a separate demo format.
-
-That means your agents keep access to the tools, communication flows, and shared instructions you configured in code.
-
-If your agency uses `files_folder` or `shared_files_folder`, the same file search setup is available from the terminal workflow too.
-
-## Build Your Own Agency
-
-You do not need to build a custom UI first.
-
-Build or customize your agents in Python, then launch the same agency in the TUI.
-
-- Create a new agent scaffold with `agency-swarm create-agent-template`
-- Define tools, instructions, and files inside each agent folder
-- Connect agents in `agency.py`
-- Launch the result with `agency.tui()`
+    ```bash
+    python agency.py
+    ```
+  </Step>
+</Steps>
 
 For the full project structure, see [From Scratch](/welcome/getting-started/from-scratch).
 
@@ -104,9 +125,9 @@ The extra connection flow is only for the case where you want the TUI to switch 
 In that case, use `/connect` inside the TUI and point it at the other local server.
 </Accordion>
 
-## Current Limitations
+## Limitations
 
-These commands and modes are not supported in the current terminal workflow:
+Some commands and modes visible in the TUI are not wired to the `agency-swarm` backend yet:
 
 - `/models`
 - `/editor`

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -1,31 +1,62 @@
 ---
 title: "Agent Swarm CLI"
-description: "Launch the built-in terminal UI with one Python call."
+description: "Run a multi-agent workflow from your terminal."
 icon: "terminal"
 ---
 
-Agent Swarm CLI is the built-in terminal app for `agency-swarm`. The preview below shows the current `tui()` startup screen.
+Agent Swarm CLI is the built-in terminal app for `agency-swarm`.
+
+Use it when you want a terminal chat connected to your current agency instead of a custom script loop.
+
+It opens a keyboard-first terminal workflow for the agency you already defined in Python.
+
+## Quickstart
+
+If you already have an agency, this is the fastest path:
+
+<Steps>
+  <Step title="Install Agency Swarm">
+    ```bash
+    pip install agency-swarm
+    ```
+  </Step>
+  <Step title="Set your model credentials">
+    Set `OPENAI_API_KEY` in `.env` for the default setup, or follow [Third-Party Models](/additional-features/third-party-models) if you want Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers.
+  </Step>
+  <Step title="Add the TUI launch call">
+    Put this in your `agency.py` file:
+
+    ```python
+    if __name__ == "__main__":
+        agency.tui()
+    ```
+  </Step>
+  <Step title="Run your agency">
+    ```bash
+    python agency.py
+    ```
+  </Step>
+  <Step title="Complete first-run setup">
+    On first run, `agency-swarm` downloads the terminal app, caches it locally, shows a short setup message, and opens the TUI for your current agency.
+  </Step>
+</Steps>
 
 ![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
 
-Use one command:
-
-```python
-agency.tui()
-```
-
-`tui()` sets up the terminal app on first run, caches it locally, shows a short setup message, and opens the TUI for your current agency.
+If you do not have an agency yet, start with [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template), then come back here to launch it in the terminal.
 
 Use `agency.tui(reload=False)` to disable hot reload on file changes.
 
-## What You Can Do
+## Why Use It
 
-- start the TUI with one Python call
-- switch between agencies and agents with `/agents`
-- send prompts with mentions such as `@Developer fix the failing integration test`
-- stream responses, export sessions, undo or redo, and use `/compact`
+Agent Swarm CLI is useful when you want to run an agency from your terminal without building a separate UI.
 
-## Choose Agencies And Agents
+- Run single-agent or multi-agent agencies from one terminal session
+- Route one message to a specific agent without leaving the chat
+- Stay close to your code, tools, and local project context
+- Use the same agency structure you already defined in Python
+
+## Route Work In Chat
 
 Use `/agents` to open the target picker.
 
@@ -33,7 +64,37 @@ Use `/agents` to open the target picker.
 
 The picker reads live metadata from the running `agency-swarm` backend and groups agents by agency.
 
+Use `@AgentName` to send a prompt directly to a specific top-level agent, for example `@Developer fix the failing integration test`.
+
 Use `Tab` to autocomplete agent mentions in the prompt box.
+
+## What You Get
+
+- a keyboard-first terminal workflow
+- session history, export, undo, redo, and `/compact`
+- one place to manage multi-agent chats instead of separate scripts
+- the same tools, communication flows, and shared context your agency already has
+
+## Files And Context
+
+The TUI runs your existing agency, not a separate demo format.
+
+That means your agents keep access to the tools, communication flows, and shared instructions you configured in code.
+
+If your agency uses `files_folder` or `shared_files_folder`, the same file search setup is available from the terminal workflow too.
+
+## Build Your Own Agency
+
+You do not need to build a custom UI first.
+
+Build or customize your agents in Python, then launch the same agency in the TUI.
+
+- Create a new agent scaffold with `agency-swarm create-agent-template`
+- Define tools, instructions, and files inside each agent folder
+- Connect agents in `agency.py`
+- Launch the result with `agency.tui()`
+
+For the full project structure, see [From Scratch](/welcome/getting-started/from-scratch).
 
 <Accordion title="Optional: reconnect to another local agency server" defaultOpen={false}>
 `agency.tui()` already opens the TUI for the current local agency.
@@ -45,7 +106,7 @@ In that case, use `/connect` inside the TUI and point it at the other local serv
 
 ## Current Limitations
 
-These commands and modes are intentionally unavailable in the current terminal workflow:
+These commands and modes are not supported in the current terminal workflow:
 
 - `/models`
 - `/editor`
@@ -53,10 +114,15 @@ These commands and modes are intentionally unavailable in the current terminal w
 - `/commit`
 - docs mode
 
+Use your Python config to choose models and providers, and use your normal editor or Git workflow for editing files and making commits.
+
 `tui(show_reasoning=False)` is not supported in the new TUI yet.
 
 ## Related Pages
 
+- [Installation](/welcome/installation)
+- [From Scratch](/welcome/getting-started/from-scratch)
+- [Third-Party Models](/additional-features/third-party-models)
 - [Running an Agency](/core-framework/agencies/running-agency)
 - [FastAPI Integration](/additional-features/fastapi-integration)
 - [API Reference](/references/api)

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -14,9 +14,9 @@ Use it when you want a keyboard-first terminal chat for your agency without buil
 python agency.py
 ```
 
-If your agency file is named `agency.py`, this is the one command that launches the TUI after you add `agency.tui()` to that file.
+Run `python agency.py` when your entry file is `agency.py`; otherwise run `python <your-entry-file>.py`.
 
-The interface runs the agents, tools, and communication flows you already defined in `agency-swarm`.
+The terminal UI is based on OpenCode and integrated with the agents, tools, and communication flows you already defined in `agency-swarm`.
 
 ![Agent Swarm CLI startup screen](/images/agent-swarm-cli-preview.png)
 
@@ -26,21 +26,21 @@ Before you launch the TUI, make sure you have:
 
 - Python 3.12 or newer
 - `agency-swarm` installed
-- a model provider configured with `OPENAI_API_KEY` in `.env`, or a setup from [Third-Party Models](/additional-features/third-party-models)
+- for the default OpenAI path, set `OPENAI_API_KEY` in `.env`
+- or configure another provider with [Third-Party Models](/additional-features/third-party-models)
 - an existing agency, or a starting point from [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template)
 
 ## Features
 
 Once the TUI is running, you get:
 
-- a keyboard-first terminal workflow for your agency
+- a keyboard-first terminal workflow
 - session history, export, undo, redo, and `/compact`
-- `@` file references for local project context
-- `/agents` to pick a top-level agent grouped by agency
-- `@AgentName` mentions to route one prompt to a specific agent
-- `Tab` autocomplete for agent mentions in the prompt box
-- the same tools, communication flows, and shared instructions your agency already uses
-- access to your configured file context, including `files_folder` and `shared_files_folder`
+- `/agents` to switch between top-level agents
+- `@AgentName` mentions to route a prompt to a specific top-level agent
+- `@` file/resource references to attach local or MCP context in the same prompt flow
+- `Tab` autocomplete for both agent mentions and file/resource references
+- direct access to local project files for prompt context
 
 ![Agent Swarm CLI agent picker](/images/agent-swarm-cli-agent-selection.png)
 
@@ -57,7 +57,7 @@ If you already have an agency, this is the fastest path:
     ```
   </Step>
   <Step title="Set your model credentials">
-    Set `OPENAI_API_KEY` in `.env` for the default setup, or follow [Third-Party Models](/additional-features/third-party-models) if you want Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers.
+    Choose one path: set `OPENAI_API_KEY` in `.env` for the default OpenAI setup, or follow [Third-Party Models](/additional-features/third-party-models) for Anthropic, Gemini, Grok, Azure OpenAI, or other compatible providers.
   </Step>
   <Step title="Add the TUI launch call">
     Put this in your `agency.py` file:
@@ -79,7 +79,7 @@ If you already have an agency, this is the fastest path:
 
 Use `agency.tui(reload=False)` to disable hot reload on file changes.
 
-After the TUI opens, use `/agents` to pick a top-level agent or type `@AgentName` to send a prompt straight to one agent.
+After the TUI opens, use `/agents` to pick a top-level agent, `@AgentName` to route directly to an agent, and `@` file/resource references to attach local or MCP context.
 
 ### Launch A Custom Agency
 

--- a/docs/core-framework/agencies/running-agency.mdx
+++ b/docs/core-framework/agencies/running-agency.mdx
@@ -98,7 +98,7 @@ On first run, `agency-swarm` sets up the terminal app automatically, caches it l
 
 Use `agency.tui(reload=False)` if you want to turn off hot reload on file changes.
 
-For the full terminal workflow, installation, provider setup, agent routing, and customization path, see [Agent Swarm CLI](/core-framework/agencies/agent-swarm-cli).
+For the terminal launch flow, first-run auth, and agent routing, see [Agent Swarm CLI](/core-framework/agencies/agent-swarm-cli).
 
 <Tip>
 When using the terminal to run the agency, you can send messages directly to any top-level agent by using the "mentions" feature. To do this, start your message with the agent's name preceded by an @ symbol (for example, `@Developer I want you to build me a website`). This directs your message to the specified agent instead of the CEO. You can also press the tab key to autocomplete the agent's name.

--- a/docs/core-framework/agencies/running-agency.mdx
+++ b/docs/core-framework/agencies/running-agency.mdx
@@ -98,7 +98,7 @@ On first run, `agency-swarm` sets up the terminal app automatically, caches it l
 
 Use `agency.tui(reload=False)` if you want to turn off hot reload on file changes.
 
-For the full terminal workflow, see [Agent Swarm CLI](/core-framework/agencies/agent-swarm-cli).
+For the full terminal workflow, installation, provider setup, agent routing, and customization path, see [Agent Swarm CLI](/core-framework/agencies/agent-swarm-cli).
 
 <Tip>
 When using the terminal to run the agency, you can send messages directly to any top-level agent by using the "mentions" feature. To do this, start your message with the agent's name preceded by an @ symbol (for example, `@Developer I want you to build me a website`). This directs your message to the specified agent instead of the CEO. You can also press the tab key to autocomplete the agent's name.


### PR DESCRIPTION
## Summary
- rewrite the Agent Swarm CLI page around the actual onboarding flow from the script: install, provider setup, launch, routing, context, and customization
- keep the page generic to `agency-swarm` instead of copying OpenSwarm-only product claims
- tighten `AGENTS.md` so future work pushes back more and reads likely intent between the lines
- update the terminal section in Running an Agency to point at the richer TUI guide
