### PR TITLE
fix: change default model from gpt-4.1 to gpt-5.4-mini

### DIFF
--- a/src/agency_swarm/agent/constants.py
+++ b/src/agency_swarm/agent/constants.py
@@ -1,5 +1,9 @@
 """Agent module constants extracted to keep files under size limits (no behavior change)."""
 
+# Override the Agents SDK default model (gpt-4.1) to prevent infinite tool-call
+# loops observed with that model in handoff workflows.
+FRAMEWORK_DEFAULT_MODEL = "gpt-5.4-mini"
+
 AGENT_PARAMS = {
     "files_folder",
     "tools_folder",

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -140,7 +140,7 @@ class Agent(BaseAgent[MasterContext]):
         ## OpenAI Agents SDK Parameters:
             prompt (Prompt | DynamicPromptFunction | None): Dynamic prompt configuration.
             model (str | Model | None): Model identifier (e.g., "gpt-5.4") or Model instance.
-                If not provided, the agents SDK default model will be used: https://openai.github.io/openai-agents-python/models
+                Defaults to "gpt-5.4-mini".
             model_settings (ModelSettings | None): Model configuration (temperature, max_tokens, etc.).
             tools (list[Tool] | None): Tool instances for the agent. Defaults to empty list.
             mcp_servers (list[MCPServer] | None): Model Context Protocol servers.

--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -13,7 +13,6 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 from agents import Agent as BaseAgent, GuardrailFunctionOutput, ModelSettings, RunContextWrapper
-from agents.models import get_default_model
 from agents.models.default_models import get_default_model_settings as get_sdk_default_model_settings
 
 from agency_swarm.agent.attachment_manager import AttachmentManager
@@ -27,6 +26,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _INPUT_GUARDRAIL_WRAPPED_ATTR = "_agency_swarm_input_guardrail_wrapped"
+
+# Override the Agents SDK default model (gpt-4.1) to prevent infinite tool-call
+# loops observed with that model in handoff workflows.
+FRAMEWORK_DEFAULT_MODEL = "gpt-5.4-mini"
 
 # Agency Swarm defaults applied when the SDK leaves a field unset
 # include_usage=True enables streaming usage tracking for LiteLLM models
@@ -212,7 +215,7 @@ def separate_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, A
         base_agent_params.pop("handoff_description")
 
     if "model" not in base_agent_params:
-        base_agent_params["model"] = get_default_model()
+        base_agent_params["model"] = FRAMEWORK_DEFAULT_MODEL
 
     return base_agent_params, current_agent_params
 

--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -16,6 +16,7 @@ from agents import Agent as BaseAgent, GuardrailFunctionOutput, ModelSettings, R
 from agents.models.default_models import get_default_model_settings as get_sdk_default_model_settings
 
 from agency_swarm.agent.attachment_manager import AttachmentManager
+from agency_swarm.agent.constants import FRAMEWORK_DEFAULT_MODEL
 from agency_swarm.agent.file_manager import AgentFileManager
 from agency_swarm.tools import BaseTool, ToolFactory
 from agency_swarm.utils.model_utils import get_default_settings_model_name
@@ -26,10 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _INPUT_GUARDRAIL_WRAPPED_ATTR = "_agency_swarm_input_guardrail_wrapped"
-
-# Override the Agents SDK default model (gpt-4.1) to prevent infinite tool-call
-# loops observed with that model in handoff workflows.
-FRAMEWORK_DEFAULT_MODEL = "gpt-5.4-mini"
 
 # Agency Swarm defaults applied when the SDK leaves a field unset
 # include_usage=True enables streaming usage tracking for LiteLLM models

--- a/tests/integration/communication/test_communication.py
+++ b/tests/integration/communication/test_communication.py
@@ -15,7 +15,8 @@ def planner_agent_instance():
         instructions=(
             "You are a Planner. You will receive a task. Determine the steps. "
             "Delegate the execution step to the Worker agent using the send_message tool. "
-            "Ensure your message to the Worker clearly includes the full and exact task description you received."
+            "Ensure your message to the Worker clearly includes the full and exact task description you received. "
+            "After receiving the final result, relay it verbatim to the user including all task identifiers."
         ),
         model_settings=ModelSettings(temperature=0.0),
     )

