### PR TITLE
chore: support scoped agentswarm cli packages

### DIFF
--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, TypedDict
+from urllib.parse import quote
 
 import requests
 
@@ -36,7 +37,7 @@ _BIN_ENV = "AGENTSWARM_BIN"
 _ARGS_ENV = "AGENCY_SWARM_OPENCODE_ARGS"
 _HOST = "127.0.0.1"
 _MODEL = "agency-swarm/default"
-_CLI_VERSION = "1.3.15"
+_CLI_VERSION = "1.4.5"
 _CLI_REGISTRY = "https://registry.npmjs.org"
 _LOCK_AGE = 300
 _LOCK_WAIT = 30
@@ -48,6 +49,7 @@ _SETUP_COMPLETE_MESSAGE = "Agent Swarm CLI setup complete."
 class _Package:
     name: str
     binary: str
+    npm_name: str | None = None
 
 
 class _Dist(TypedDict):
@@ -241,7 +243,7 @@ def _install(pkg: _Package, root: Path, path: Path) -> None:
     tmp = Path(tempfile.mkdtemp(prefix="agentswarm-", dir=root))
     try:
         archive = tmp / "cli.tgz"
-        meta = _metadata(pkg.name)
+        meta = _metadata(pkg.npm_name or pkg.name)
         _download(meta["dist"]["tarball"], archive)
         if meta["dist"].get("shasum") and _sha1(archive) != meta["dist"]["shasum"]:
             raise RuntimeError("Agent Swarm CLI download checksum mismatch.")
@@ -265,7 +267,7 @@ def _install(pkg: _Package, root: Path, path: Path) -> None:
 
 
 def _metadata(name: str) -> _Meta:
-    response = requests.get(f"{_CLI_REGISTRY}/{name}/{_CLI_VERSION}", timeout=30)
+    response = requests.get(f"{_CLI_REGISTRY}/{quote(name, safe='')}/{_CLI_VERSION}", timeout=30)
     response.raise_for_status()
     data = response.json()
     dist = data.get("dist") if isinstance(data, dict) else None
@@ -310,25 +312,27 @@ def _package() -> _Package:
     machine = platform.machine().lower()
     if sys.platform == "darwin":
         if machine in ("aarch64", "arm64"):
-            return _Package("agent-swarm-cli-darwin-arm64", "agency")
+            return _Package("agentswarm-cli-darwin-arm64", "agency", "@vrsen/agentswarm-cli-darwin-arm64")
         if machine in ("amd64", "x86_64"):
-            return _Package("agent-swarm-cli-darwin-x64-baseline", "agency")
+            return _Package("agentswarm-cli-darwin-x64-baseline", "agency", "@vrsen/agentswarm-cli-darwin-x64-baseline")
     if sys.platform == "win32":
         if machine in ("aarch64", "arm64"):
-            return _Package("agent-swarm-cli-windows-arm64", "agency.exe")
+            return _Package("agentswarm-cli-windows-arm64", "agency.exe", "@vrsen/agentswarm-cli-windows-arm64")
         if machine in ("amd64", "x86_64"):
-            return _Package("agent-swarm-cli-windows-x64-baseline", "agency.exe")
+            return _Package(
+                "agentswarm-cli-windows-x64-baseline", "agency.exe", "@vrsen/agentswarm-cli-windows-x64-baseline"
+            )
     if sys.platform.startswith("linux"):
         if machine in ("aarch64", "arm64"):
-            name = "agent-swarm-cli-linux-arm64"
+            name = "agentswarm-cli-linux-arm64"
         elif machine in ("amd64", "x86_64"):
-            name = "agent-swarm-cli-linux-x64-baseline"
+            name = "agentswarm-cli-linux-x64-baseline"
         else:
             name = ""
         if name:
             if _musl():
                 name += "-musl"
