### PR TITLE
feat: add first-class system_reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Context
 - Assume user guidance may contain mistakes; verify referenced files and facts against the repo and latest diffs before acting.
 - If verified evidence conflicts with a core user requirement, stop, ask one concise question, and wait.
 - Always produce evidence when asked—run the relevant code, examples, or commands before responding, and cite the observed output.
+- For Notion-backed or task-tracker-backed work, fetch the task comments/discussions before scoping or planning; treat those comments as the latest clarification source unless newer user instructions override them.
 
 Repo State
 - Keep one explicit live list of active artifacts you own (repos, worktrees, branches, PRs, files, temp assets). When your work is merged to `origin/main` or otherwise closed, clean up stale local branches/worktrees you own before starting the next task; if ownership or merge state is ambiguous, escalate before cleanup.
@@ -384,7 +385,7 @@ Strictness
 
 ## Memory & Expectations
 - User expects explicit status reporting, a test-first mindset, and directness. Ask at most one question at a time. After negative feedback or a protocol breach, tighten approvals: present minimal options and wait for explicit approval before changes; re-run Step 1 before and after edits.
-- Memory files are for durable lessons learned and task SOPs only; never use them as run logs, journals, or chronological transcripts.
+- Memory files are for durable lessons learned and task SOPs only; never store run logs, branch names, SHAs, command transcripts, validation output, or chronological transcripts in them.
 - Operate with maximum diligence and ownership; carry every task to completion with urgency and reliability.
 - When new insights improve clarity, distill them into existing sections (prefer refining current lines over adding new ones). After addressing the feedback, continue working if needed.
 