--- a/tests/integration/communication/test_streaming_order_consistency.py
+++ b/tests/integration/communication/test_streaming_order_consistency.py
@@ -294,8 +294,9 @@ async def test_multiple_sequential_subagent_calls() -> None:
             if isinstance(evt_type, str) and isinstance(agent_name, str):
                 stream_items.append((evt_type, agent_name, tool_name))
 
-    # Verify stream matches expected
-    assert stream_items == EXPECTED_FLOW_MULTIPLE_CALLS, (
+    # Verify stream matches expected (allow optional initial message_output from reasoning models)
+    normalized = _strip_optional_initial_message_output(stream_items, "Coordinator")
+    assert normalized == EXPECTED_FLOW_MULTIPLE_CALLS, (
         f"Multiple calls stream mismatch:\n got={stream_items}\n exp={EXPECTED_FLOW_MULTIPLE_CALLS}"
     )
 
@@ -530,8 +531,9 @@ async def test_parallel_subagent_calls() -> None:
             if isinstance(evt_type, str) and isinstance(agent_name, str):
                 stream_items.append((evt_type, agent_name, tool_name))
 
-    # Verify stream matches expected (strict assertion)
-    if stream_items != EXPECTED_FLOW_PARALLEL:
+    # Verify stream matches expected (allow optional initial message_output from reasoning models)
+    normalized = _strip_optional_initial_message_output(stream_items, "Orchestrator")
+    if normalized != EXPECTED_FLOW_PARALLEL:
         logger.error(
             "Parallel sub-agent stream mismatch",
             extra={
@@ -539,7 +541,7 @@ async def test_parallel_subagent_calls() -> None:
                 "expected": EXPECTED_FLOW_PARALLEL,
             },
         )
-    assert stream_items == EXPECTED_FLOW_PARALLEL, (
+    assert normalized == EXPECTED_FLOW_PARALLEL, (
         f"Parallel calls stream mismatch:\n got={stream_items}\n exp={EXPECTED_FLOW_PARALLEL}"
     )
 

--- a/tests/integration/fastapi/test_fastapi_metadata.py
+++ b/tests/integration/fastapi/test_fastapi_metadata.py
@@ -132,7 +132,7 @@ def test_metadata_includes_agent_capabilities():
     assert hosted_agent is not None
     assert "capabilities" in hosted_agent["data"]
     capabilities = set(hosted_agent["data"]["capabilities"])
-    assert capabilities == {"file_search", "code_interpreter", "web_search"}
+    assert capabilities == {"file_search", "code_interpreter", "web_search", "reasoning"}
     assert "tools" not in capabilities
 
     reasoning_agent = next((n for n in nodes if n["id"] == "ReasoningAgent"), None)
@@ -150,7 +150,7 @@ def test_metadata_includes_agent_capabilities():
 
 
 def test_metadata_capabilities_empty_for_basic_agent():
-    """Agent with no special features has empty capabilities list."""
+    """Agent with no tools only reports reasoning from the default model."""
 
     def create_agency(load_threads_callback=None, save_threads_callback=None):
         agent = Agent(name="BasicAgent", instructions="Basic agent with no tools")
@@ -168,7 +168,7 @@ def test_metadata_capabilities_empty_for_basic_agent():
     basic_agent = next((n for n in nodes if n["id"] == "BasicAgent"), None)
     assert basic_agent is not None
     assert "capabilities" in basic_agent["data"]
-    assert basic_agent["data"]["capabilities"] == []
+    assert basic_agent["data"]["capabilities"] == ["reasoning"]
 
 
 def test_metadata_includes_allowed_local_file_dirs(tmp_path, agency_factory):

--- a/tests/integration/files/test_file_handling.py
+++ b/tests/integration/files/test_file_handling.py
@@ -500,7 +500,11 @@ async def test_agent_vision_capabilities(real_openai_client: AsyncOpenAI, tmp_pa
     # Resolve paths relative to the project root
     project_root = Path(__file__).resolve().parents[3]  # Go up to project root
     test_images = [
-        (project_root / "examples/data/shapes_and_text.png", "How many shapes do you see in this image?", "three"),
+        (
+            project_root / "examples/data/shapes_and_text.png",
+            "How many shapes do you see in this image?",
+            ("three", "3"),
+        ),
         (project_root / "examples/data/shapes_and_text.png", "What text do you see in this image?", "VISION TEST 2024"),
     ]
 
@@ -551,12 +555,10 @@ async def test_agent_vision_capabilities(real_openai_client: AsyncOpenAI, tmp_pa
         assert response_result.final_output is not None
         print(f"Vision response for {image_path.name}: {response_result.final_output}")
 
-        # Use case-insensitive search for matching
+        # Use case-insensitive search for matching (accept any alternative)
         response_lower = response_result.final_output.lower()
-        expected_lower = expected_content.lower()
-
-        # With temperature=0, responses should be deterministic
-        content_found = expected_lower in response_lower
+        alternatives = (expected_content,) if isinstance(expected_content, str) else expected_content
+        content_found = any(alt.lower() in response_lower for alt in alternatives)
 
         assert content_found, (
             f"Expected content '{expected_content}' not found in vision response for {image_path.name}. "

--- a/tests/test_agent_modules/test_agent_capabilities.py
+++ b/tests/test_agent_modules/test_agent_capabilities.py
@@ -41,20 +41,20 @@ def test_agent_capabilities_case_table() -> None:
     hosted_mcp = HostedMCPTool(tool_config=Mcp(server_label="test", server_url="https://example.com"))
 
     cases: list[tuple[Agent, set[str]]] = [
-        (Agent(name="EmptyAgent", instructions="Test"), set()),
-        (Agent(name="BaseToolAgent", instructions="Test", tools=[SampleTool]), {"tools"}),
-        (Agent(name="FunctionToolAgent", instructions="Test", tools=[sample_function_tool]), {"tools"}),
+        (Agent(name="EmptyAgent", instructions="Test"), {"reasoning"}),
+        (Agent(name="BaseToolAgent", instructions="Test", tools=[SampleTool]), {"tools", "reasoning"}),
+        (Agent(name="FunctionToolAgent", instructions="Test", tools=[sample_function_tool]), {"tools", "reasoning"}),
         (
             Agent(name="HostedToolsAgent", instructions="Test", tools=[FileSearchTool(vector_store_ids=["vs_123"])]),
-            {"file_search"},
+            {"file_search", "reasoning"},
         ),
         (
             Agent(name="CodeAgent", instructions="Test", tools=[CodeInterpreterTool(tool_config=CodeInterpreter())]),
-            {"code_interpreter"},
+            {"code_interpreter", "reasoning"},
         ),
-        (Agent(name="WebAgent", instructions="Test", tools=[WebSearchTool()]), {"web_search"}),
-        (Agent(name="HostedMcpAgent", instructions="Test", tools=[hosted_mcp]), {"hosted_mcp"}),
-        (Agent(name="McpServerAgent", instructions="Test", mcp_servers=[mcp_server]), {"tools"}),
+        (Agent(name="WebAgent", instructions="Test", tools=[WebSearchTool()]), {"web_search", "reasoning"}),
+        (Agent(name="HostedMcpAgent", instructions="Test", tools=[hosted_mcp]), {"hosted_mcp", "reasoning"}),
+        (Agent(name="McpServerAgent", instructions="Test", mcp_servers=[mcp_server]), {"tools", "reasoning"}),
         (
             Agent(
                 name="MixedAgent",
@@ -65,7 +65,7 @@ def test_agent_capabilities_case_table() -> None:
                     CodeInterpreterTool(tool_config=CodeInterpreter()),
                 ],
             ),
-            {"tools", "file_search", "code_interpreter"},
+            {"tools", "file_search", "code_interpreter", "reasoning"},
         ),
     ]
     for agent, expected in cases:

--- a/tests/test_agent_modules/test_agent_initialization.py
+++ b/tests/test_agent_modules/test_agent_initialization.py
@@ -38,6 +38,7 @@ def test_agent_initialization_core_configuration_variants():
     minimal = Agent(name="Agent1", instructions="Be helpful")
     assert minimal.name == "Agent1"
     assert minimal.instructions == "Be helpful"
+    assert minimal.model == "gpt-5.4-mini"
     assert minimal.tools == []
     assert minimal.files_folder is None
     assert not hasattr(minimal, "response_validator")


### PR DESCRIPTION
## Summary
- The Agents SDK default model (`gpt-4.1`) caused infinite tool-call loops in handoff workflows (e.g. `examples/handoffs.py`), running for 9,058 seconds and draining API credits
- Overrides the framework default to `gpt-5.4-mini` via a `FRAMEWORK_DEFAULT_MODEL` constant in `initialization.py`, decoupling from upstream SDK defaults
- Updates the Agent docstring and adjusts capability tests to reflect the new reasoning-capable default
 