-            return _Package(name, "agency")
+            return _Package(name, "agency", f"@vrsen/{name}")
     raise RuntimeError(f"Agent Swarm CLI is not available on {sys.platform}/{machine}.")
 
 

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -37,7 +37,7 @@ _BIN_ENV = "AGENTSWARM_BIN"
 _ARGS_ENV = "AGENCY_SWARM_OPENCODE_ARGS"
 _HOST = "127.0.0.1"
 _MODEL = "agency-swarm/default"
-_CLI_VERSION = "1.4.5"
+_CLI_VERSION = "1.4.6"
 _CLI_REGISTRY = "https://registry.npmjs.org"
 _LOCK_AGE = 300
 _LOCK_WAIT = 30
@@ -312,15 +312,17 @@ def _package() -> _Package:
     machine = platform.machine().lower()
     if sys.platform == "darwin":
         if machine in ("aarch64", "arm64"):
-            return _Package("agentswarm-cli-darwin-arm64", "agency", "@vrsen/agentswarm-cli-darwin-arm64")
-        if machine in ("amd64", "x86_64"):
-            return _Package("agentswarm-cli-darwin-x64-baseline", "agency", "@vrsen/agentswarm-cli-darwin-x64-baseline")
-    if sys.platform == "win32":
-        if machine in ("aarch64", "arm64"):
-            return _Package("agentswarm-cli-windows-arm64", "agency.exe", "@vrsen/agentswarm-cli-windows-arm64")
+            return _Package("agentswarm-cli-darwin-arm64", "agentswarm", "@vrsen/agentswarm-cli-darwin-arm64")
         if machine in ("amd64", "x86_64"):
             return _Package(
-                "agentswarm-cli-windows-x64-baseline", "agency.exe", "@vrsen/agentswarm-cli-windows-x64-baseline"
+                "agentswarm-cli-darwin-x64-baseline", "agentswarm", "@vrsen/agentswarm-cli-darwin-x64-baseline"
+            )
+    if sys.platform == "win32":
+        if machine in ("aarch64", "arm64"):
+            return _Package("agentswarm-cli-windows-arm64", "agentswarm.exe", "@vrsen/agentswarm-cli-windows-arm64")
+        if machine in ("amd64", "x86_64"):
+            return _Package(
+                "agentswarm-cli-windows-x64-baseline", "agentswarm.exe", "@vrsen/agentswarm-cli-windows-x64-baseline"
             )
     if sys.platform.startswith("linux"):
         if machine in ("aarch64", "arm64"):
@@ -332,7 +334,7 @@ def _package() -> _Package:
         if name:
             if _musl():
                 name += "-musl"
-            return _Package(name, "agency", f"@vrsen/{name}")
+            return _Package(name, "agentswarm", f"@vrsen/{name}")
     raise RuntimeError(f"Agent Swarm CLI is not available on {sys.platform}/{machine}.")
 
 

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -167,7 +167,7 @@ def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):
         return Response(
             payload={
                 "dist": {
-                    "tarball": "https://registry.npmjs.org/agent-swarm-cli-darwin-arm64/-/pkg.tgz",
+                    "tarball": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/pkg.tgz",
                     "shasum": sha,
                 }
             }
@@ -178,17 +178,21 @@ def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):
     monkeypatch.setattr(
         agentswarm_cli_demo,
         "_package",
-        lambda: agentswarm_cli_demo._Package("agent-swarm-cli-darwin-arm64", "agency"),
+        lambda: agentswarm_cli_demo._Package(
+            "agentswarm-cli-darwin-arm64",
+            "agency",
+            "@vrsen/agentswarm-cli-darwin-arm64",
+        ),
     )
     monkeypatch.setattr(agentswarm_cli_demo, "_CLI_VERSION", "1.2.27-test")
 
     path = agentswarm_cli_demo._ensure_cli()
 