--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -278,6 +278,22 @@ For a full example showing agency context in action, see the [Agency Context Wor
 - Workflow coordination
 - Context monitoring and debugging
 
-If you want a reminder pattern, see the [System Reminders Example](https://github.com/VRSEN/agency-swarm/blob/main/examples/system_reminders.py). It keeps reminder content in agency context, configures `Agent(system_reminders=[...])`, and shows both a reminder after each new user message and a stronger reminder after every 15 tool calls.
+If you want reminder text to read from agency context, pass a callable instead of a string:
+
+```python
+from agency_swarm import Agent, AfterEveryUserMessage, MasterContext, RunContextWrapper
+
+def build_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
+    customer_name = ctx.context.user_context.get("customer_name", "the user")
+    return f"Greet {customer_name} by name and end with one next step."
+
+agent = Agent(
+    name="SupportAgent",
+    instructions="You help customers.",
+    system_reminders=[AfterEveryUserMessage(build_reminder)],
+)
+```
+
+If you just want the simplest starting point, see the [System Reminders Example](https://github.com/VRSEN/agency-swarm/blob/main/examples/system_reminders.py).
 
 Agency context eliminates the need for complex parameter passing and enables multi-agent workflows while maintaining clean separation of concerns.

--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -278,4 +278,6 @@ For a full example showing agency context in action, see the [Agency Context Wor
 - Workflow coordination
 - Context monitoring and debugging
 
+If you want a reminder pattern, see the [System Reminders Example](https://github.com/VRSEN/agency-swarm/blob/main/examples/system_reminders.py). It keeps reminder content in agency context, configures `Agent(system_reminders=[...])`, and shows both a reminder after each new user message and a stronger reminder after every 15 tool calls.
+
 Agency context eliminates the need for complex parameter passing and enables multi-agent workflows while maintaining clean separation of concerns.

--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -46,6 +46,23 @@ Set `include_web_search_sources=False` to skip this.
 ### System Reminders
 
 Use `system_reminders` when you want reminder system messages without writing custom lifecycle hooks.
+Start with one short reminder string.
+
+```python
+from agency_swarm import Agent, AfterEveryUserMessage
+
+agent = Agent(
+    name="SupportAgent",
+    instructions="Answer clearly and keep the user moving forward.",
+    system_reminders=[
+        AfterEveryUserMessage("Before replying, end with one clear next step."),
+    ],
+)
+```
+
+This reminder is injected into the model input before each new user message. It is not saved into the main thread history.
+
+For tool-heavy agents, add a checkpoint reminder:
 
 ```python
 from agency_swarm import Agent, AfterEveryUserMessage, EveryNToolCalls
@@ -54,13 +71,27 @@ agent = Agent(
     name="SupportAgent",
     instructions="Answer clearly and keep the user moving forward.",
     system_reminders=[
-        AfterEveryUserMessage("Restate the next follow-up before answering."),
-        EveryNToolCalls(15, "Summarize progress before using more tools."),
+        AfterEveryUserMessage("Before replying, end with one clear next step."),
+        EveryNToolCalls(15, "Pause and summarize progress before using more tools."),
     ],
 )
 ```
 
-These reminders are injected into the model input only. They are not saved into the main thread history.
+Reminder text can also be dynamic:
+
+```python
+from agency_swarm import Agent, AfterEveryUserMessage, MasterContext, RunContextWrapper
+
+def build_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
+    customer_name = ctx.context.user_context.get("customer_name", "the user")
+    return f"Greet {customer_name} by name and end with one next step."
+
+agent = Agent(
+    name="SupportAgent",
+    instructions="Answer clearly and keep the user moving forward.",
+    system_reminders=[AfterEveryUserMessage(build_reminder)],
+)
+```
 
 <Note>
 Use `system_reminders` for the common reminder cases. Keep `hooks` for advanced lifecycle behavior that falls outside the built-in reminder triggers.

--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -43,6 +43,29 @@ agent = Agent(
 With `include_web_search_sources=True` (default), `WebSearchTool` calls include source URLs.
 Set `include_web_search_sources=False` to skip this.
 
+### System Reminders
+
+Use `system_reminders` when you want reminder system messages without writing custom lifecycle hooks.
+
+```python
+from agency_swarm import Agent, AfterEveryUserMessage, EveryNToolCalls
+
+agent = Agent(
+    name="SupportAgent",
+    instructions="Answer clearly and keep the user moving forward.",
+    system_reminders=[
+        AfterEveryUserMessage("Restate the next follow-up before answering."),
+        EveryNToolCalls(15, "Summarize progress before using more tools."),
+    ],
+)
+```
+
+These reminders are injected into the model input only. They are not saved into the main thread history.
+
+<Note>
+Use `system_reminders` for the common reminder cases. Keep `hooks` for advanced lifecycle behavior that falls outside the built-in reminder triggers.
+</Note>
+
 ### Conversation starters cache
 
 Conversation starters are the suggested prompts you see in the chat UI.

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -76,6 +76,7 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Schemas Folder *(optional)* | `schemas_folder` | Path to a directory containing openapi schema files in .json format. Schemas are automatically converted into FunctionTools. Default: `None` |
 | Validation Attempts *(optional)* | `validation_attempts` | Number of retries when an output guardrail trips. Default: `1` |
 | Raise Input Guardrail Error *(optional)* | `raise_input_guardrail_error` | If set to `True`, input guardrail errors raise an exception. If set to `False`, the guardrail message is returned as the agent's response. Default: `False` |
+| System Reminders *(optional)* | `system_reminders` | Injects transient system reminders before model calls. Use `AfterEveryUserMessage(...)` or `EveryNToolCalls(...)` for the common reminder cases without writing custom hooks. Default: `[]` |
 | Handoff Reminder *(optional)* | `handoff_reminder` | Replaces the default handoff reminder system message with a given string. Default: "Transfer completed. You are [recipient_agent_name]. Please continue the task." |
 | Include Search Results *(optional)* | `include_search_results` | Include search results in FileSearchTool output for citation extraction. Default: `False` |
 | Include Web Search Sources *(optional)* | `include_web_search_sources` | Include source URLs from WebSearchTool calls. Default: `True` |

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -76,7 +76,7 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Schemas Folder *(optional)* | `schemas_folder` | Path to a directory containing openapi schema files in .json format. Schemas are automatically converted into FunctionTools. Default: `None` |
 | Validation Attempts *(optional)* | `validation_attempts` | Number of retries when an output guardrail trips. Default: `1` |
 | Raise Input Guardrail Error *(optional)* | `raise_input_guardrail_error` | If set to `True`, input guardrail errors raise an exception. If set to `False`, the guardrail message is returned as the agent's response. Default: `False` |
-| System Reminders *(optional)* | `system_reminders` | Injects transient system reminders before model calls. Use `AfterEveryUserMessage(...)` or `EveryNToolCalls(...)` for the common reminder cases without writing custom hooks. Default: `[]` |
+| System Reminders *(optional)* | `system_reminders` | Injects transient system reminders before model calls. Start with `AfterEveryUserMessage("...")`, then add `EveryNToolCalls(...)` if you need checkpoints. Default: `[]` |
 | Handoff Reminder *(optional)* | `handoff_reminder` | Replaces the default handoff reminder system message with a given string. Default: "Transfer completed. You are [recipient_agent_name]. Please continue the task." |
 | Include Search Results *(optional)* | `include_search_results` | Include search results in FileSearchTool output for citation extraction. Default: `False` |
 | Include Web Search Sources *(optional)* | `include_web_search_sources` | Include source URLs from WebSearchTool calls. Default: `True` |

--- a/docs/references/api.mdx
+++ b/docs/references/api.mdx
@@ -291,6 +291,7 @@ class Agent(BaseAgent[MasterContext]):
             include_web_search_sources (bool): Include source URLs for WebSearchTool output (default True)
             validation_attempts (int): Number of retries when output guardrails trigger (default 1)
             raise_input_guardrail_error (bool): Controls input guardrail behavior—False enables non-strict mode (guidance as assistant message), True enables strict mode (raises exceptions). Default: False
+            system_reminders (list[SystemReminder] | None): Transient reminder configs injected before model calls
             handoff_reminder (str | None): Custom reminder text when handing off to another agent
             model (str | Model | None): Model identifier; defaults to agents SDK configuration
             model_settings (ModelSettings | None): Model configuration overrides
@@ -318,6 +319,7 @@ class Agent(BaseAgent[MasterContext]):
 - **`include_web_search_sources`** (bool): Whether WebSearchTool responses include source URLs
 - **`validation_attempts`** (int): Retry count for output guardrail enforcement
 - **`raise_input_guardrail_error`** (bool): Controls input guardrail mode—False for non-strict (guidance as assistant), True for strict (raises exceptions).
+- **`system_reminders`** (list[SystemReminder]): Transient reminder configs for per-user-message and per-tool-call reminders
 - **`handoff_reminder`** (str | None): Custom reminder appended to handoff prompts
 - **`tool_concurrency_manager`** (ToolConcurrencyManager): Coordinates concurrent tool execution
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ This directory contains runnable examples demonstrating key features of Agency S
 ## Core Functionality
 - **`multi_agent_workflow.py`** – Multi-agent collaboration with validation patterns
 - **`agency_context.py`** – Sharing data between agents using agency context
+- **`system_reminders.py`** – First-class `system_reminders` fed by agency context
 - **`streaming.py`** – Real-time streaming responses
 - **`guardrails.py`** – Input and output guardrails
 - **`custom_persistence.py`** – Chat history persistence between sessions

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This directory contains runnable examples demonstrating key features of Agency S
 ## Core Functionality
 - **`multi_agent_workflow.py`** – Multi-agent collaboration with validation patterns
 - **`agency_context.py`** – Sharing data between agents using agency context
-- **`system_reminders.py`** – First-class `system_reminders` fed by agency context
+- **`system_reminders.py`** – Beginner-friendly first `system_reminders` setup
 - **`streaming.py`** – Real-time streaming responses
 - **`guardrails.py`** – Input and output guardrails
 - **`custom_persistence.py`** – Chat history persistence between sessions

--- a/examples/system_reminders.py
+++ b/examples/system_reminders.py
@@ -1,0 +1,229 @@
+"""
+System Reminders Example
+
+This example shows how to:
+- store reminder data in agency context
+- configure first-class Agent system reminders
+- inject a reminder after each new user message
+- inject a stronger reminder after every 15 tool calls
+
+Run:
+    uv run python examples/system_reminders.py
+
+If OPENAI_API_KEY is not set, the script runs a dry preview that prints the
+structured input items that the configured reminders would inject.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+# Path setup for standalone examples
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from agency_swarm import (  # noqa: E402
+    AfterEveryUserMessage,
+    Agency,
+    Agent,
+    EveryNToolCalls,
+    MasterContext,
+    ModelSettings,
+    RunContextWrapper,
+    function_tool,
+)
+
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger("agency_swarm").setLevel(logging.WARNING)
+
+
+def _format_follow_up(user_context: dict[str, Any]) -> str:
+    follow_up = user_context.get("follow_up")
+    if not isinstance(follow_up, dict):
+        return "None recorded yet."
+
+    owner = follow_up.get("owner", "unknown owner")
+    promise = follow_up.get("promise", "unknown task")
+    due = follow_up.get("due", "no due date")
+    status = follow_up.get("status", "open")
+    return f"{promise} (owner: {owner}, due: {due}, status: {status})"
+
+
+def _store_follow_up(user_context: dict[str, Any], owner: str, promise: str, due: str) -> str:
+    user_context["follow_up"] = {
+        "owner": owner,
+        "promise": promise,
+        "due": due,
+        "status": "open",
+    }
+    return f"Saved follow-up: {promise} (owner: {owner}, due: {due})."
+
+
+def _complete_follow_up(user_context: dict[str, Any]) -> str:
+    follow_up = user_context.get("follow_up")
+    if not isinstance(follow_up, dict):
+        return "No follow-up is stored yet."
+
+    follow_up["status"] = "done"
+    return f"Marked follow-up as done: {follow_up['promise']}."
+
+
+@function_tool
+async def save_follow_up(
+    ctx: RunContextWrapper[MasterContext],
+    owner: str,
+    promise: str,
+    due: str,
+) -> str:
+    """Store a follow-up item in agency context."""
+    return _store_follow_up(ctx.context.user_context, owner, promise, due)
+
+
+@function_tool
+async def inspect_follow_up(ctx: RunContextWrapper[MasterContext]) -> str:
+    """Inspect the reminder state currently stored in agency context."""
+    return f"Current follow-up: {_format_follow_up(ctx.context.user_context)}"
+
+
+@function_tool
+async def complete_follow_up(ctx: RunContextWrapper[MasterContext]) -> str:
+    """Mark the stored follow-up as complete."""
+    return _complete_follow_up(ctx.context.user_context)
+
+
+def build_follow_up_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
+    """Render the per-user-message reminder from agency context."""
+    user_context = ctx.context.user_context
+    base_reminder = str(
+        user_context.get(
+            "base_turn_reminder",
+            "Before answering, restate the next follow-up and keep the reply actionable.",
+        )
+    )
+    return "\n".join(
+        [
+            base_reminder,
+            f"Stored follow-up: {_format_follow_up(user_context)}",
+        ]
+    )
+
+
+def build_checkpoint_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
+    """Render the tool-call checkpoint reminder from agency context."""
+    return "\n".join(
+        [
+            "Checkpoint reminder: 15 tool calls have happened since the last checkpoint.",
+            f"Stored follow-up: {_format_follow_up(ctx.context.user_context)}",
+            "Summarize progress before using more tools.",
+        ]
+    )
+
+
+def preview_turn_input(user_message: str, agency: Agency, include_checkpoint: bool = False) -> list[dict[str, str]]:
+    """Preview the reminder-enriched input items for this example."""
+    agent = agency.agents["ReminderAgent"]
+    preview_context = RunContextWrapper(
+        MasterContext(
+            thread_manager=agency.thread_manager,
+            agents=agency.agents,
+            user_context=agency.user_context,
+            current_agent_name=agent.name,
+        )
+    )
+    preview_items: list[dict[str, str]] = []
+    for reminder in agent.system_reminders:
+        if isinstance(reminder, AfterEveryUserMessage):
+            preview_items.append({"role": "system", "content": reminder.render(preview_context, agent)})
+        if include_checkpoint and isinstance(reminder, EveryNToolCalls):
+            preview_items.append({"role": "system", "content": reminder.render(preview_context, agent)})
+    preview_items.append({"role": "user", "content": user_message})
+    return preview_items
+
+
+def create_demo_agency() -> Agency:
+    reminder_agent = Agent(
+        name="ReminderAgent",
+        instructions=(
+            "You help with customer follow-ups. "
+            "When a user asks to save, inspect, or complete a follow-up, always use the matching tool first. "
+            "Then answer with a concise update that reflects the reminder system message."
+        ),
+        tools=[save_follow_up, inspect_follow_up, complete_follow_up],
+        model_settings=ModelSettings(temperature=0.0),
+        system_reminders=[
+            AfterEveryUserMessage(build_follow_up_reminder),
+            EveryNToolCalls(15, build_checkpoint_reminder),
+        ],
+    )
+
+    return Agency(
+        reminder_agent,
+        user_context={
+            "base_turn_reminder": "Before answering, mention the next follow-up and keep the response actionable.",
+        },
+    )
+
+
+def _print_turn_preview(title: str, user_message: str, agency: Agency, include_checkpoint: bool = False) -> None:
+    print(f"\n{title}")
+    print(json.dumps(preview_turn_input(user_message, agency, include_checkpoint=include_checkpoint), indent=2))
+
+
+def run_dry_preview() -> None:
+    """Preview the reminder-enriched input items without calling the API."""
+    agency = create_demo_agency()
+
+    print("System Reminders Demo (dry preview)")
+    print("=" * 40)
+    print("OPENAI_API_KEY is not set, so this run prints the structured input items only.")
+
+    _print_turn_preview(
+        "Turn 1: before any tool calls",
+        "Save a follow-up for Acme: send the renewal deck by Friday. Ava owns it.",
+        agency,
+    )
+
+    print("\nSimulating one tool call by updating agency context...")
+    print(_store_follow_up(agency.user_context, owner="Ava", promise="Send the renewal deck", due="Friday"))
+
+    _print_turn_preview(
+        "Turn 2: reminder after context changes",
+        "What follow-up is still open?",
+        agency,
+    )
+
+    print("\nSimulating the optional 15-tool-call checkpoint...")
+    _print_turn_preview(
+        "Turn 3: checkpoint reminder",
+        "Draft a short customer update for the follow-up.",
+        agency,
+        include_checkpoint=True,
+    )
+
+
+async def run_live_demo() -> None:
+    """Run the reminder pattern against a live model."""
+    agency = create_demo_agency()
+
+    print("System Reminders Demo")
+    print("=" * 30)
+
+    turns = [
+        "Save a follow-up for Acme: send the renewal deck by Friday. Ava owns it.",
+        "What follow-up is still open?",
+        "Draft a short customer update for the follow-up.",
+    ]
+
+    for index, user_message in enumerate(turns, start=1):
+        print(f"\nTurn {index}")
+        response = await agency.get_response(user_message)
+        print(response.final_output)
+
+
+if __name__ == "__main__":
+    if os.getenv("OPENAI_API_KEY"):
+        asyncio.run(run_live_demo())
+    else:
+        run_dry_preview()

--- a/examples/system_reminders.py
+++ b/examples/system_reminders.py
@@ -1,229 +1,60 @@
 """
 System Reminders Example
 
-This example shows how to:
-- store reminder data in agency context
-- configure first-class Agent system reminders
-- inject a reminder after each new user message
-- inject a stronger reminder after every 15 tool calls
+The simplest way to add a reminder before every reply.
 
 Run:
     uv run python examples/system_reminders.py
-
-If OPENAI_API_KEY is not set, the script runs a dry preview that prints the
-structured input items that the configured reminders would inject.
 """
 
 import asyncio
-import json
-import logging
 import os
 import sys
-from typing import Any
 
 # Path setup for standalone examples
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from agency_swarm import (  # noqa: E402
-    AfterEveryUserMessage,
-    Agency,
-    Agent,
-    EveryNToolCalls,
-    MasterContext,
-    ModelSettings,
-    RunContextWrapper,
-    function_tool,
-)
+from agency_swarm import AfterEveryUserMessage, Agency, Agent  # noqa: E402
 
-logging.basicConfig(level=logging.WARNING)
-logging.getLogger("agency_swarm").setLevel(logging.WARNING)
-
-
-def _format_follow_up(user_context: dict[str, Any]) -> str:
-    follow_up = user_context.get("follow_up")
-    if not isinstance(follow_up, dict):
-        return "None recorded yet."
-
-    owner = follow_up.get("owner", "unknown owner")
-    promise = follow_up.get("promise", "unknown task")
-    due = follow_up.get("due", "no due date")
-    status = follow_up.get("status", "open")
-    return f"{promise} (owner: {owner}, due: {due}, status: {status})"
-
-
-def _store_follow_up(user_context: dict[str, Any], owner: str, promise: str, due: str) -> str:
-    user_context["follow_up"] = {
-        "owner": owner,
-        "promise": promise,
-        "due": due,
-        "status": "open",
-    }
-    return f"Saved follow-up: {promise} (owner: {owner}, due: {due})."
-
-
-def _complete_follow_up(user_context: dict[str, Any]) -> str:
-    follow_up = user_context.get("follow_up")
-    if not isinstance(follow_up, dict):
-        return "No follow-up is stored yet."
-
-    follow_up["status"] = "done"
-    return f"Marked follow-up as done: {follow_up['promise']}."
-
-
-@function_tool
-async def save_follow_up(
-    ctx: RunContextWrapper[MasterContext],
-    owner: str,
-    promise: str,
-    due: str,
-) -> str:
-    """Store a follow-up item in agency context."""
-    return _store_follow_up(ctx.context.user_context, owner, promise, due)
-
-
-@function_tool
-async def inspect_follow_up(ctx: RunContextWrapper[MasterContext]) -> str:
-    """Inspect the reminder state currently stored in agency context."""
-    return f"Current follow-up: {_format_follow_up(ctx.context.user_context)}"
-
-
-@function_tool
-async def complete_follow_up(ctx: RunContextWrapper[MasterContext]) -> str:
-    """Mark the stored follow-up as complete."""
-    return _complete_follow_up(ctx.context.user_context)
-
-
-def build_follow_up_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
-    """Render the per-user-message reminder from agency context."""
-    user_context = ctx.context.user_context
-    base_reminder = str(
-        user_context.get(
-            "base_turn_reminder",
-            "Before answering, restate the next follow-up and keep the reply actionable.",
-        )
-    )
-    return "\n".join(
-        [
-            base_reminder,
-            f"Stored follow-up: {_format_follow_up(user_context)}",
-        ]
-    )
-
-
-def build_checkpoint_reminder(ctx: RunContextWrapper[MasterContext], _agent: Agent) -> str:
-    """Render the tool-call checkpoint reminder from agency context."""
-    return "\n".join(
-        [
-            "Checkpoint reminder: 15 tool calls have happened since the last checkpoint.",
-            f"Stored follow-up: {_format_follow_up(ctx.context.user_context)}",
-            "Summarize progress before using more tools.",
-        ]
-    )
-
-
-def preview_turn_input(user_message: str, agency: Agency, include_checkpoint: bool = False) -> list[dict[str, str]]:
-    """Preview the reminder-enriched input items for this example."""
-    agent = agency.agents["ReminderAgent"]
-    preview_context = RunContextWrapper(
-        MasterContext(
-            thread_manager=agency.thread_manager,
-            agents=agency.agents,
-            user_context=agency.user_context,
-            current_agent_name=agent.name,
-        )
-    )
-    preview_items: list[dict[str, str]] = []
-    for reminder in agent.system_reminders:
-        if isinstance(reminder, AfterEveryUserMessage):
-            preview_items.append({"role": "system", "content": reminder.render(preview_context, agent)})
-        if include_checkpoint and isinstance(reminder, EveryNToolCalls):
-            preview_items.append({"role": "system", "content": reminder.render(preview_context, agent)})
-    preview_items.append({"role": "user", "content": user_message})
-    return preview_items
+REMINDER_TEXT = "Before replying, end with one clear next step."
 
 
 def create_demo_agency() -> Agency:
     reminder_agent = Agent(
         name="ReminderAgent",
-        instructions=(
-            "You help with customer follow-ups. "
-            "When a user asks to save, inspect, or complete a follow-up, always use the matching tool first. "
-            "Then answer with a concise update that reflects the reminder system message."
-        ),
-        tools=[save_follow_up, inspect_follow_up, complete_follow_up],
-        model_settings=ModelSettings(temperature=0.0),
-        system_reminders=[
-            AfterEveryUserMessage(build_follow_up_reminder),
-            EveryNToolCalls(15, build_checkpoint_reminder),
-        ],
+        instructions="You are a helpful assistant. Keep replies short, friendly, and practical.",
+        system_reminders=[AfterEveryUserMessage(REMINDER_TEXT)],
     )
-
-    return Agency(
-        reminder_agent,
-        user_context={
-            "base_turn_reminder": "Before answering, mention the next follow-up and keep the response actionable.",
-        },
-    )
+    return Agency(reminder_agent)
 
 
-def _print_turn_preview(title: str, user_message: str, agency: Agency, include_checkpoint: bool = False) -> None:
-    print(f"\n{title}")
-    print(json.dumps(preview_turn_input(user_message, agency, include_checkpoint=include_checkpoint), indent=2))
-
-
-def run_dry_preview() -> None:
-    """Preview the reminder-enriched input items without calling the API."""
-    agency = create_demo_agency()
-
-    print("System Reminders Demo (dry preview)")
+def show_setup() -> None:
+    print("System Reminders Demo")
     print("=" * 40)
-    print("OPENAI_API_KEY is not set, so this run prints the structured input items only.")
-
-    _print_turn_preview(
-        "Turn 1: before any tool calls",
-        "Save a follow-up for Acme: send the renewal deck by Friday. Ava owns it.",
-        agency,
-    )
-
-    print("\nSimulating one tool call by updating agency context...")
-    print(_store_follow_up(agency.user_context, owner="Ava", promise="Send the renewal deck", due="Friday"))
-
-    _print_turn_preview(
-        "Turn 2: reminder after context changes",
-        "What follow-up is still open?",
-        agency,
-    )
-
-    print("\nSimulating the optional 15-tool-call checkpoint...")
-    _print_turn_preview(
-        "Turn 3: checkpoint reminder",
-        "Draft a short customer update for the follow-up.",
-        agency,
-        include_checkpoint=True,
-    )
+    print("This example adds one reminder before every user message:")
+    print(f"- {REMINDER_TEXT}")
+    print("\nSet OPENAI_API_KEY to run the live demo.")
 
 
-async def run_live_demo() -> None:
-    """Run the reminder pattern against a live model."""
+async def run_demo() -> None:
     agency = create_demo_agency()
 
     print("System Reminders Demo")
-    print("=" * 30)
+    print("=" * 40)
 
     turns = [
-        "Save a follow-up for Acme: send the renewal deck by Friday. Ava owns it.",
-        "What follow-up is still open?",
-        "Draft a short customer update for the follow-up.",
+        "I want to start a small balcony herb garden.",
+        "What should I do first?",
     ]
 
-    for index, user_message in enumerate(turns, start=1):
-        print(f"\nTurn {index}")
+    for user_message in turns:
+        print(f"\nUser: {user_message}")
         response = await agency.get_response(user_message)
-        print(response.final_output)
+        print(f"Agent: {response.final_output}")
 
 
 if __name__ == "__main__":
     if os.getenv("OPENAI_API_KEY"):
-        asyncio.run(run_live_demo())
+        asyncio.run(run_demo())
     else:
-        run_dry_preview()
+        show_setup()

--- a/src/agency_swarm/__init__.py
+++ b/src/agency_swarm/__init__.py
@@ -60,6 +60,7 @@ from .context import MasterContext  # noqa: E402
 from .hooks import PersistenceHooks  # noqa: E402
 from .integrations.fastapi import run_fastapi  # noqa: E402
 from .integrations.mcp_server import run_mcp  # noqa: E402
+from .reminders import AfterEveryUserMessage, EveryNToolCalls, SystemReminder  # noqa: E402
 from .tools import (  # noqa: E402
     BaseTool,
     CodeInterpreter,
@@ -101,6 +102,8 @@ __all__ = [
     "Agent",
     "Agency",
     "AgencyContext",
+    "AfterEveryUserMessage",
+    "EveryNToolCalls",
     "StreamingRunResponse",
     "BaseTool",
     "MasterContext",
@@ -161,6 +164,7 @@ __all__ = [
     "Query",
     "Body",
     "ResponseIncludable",
+    "SystemReminder",
     "ToolOutputText",
     "ToolOutputTextDict",
     "ToolOutputImage",

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -41,8 +41,10 @@ from agency_swarm.agent.conversation_starters_cache import (
 )
 from agency_swarm.agent.execution_streaming import StreamingRunResponse
 from agency_swarm.agent.file_manager import AgentFileManager
+from agency_swarm.agent.system_reminders import prepare_agent_hooks, validate_system_reminders
 from agency_swarm.agent.tools import _attach_one_call_guard
 from agency_swarm.context import MasterContext
+from agency_swarm.reminders import SystemReminder
 from agency_swarm.tools.concurrency import ToolConcurrencyManager
 from agency_swarm.tools.mcp_manager import convert_mcp_servers_to_tools
 from agency_swarm.utils.dry_run import is_dry_run
@@ -89,6 +91,7 @@ class Agent(BaseAgent[MasterContext]):
     raise_input_guardrail_error: bool = False
     supports_outbound_communication: bool = True
     supports_framework_tool_wiring: bool = True
+    system_reminders: list[SystemReminder]
 
     # --- Internal State ---
     _associated_vector_store_id: str | None = None
@@ -134,6 +137,8 @@ class Agent(BaseAgent[MasterContext]):
             validation_attempts (int): Number of retries when an output guardrail trips. Defaults to 1.
             raise_input_guardrail_error (bool): Whether to raise input guardrail errors as exceptions.
                 Defaults to False.
+            system_reminders (list[SystemReminder] | None): Transient reminder configs injected before model calls.
+                Supports reminders after each new user message and after every N tool calls.
             handoff_reminder (str | None): Custom reminder for handoffs.
                 Defaults to `Transfer completed. You are {recipient_agent_name}. Please continue the task.`
 
@@ -189,6 +194,13 @@ class Agent(BaseAgent[MasterContext]):
 
         # Remove description from base_agent_params if it was added for Swarm Agent
         base_agent_params.pop("description", None)
+        system_reminders = validate_system_reminders(current_agent_params.get("system_reminders"))
+        user_hooks = base_agent_params.get("hooks")
+        prepared_hooks = prepare_agent_hooks(user_hooks, system_reminders)
+        if prepared_hooks is None:
+            base_agent_params.pop("hooks", None)
+        else:
+            base_agent_params["hooks"] = prepared_hooks
 
         # Initialize base agent
         super().__init__(**base_agent_params)
@@ -217,6 +229,7 @@ class Agent(BaseAgent[MasterContext]):
         self.supports_framework_tool_wiring = bool(
             current_agent_params.get("supports_framework_tool_wiring", self.supports_framework_tool_wiring)
         )
+        self.system_reminders = system_reminders
         self.handoff_reminder = current_agent_params.get("handoff_reminder")
 
         # Internal state

--- a/src/agency_swarm/agent/system_reminders.py
+++ b/src/agency_swarm/agent/system_reminders.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from agents import Agent as SDKAgent, AgentHookContext, AgentHooks, RunContextWrapper, TResponseInputItem
+from agents.items import ModelResponse
+
+from agency_swarm.context import MasterContext
+from agency_swarm.reminders import AfterEveryUserMessage, EveryNToolCalls, SystemReminder
+
+if TYPE_CHECKING:
+    from agents.tool import Tool
+
+    from agency_swarm.agent.core import Agent
+
+
+class CompositeAgentHooks(AgentHooks[MasterContext]):
+    """Run multiple agent hook implementations in sequence."""
+
+    def __init__(self, hooks: list[AgentHooks[MasterContext]]) -> None:
+        self._hooks = tuple(hooks)
+
+    async def on_start(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any]) -> None:
+        for hook in self._hooks:
+            await hook.on_start(context, agent)
+
+    async def on_end(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any], output: object) -> None:
+        for hook in self._hooks:
+            await hook.on_end(context, agent, output)
+
+    async def on_handoff(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[Any],
+        source: SDKAgent[Any],
+    ) -> None:
+        for hook in self._hooks:
+            await hook.on_handoff(context, agent, source)
+
+    async def on_tool_start(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[Any],
+        tool: Tool,
+    ) -> None:
+        for hook in self._hooks:
+            await hook.on_tool_start(context, agent, tool)
+
+    async def on_tool_end(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        for hook in self._hooks:
+            await hook.on_tool_end(context, agent, tool, result)
+
+    async def on_llm_start(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[MasterContext],
+        system_prompt: str | None,
+        input_items: list[TResponseInputItem],
+    ) -> None:
+        for hook in self._hooks:
+            await hook.on_llm_start(context, agent, system_prompt, input_items)
+
+    async def on_llm_end(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[MasterContext],
+        response: ModelResponse,
+    ) -> None:
+        for hook in self._hooks:
+            await hook.on_llm_end(context, agent, response)
+
+
+class SystemReminderHooks(AgentHooks[MasterContext]):
+    """Internal hook implementation for first-class Agent system reminders."""
+
+    def __init__(self, reminders: list[SystemReminder]) -> None:
+        self._user_turn_reminders = [reminder for reminder in reminders if isinstance(reminder, AfterEveryUserMessage)]
+        self._tool_call_reminders = [reminder for reminder in reminders if isinstance(reminder, EveryNToolCalls)]
+        self._run_state: dict[str, _RunReminderState] = {}
+
+    async def on_start(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any]) -> None:
+        if not self._should_stage_user_turn_reminders(context, agent):
+            return
+
+        state = self._get_state(context)
+        if state.user_turn_reminders_staged:
+            return
+
+        swarm_agent = cast("Agent", agent)
+        for reminder in self._user_turn_reminders:
+            state.pending_messages.append(reminder.render(context, swarm_agent))
+        state.user_turn_reminders_staged = True
+
+    async def on_end(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any], output: object) -> None:
+        self._run_state.pop(self._resolve_run_key(context), None)
+
+    async def on_tool_end(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[Any],
+        tool: Tool,
+        result: str,
+    ) -> None:
+        if not self._tool_call_reminders:
+            return
+
+        state = self._get_state(context)
+        swarm_agent = cast("Agent", agent)
+        for index, reminder in enumerate(self._tool_call_reminders):
+            current_count = state.tool_call_counts.get(index, 0) + 1
+            if current_count >= reminder.tool_calls:
+                state.pending_messages.append(reminder.render(context, swarm_agent))
+                state.tool_call_counts[index] = 0
+            else:
+                state.tool_call_counts[index] = current_count
+
+    async def on_llm_start(
+        self,
+        context: RunContextWrapper[MasterContext],
+        agent: SDKAgent[MasterContext],
+        system_prompt: str | None,
+        input_items: list[TResponseInputItem],
+    ) -> None:
+        state = self._get_state(context)
+        if not state.pending_messages:
+            return
+
+        pending_messages = list(state.pending_messages)
+        state.pending_messages.clear()
+        for reminder_text in reversed(pending_messages):
+            input_items.insert(0, _build_system_message(reminder_text))
+
+    def _get_state(self, context: RunContextWrapper[MasterContext]) -> _RunReminderState:
+        run_key = self._resolve_run_key(context)
+        state = self._run_state.get(run_key)
+        if state is None:
+            state = _RunReminderState()
+            self._run_state[run_key] = state
+        return state
+
+    def _resolve_run_key(self, context: RunContextWrapper[MasterContext]) -> str:
+        run_id = context.context._current_agent_run_id
+        if isinstance(run_id, str) and run_id:
+            return run_id
+        return f"context-{id(context.context)}"
+
+    def _should_stage_user_turn_reminders(
+        self,
+        context: AgentHookContext[MasterContext],
+        agent: SDKAgent[Any],
+    ) -> bool:
+        if not self._user_turn_reminders:
+            return False
+        if context.context._parent_run_id is not None:
+            return False
+        if context.context.current_agent_name != agent.name:
+            return False
+        if not context.turn_input:
+            return False
+
+        last_item = context.turn_input[-1]
+        return _is_user_message(last_item)
+
+
+def prepare_agent_hooks(
+    user_hooks: AgentHooks[MasterContext] | None,
+    system_reminders: list[SystemReminder],
+) -> AgentHooks[MasterContext] | None:
+    """Compose internal reminder hooks with user-provided Agent hooks."""
+    reminder_hooks = SystemReminderHooks(system_reminders) if system_reminders else None
+    if reminder_hooks and user_hooks:
+        return CompositeAgentHooks([reminder_hooks, user_hooks])
+    if reminder_hooks:
+        return reminder_hooks
+    return user_hooks
+
+
+def validate_system_reminders(value: object) -> list[SystemReminder]:
+    """Validate and normalize the public Agent(system_reminders=...) value."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise TypeError("system_reminders must be a list of reminder configs.")
+    for reminder in value:
+        if not isinstance(reminder, SystemReminder):
+            raise TypeError("system_reminders entries must inherit from SystemReminder.")
+    return list(value)
+
+
+def _build_system_message(text: str) -> TResponseInputItem:
+    return {"role": "system", "content": text}
+
+
+def _is_user_message(item: TResponseInputItem) -> bool:
+    if not isinstance(item, dict):
+        return False
+    return item.get("role") == "user"
+
+
+@dataclass(slots=True)
+class _RunReminderState:
+    pending_messages: list[str] = field(default_factory=list)
+    tool_call_counts: dict[int, int] = field(default_factory=dict)
+    user_turn_reminders_staged: bool = False

--- a/src/agency_swarm/reminders.py
+++ b/src/agency_swarm/reminders.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from agents import RunContextWrapper
+
+from agency_swarm.context import MasterContext
+
+if TYPE_CHECKING:
+    from agency_swarm.agent.core import Agent
+
+type ReminderMessage = str | Callable[[RunContextWrapper[MasterContext], "Agent"], str]
+
+
+class SystemReminder:
+    """Base reminder configuration shared by public reminder triggers."""
+
+    message: ReminderMessage
+
+    def _validate_message(self) -> None:
+        if isinstance(self.message, str):
+            return
+        if callable(self.message):
+            return
+        raise TypeError("system_reminders message must be a string or callable.")
+
+    def render(self, context: RunContextWrapper[MasterContext], agent: Agent) -> str:
+        """Render the reminder message for the current run context."""
+        if isinstance(self.message, str):
+            return self.message
+
+        rendered = self.message(context, agent)
+        if not isinstance(rendered, str):
+            raise TypeError("system_reminders message callables must return a string.")
+        return rendered
+
+
+@dataclass(frozen=True, slots=True)
+class AfterEveryUserMessage(SystemReminder):
+    """Inject a transient reminder before the first LLM call of a user turn."""
+
+    message: ReminderMessage
+
+    def __post_init__(self) -> None:
+        self._validate_message()
+
+
+@dataclass(frozen=True, slots=True)
+class EveryNToolCalls(SystemReminder):
+    """Inject a transient reminder after every N tool calls on the next LLM call."""
+
+    tool_calls: int
+    message: ReminderMessage
+
+    def __post_init__(self) -> None:
+        self._validate_message()
+        if not isinstance(self.tool_calls, int):
+            raise TypeError("EveryNToolCalls.tool_calls must be an integer.")
+        if self.tool_calls <= 0:
+            raise ValueError("EveryNToolCalls.tool_calls must be greater than 0.")

--- a/tests/test_agent_modules/test_reminders.py
+++ b/tests/test_agent_modules/test_reminders.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import AsyncIterator
+
+import pytest
+from agents import (
+    AgentHookContext,
+    AgentHooks,
+    ModelSettings,
+    RunContextWrapper,
+    Tool,
+    TResponseInputItem,
+    function_tool,
+)
+from agents.agent_output import AgentOutputSchemaBase
+from agents.handoffs import Handoff as RawSDKHandoff
+from agents.items import ModelResponse, TResponseStreamEvent
+from agents.models.interface import Model, ModelTracing
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+
+from agency_swarm import AfterEveryUserMessage, Agency, Agent, EveryNToolCalls, MasterContext
+from agency_swarm.tools import Handoff
+from tests.deterministic_model import (
+    DeterministicModel,
+    _build_message_response,
+    _build_tool_call_response,
+    _stream_text_events,
+)
+
+
+def test_every_n_tool_calls_rejects_non_positive_threshold() -> None:
+    with pytest.raises(ValueError, match="greater than 0"):
+        EveryNToolCalls(0, "Checkpoint reminder")
+
+
+class _TrackingHook(AgentHooks[MasterContext]):
+    def __init__(self) -> None:
+        self.started = False
+
+    async def on_start(self, context: AgentHookContext[MasterContext], agent: Agent) -> None:
+        self.started = True
+
+
+class _RecordingDeterministicModel(DeterministicModel):
+    def __init__(self, default_response: str = "OK") -> None:
+        super().__init__(default_response=default_response)
+        self.recorded_inputs: list[list[TResponseInputItem]] = []
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[RawSDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> ModelResponse:
+        if isinstance(input, list):
+            self.recorded_inputs.append(copy.deepcopy(input))
+        return await super().get_response(
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            prompt=prompt,
+        )
+
+
+class _TwoToolCallsModel(Model):
+    def __init__(self) -> None:
+        self.model = "test-two-tools"
+        self.recorded_inputs: list[list[TResponseInputItem]] = []
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[RawSDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> ModelResponse:
+        if not isinstance(input, list):
+            raise TypeError("This test model expects structured input items.")
+
+        self.recorded_inputs.append(copy.deepcopy(input))
+        tool_outputs = 0
+        for item in reversed(input):
+            if isinstance(item, dict) and item.get("role") == "user":
+                break
+            if isinstance(item, dict) and item.get("type") in {"function_call_output", "tool_call_output_item"}:
+                tool_outputs += 1
+        if tool_outputs < 2:
+            return _build_tool_call_response(tools[0].name, {})
+        return _build_message_response("done", self.model)
+
+    def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[RawSDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        return _stream_text_events("done", self.model)
+
+
+@function_tool
+async def inspect_follow_up(ctx: RunContextWrapper[MasterContext]) -> str:
+    """Return the stored follow-up for reminder tests."""
+    follow_up = ctx.context.user_context.get("follow_up", "none")
+    return f"Follow-up: {follow_up}"
+
+
+def _extract_text(item: TResponseInputItem) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    content = item.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                text_value = part.get("text")
+                if isinstance(text_value, str):
+                    parts.append(text_value)
+        if parts:
+            return "".join(parts)
+    return None
+
+
+def _contains_text(items: list[TResponseInputItem], expected: str) -> bool:
+    return any(expected in (_extract_text(item) or "") for item in items)
+
+
+@pytest.mark.asyncio
+async def test_system_reminders_compose_with_user_hooks() -> None:
+    tracking_hook = _TrackingHook()
+    model = _RecordingDeterministicModel()
+    agent = Agent(
+        name="ReminderAgent",
+        instructions="Answer briefly.",
+        hooks=tracking_hook,
+        model=model,
+        model_settings=ModelSettings(temperature=0.0),
+        system_reminders=[
+            AfterEveryUserMessage(lambda ctx, _agent: f"Follow-up: {ctx.context.user_context['follow_up']}")
+        ],
+    )
+    agency = Agency(agent, user_context={"follow_up": "Send the renewal deck"})
+
+    await agency.get_response("What should I do next?")
+
+    assert tracking_hook.started is True
+    assert _contains_text(model.recorded_inputs[0], "Follow-up: Send the renewal deck")
+
+
+@pytest.mark.asyncio
+async def test_after_every_user_message_is_transient_in_thread_history() -> None:
+    model = _RecordingDeterministicModel(default_response="Actionable reply")
+    agent = Agent(
+        name="ReminderAgent",
+        instructions="Answer briefly.",
+        model=model,
+        model_settings=ModelSettings(temperature=0.0),
+        system_reminders=[
+            AfterEveryUserMessage(lambda ctx, _agent: f"Stored follow-up: {ctx.context.user_context['follow_up']}")
+        ],
+    )
+    agency = Agency(agent, user_context={"follow_up": "Send the renewal deck"})
+
+    await agency.get_response("What follow-up is open?")
+
+    assert _contains_text(model.recorded_inputs[0], "Stored follow-up: Send the renewal deck")
+    history = agency.thread_manager.get_all_messages()
+    assert [message["role"] for message in history] == ["user", "assistant"]
+    assert not any("Stored follow-up:" in str(message.get("content", "")) for message in history)
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_injects_on_next_llm_call_and_resets() -> None:
+    model = _TwoToolCallsModel()
+    agent = Agent(
+        name="ReminderAgent",
+        instructions="Use the tool until the task is done.",
+        model=model,
+        model_settings=ModelSettings(temperature=0.0),
+        tools=[inspect_follow_up],
+        system_reminders=[EveryNToolCalls(2, "Checkpoint reminder")],
+    )
+    agency = Agency(agent, user_context={"follow_up": "Send the renewal deck"})
+
+    await agency.get_response("Handle task-1")
+    await agency.get_response("Handle task-2")
+
+    assert len(model.recorded_inputs) == 6
+    assert not _contains_text(model.recorded_inputs[0], "Checkpoint reminder")
+    assert not _contains_text(model.recorded_inputs[1], "Checkpoint reminder")
+    assert _contains_text(model.recorded_inputs[2], "Checkpoint reminder")
+    assert not _contains_text(model.recorded_inputs[3], "Checkpoint reminder")
+    assert not _contains_text(model.recorded_inputs[4], "Checkpoint reminder")
+    assert _contains_text(model.recorded_inputs[5], "Checkpoint reminder")
+
+
+@pytest.mark.asyncio
+async def test_after_every_user_message_skips_send_message_recipients() -> None:
+    coordinator = Agent(
+        name="Coordinator",
+        instructions="Delegate work to Worker when asked.",
+        model=DeterministicModel(),
+        model_settings=ModelSettings(temperature=0.0),
+    )
+    worker_model = _RecordingDeterministicModel(default_response="Worker done")
+    worker = Agent(
+        name="Worker",
+        instructions="Handle delegated tasks.",
+        model=worker_model,
+        model_settings=ModelSettings(temperature=0.0),
+        system_reminders=[AfterEveryUserMessage("Nested reminder")],
+    )
+    agency = Agency(coordinator, worker, communication_flows=[coordinator > worker])
+
+    await agency.get_response("Ask Worker to handle task-123", recipient_agent=coordinator)
+
+    assert worker_model.recorded_inputs
+    assert not _contains_text(worker_model.recorded_inputs[0], "Nested reminder")
+
+
+@pytest.mark.asyncio
+async def test_after_every_user_message_skips_handoff_recipients() -> None:
+    coordinator = Agent(
+        name="Coordinator",
+        instructions="Hand off work to Worker when asked.",
+        model=DeterministicModel(),
+        model_settings=ModelSettings(temperature=0.0),
+    )
+    worker_model = _RecordingDeterministicModel(default_response="Worker done")
+    worker = Agent(
+        name="Worker",
+        instructions="Handle handed-off tasks.",
+        model=worker_model,
+        model_settings=ModelSettings(temperature=0.0),
+        system_reminders=[AfterEveryUserMessage("Handoff reminder should not appear")],
+    )
+    agency = Agency(coordinator, worker, communication_flows=[(coordinator > worker, Handoff)])
+
+    await agency.get_response("Transfer to Worker and handle task-123", recipient_agent=coordinator)
+
+    assert worker_model.recorded_inputs
+    assert not _contains_text(worker_model.recorded_inputs[0], "Handoff reminder should not appear")

--- a/tests/test_agent_modules/test_system_reminders_example.py
+++ b/tests/test_agent_modules/test_system_reminders_example.py
@@ -1,0 +1,71 @@
+from agency_swarm import AfterEveryUserMessage, EveryNToolCalls, MasterContext, RunContextWrapper
+from examples.system_reminders import (
+    build_checkpoint_reminder,
+    build_follow_up_reminder,
+    create_demo_agency,
+    preview_turn_input,
+)
+
+
+def test_preview_turn_input_uses_agent_system_reminders() -> None:
+    agency = create_demo_agency()
+    agency.user_context["follow_up"] = {
+        "owner": "Ava",
+        "promise": "Send the renewal deck",
+        "due": "Friday",
+        "status": "open",
+    }
+
+    items = preview_turn_input("What follow-up is still open?", agency)
+
+    assert items[0]["role"] == "system"
+    assert "Send the renewal deck" in items[0]["content"]
+    assert items[1] == {"role": "user", "content": "What follow-up is still open?"}
+
+
+def test_demo_agency_configures_both_public_reminder_types() -> None:
+    agency = create_demo_agency()
+    reminder_agent = agency.agents["ReminderAgent"]
+
+    assert isinstance(reminder_agent.system_reminders[0], AfterEveryUserMessage)
+    assert isinstance(reminder_agent.system_reminders[1], EveryNToolCalls)
+
+
+def test_preview_checkpoint_renders_optional_tool_call_reminder() -> None:
+    agency = create_demo_agency()
+    agency.user_context["follow_up"] = {
+        "owner": "Ava",
+        "promise": "Send the renewal deck",
+        "due": "Friday",
+        "status": "open",
+    }
+
+    items = preview_turn_input("Draft a short customer update.", agency, include_checkpoint=True)
+
+    assert "Stored follow-up: Send the renewal deck" in items[0]["content"]
+    assert "Checkpoint reminder" in items[1]["content"]
+
+
+def test_public_reminder_renderers_read_agency_context() -> None:
+    agency = create_demo_agency()
+    agency.user_context["follow_up"] = {
+        "owner": "Ava",
+        "promise": "Send the renewal deck",
+        "due": "Friday",
+        "status": "open",
+    }
+    reminder_agent = agency.agents["ReminderAgent"]
+    preview_context = RunContextWrapper(
+        MasterContext(
+            thread_manager=agency.thread_manager,
+            agents=agency.agents,
+            user_context=agency.user_context,
+            current_agent_name=reminder_agent.name,
+        )
+    )
+
+    user_message_preview = build_follow_up_reminder(preview_context, reminder_agent)
+    checkpoint_preview = build_checkpoint_reminder(preview_context, reminder_agent)
+
+    assert "Send the renewal deck" in user_message_preview
+    assert "Checkpoint reminder" in checkpoint_preview

--- a/tests/test_agent_modules/test_system_reminders_example.py
+++ b/tests/test_agent_modules/test_system_reminders_example.py
@@ -1,71 +1,21 @@
-from agency_swarm import AfterEveryUserMessage, EveryNToolCalls, MasterContext, RunContextWrapper
-from examples.system_reminders import (
-    build_checkpoint_reminder,
-    build_follow_up_reminder,
-    create_demo_agency,
-    preview_turn_input,
-)
+from agency_swarm import AfterEveryUserMessage
+from examples.system_reminders import REMINDER_TEXT, create_demo_agency, show_setup
 
 
-def test_preview_turn_input_uses_agent_system_reminders() -> None:
-    agency = create_demo_agency()
-    agency.user_context["follow_up"] = {
-        "owner": "Ava",
-        "promise": "Send the renewal deck",
-        "due": "Friday",
-        "status": "open",
-    }
-
-    items = preview_turn_input("What follow-up is still open?", agency)
-
-    assert items[0]["role"] == "system"
-    assert "Send the renewal deck" in items[0]["content"]
-    assert items[1] == {"role": "user", "content": "What follow-up is still open?"}
-
-
-def test_demo_agency_configures_both_public_reminder_types() -> None:
+def test_demo_agency_configures_one_beginner_reminder() -> None:
     agency = create_demo_agency()
     reminder_agent = agency.agents["ReminderAgent"]
 
+    assert reminder_agent.tools == []
+    assert len(reminder_agent.system_reminders) == 1
     assert isinstance(reminder_agent.system_reminders[0], AfterEveryUserMessage)
-    assert isinstance(reminder_agent.system_reminders[1], EveryNToolCalls)
+    assert reminder_agent.system_reminders[0].message == REMINDER_TEXT
 
 
-def test_preview_checkpoint_renders_optional_tool_call_reminder() -> None:
-    agency = create_demo_agency()
-    agency.user_context["follow_up"] = {
-        "owner": "Ava",
-        "promise": "Send the renewal deck",
-        "due": "Friday",
-        "status": "open",
-    }
+def test_show_setup_explains_the_simple_starting_point(capsys) -> None:
+    show_setup()
+    output = capsys.readouterr().out
 
-    items = preview_turn_input("Draft a short customer update.", agency, include_checkpoint=True)
-
-    assert "Stored follow-up: Send the renewal deck" in items[0]["content"]
-    assert "Checkpoint reminder" in items[1]["content"]
-
-
-def test_public_reminder_renderers_read_agency_context() -> None:
-    agency = create_demo_agency()
-    agency.user_context["follow_up"] = {
-        "owner": "Ava",
-        "promise": "Send the renewal deck",
-        "due": "Friday",
-        "status": "open",
-    }
-    reminder_agent = agency.agents["ReminderAgent"]
-    preview_context = RunContextWrapper(
-        MasterContext(
-            thread_manager=agency.thread_manager,
-            agents=agency.agents,
-            user_context=agency.user_context,
-            current_agent_name=reminder_agent.name,
-        )
-    )
-
-    user_message_preview = build_follow_up_reminder(preview_context, reminder_agent)
-    checkpoint_preview = build_checkpoint_reminder(preview_context, reminder_agent)
-
-    assert "Send the renewal deck" in user_message_preview
-    assert "Checkpoint reminder" in checkpoint_preview
+    assert "System Reminders Demo" in output
+    assert REMINDER_TEXT in output
+    assert "OPENAI_API_KEY" in output


### PR DESCRIPTION
## Summary
- add first-class `system_reminders` to `Agent` with public reminder configs and internal hook composition
- keep reminder injection transient, out of persisted thread history, with triggers for each top-level user turn and every N tool calls
- add docs, example, tests, and AGENTS guidance updates for the new reminder flow
