### PR TITLE
docs: streamline Agent Swarm CLI first run

### DIFF
--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -13,21 +13,27 @@ Use it when you want to build or test your Agency Swarm project in the terminal.
 For most users, the right way to start is:
 
 ```bash
+mkdir my-agency
+cd my-agency
 npx @vrsen/agentswarm
 ```
 
-This is the main launch path. It handles first-run setup, then opens the terminal UI in local `Agent Builder` mode.
+If you already have an Agency Swarm project, just `cd` into that project and run the same command.
 
-Run it from your project root. If you are starting fresh, run it in a new empty folder.
+This is the main launch path. It handles first-run setup, then opens the terminal UI.
 
 You do not need to install the CLI globally first.
+
+<Tip>
+On first run, the launcher may create `.venv`, install dependencies, and ask a few setup questions. This is expected.
+</Tip>
 
 ## Before You Start
 
 Make sure you have:
 
-- Node.js installed so `npx` is available
-- Python 3.12 or newer available for Agency Swarm projects
+- `node --version` works in your terminal so `npx` is available
+- `python --version` works and points to Python 3.12 or newer
 - a model provider credential if you want to send prompts right away, or you can add it later with `/auth`
 - an existing agency project, or a starting point from [From Scratch](/welcome/getting-started/from-scratch) or the [Starter Template](/welcome/getting-started/starter-template)
 

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -125,6 +125,8 @@ python agency.py
 
 This path stays bound to the exact `Agency` instance you passed in Python. It starts the local bridge for that agency, then opens the TUI in connected agency mode.
 
+In this connected mode, local file tools are not available. If you want the TUI to work directly on local project files, start with `npx @vrsen/agentswarm` from that project directory instead.
+
 Use it when your team already starts the project from Python and you want a quick TUI test path without switching directories or changing entrypoints.
 </Accordion>
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This makes the Agent Swarm CLI page easier for first-time users to act on.

It puts the empty-folder quickstart directly under the main command, shows how existing projects use the same command, and adds a short reassurance note about the expected first-run setup work.

It also makes the prerequisite list more practical by telling users which commands to run in their terminal before they start.

### How did you verify your code works?

- Reviewed the rendered page in a local Mintlify preview
- Checked the final rendered structure with a browser snapshot after the edit
- Ran an outside-eye docs review focused on first-time user clarity and only applied the highest-signal fixes

### Screenshots / recordings

Not included. This PR is a wording and flow polish on an existing docs page.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