-    assert path == root / "1.2.27-test" / "agent-swarm-cli-darwin-arm64" / "agency"
+    assert path == root / "1.2.27-test" / "agentswarm-cli-darwin-arm64" / "agency"
     assert path.read_text() == "#!/bin/sh\nexit 0\n"
     assert calls == [
-        "https://registry.npmjs.org/agent-swarm-cli-darwin-arm64/1.2.27-test",
-        "https://registry.npmjs.org/agent-swarm-cli-darwin-arm64/-/pkg.tgz",
+        "https://registry.npmjs.org/%40vrsen%2Fagentswarm-cli-darwin-arm64/1.2.27-test",
+        "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/pkg.tgz",
     ]
 
 
@@ -200,7 +204,11 @@ def test_agentswarm_cli_tui_notifies_on_first_run(monkeypatch, tmp_path):
     monkeypatch.setattr(
         agentswarm_cli_demo,
         "_package",
-        lambda: agentswarm_cli_demo._Package("agent-swarm-cli-darwin-arm64", "agency"),
+        lambda: agentswarm_cli_demo._Package(
+            "agentswarm-cli-darwin-arm64",
+            "agency",
+            "@vrsen/agentswarm-cli-darwin-arm64",
+        ),
     )
     monkeypatch.setattr(agentswarm_cli_demo, "_install", lambda pkg, install_root, path: path.write_text("ok"))
     monkeypatch.setattr(agentswarm_cli_demo, "_notify_setup", notices.append)

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -132,7 +132,7 @@ def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):
     blob = BytesIO()
     with tarfile.open(fileobj=blob, mode="w:gz") as tar:
         data = b"#!/bin/sh\nexit 0\n"
-        info = tarfile.TarInfo("package/bin/agency")
+        info = tarfile.TarInfo("package/bin/agentswarm")
         info.size = len(data)
         info.mode = 0o755
         tar.addfile(info, BytesIO(data))
@@ -180,7 +180,7 @@ def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):
         "_package",
         lambda: agentswarm_cli_demo._Package(
             "agentswarm-cli-darwin-arm64",
-            "agency",
+            "agentswarm",
             "@vrsen/agentswarm-cli-darwin-arm64",
         ),
     )
@@ -188,7 +188,7 @@ def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):
 
     path = agentswarm_cli_demo._ensure_cli()
 
-    assert path == root / "1.2.27-test" / "agentswarm-cli-darwin-arm64" / "agency"
+    assert path == root / "1.2.27-test" / "agentswarm-cli-darwin-arm64" / "agentswarm"
     assert path.read_text() == "#!/bin/sh\nexit 0\n"
     assert calls == [
         "https://registry.npmjs.org/%40vrsen%2Fagentswarm-cli-darwin-arm64/1.2.27-test",
@@ -206,7 +206,7 @@ def test_agentswarm_cli_tui_notifies_on_first_run(monkeypatch, tmp_path):
         "_package",
         lambda: agentswarm_cli_demo._Package(
             "agentswarm-cli-darwin-arm64",
-            "agency",
+            "agentswarm",
             "@vrsen/agentswarm-cli-darwin-arm64",
         ),
     )


### PR DESCRIPTION
### Summary

Teach the Agent Swarm framework launcher to resolve the newer scoped CLI platform packages while keeping the local cache layout stable.

This updates the launcher to:
- fetch npm metadata from scoped package names like `@vrsen/agentswarm-cli-darwin-arm64`
- keep the local cached binary paths unscoped and stable
- pin the launcher to the released CLI version that contains the new auth/onboarding work

### Test plan

- `uv run pytest tests/test_agency_modules/test_agentswarm_cli_tui.py`
- `python -m compileall src/agency_swarm/ui/demos/agentswarm_cli.py tests/test_agency_modules/test_agentswarm_cli_tui.py`
- `make check`
- re-ran the named failing CI test locally with the repo Python 3.13 env:
  - `tests/integration/persistence/test_thread_isolation_basic.py::test_thread_identifier_format`
  - it passed on both the PR branch and `origin/main`

### Issue number

Closes #

### Checks

- [ ] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
