### PR TITLE
fix: contain python bridge output during tui

### DIFF
--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -373,13 +373,12 @@ def _contain_bridge_output(path: Path | None):
         return
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    owner = threading.get_ident()
     original = builtins.print
     lock = threading.Lock()
 
     def print_wrapper(*args, **kwargs):
         file = kwargs.get("file")
-        if threading.get_ident() != owner or file not in (None, sys.stdout, sys.stderr):
+        if file not in (None, sys.stdout, sys.stderr):
             return original(*args, **kwargs)
 
         end = kwargs.get("end", "\n")

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -14,7 +14,7 @@ import tarfile
 import tempfile
 import threading
 import time
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager, redirect_stderr, redirect_stdout, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, TypedDict
@@ -93,22 +93,23 @@ def start_tui(agency, show_reasoning: bool | None = None, reload: bool = True) -
 
     command = _command()
 
-    try:
-        server = _start_server(agency)
-    except Exception as exc:
-        raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
+    with _contain_bridge_output():
+        try:
+            server = _start_server(agency)
+        except Exception as exc:
+            raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
 
-    try:
-        result = subprocess.run(
-            [*command, *_command_args()],
-            cwd=os.getcwd(),
-            env=_env(server.port, _agency_id(agency)),
-            check=False,
-        )
-    except OSError as exc:
-        raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
-    finally:
-        server.stop()
+        try:
+            result = subprocess.run(
+                [*command, *_command_args()],
+                cwd=os.getcwd(),
+                env=_env(server.port, _agency_id(agency)),
+                check=False,
+            )
+        except OSError as exc:
+            raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
+        finally:
+            server.stop()
 
     if result.returncode not in (0, 130):
         raise subprocess.CalledProcessError(result.returncode, [*command, *_command_args()])
@@ -355,6 +356,29 @@ def _chmod(path: Path) -> None:
 
 def _notify_setup(message: str) -> None:
     print(message, file=sys.stderr, flush=True)
+
+
+@contextmanager
+def _contain_bridge_output():
+    if not _should_contain_bridge_output():
+        yield
+        return
+
+    with open(os.devnull, "w", encoding="utf-8") as sink:
+        with redirect_stdout(sink), redirect_stderr(sink):
+            yield
+
+
+def _should_contain_bridge_output() -> bool:
+    return _isatty(sys.stdout) or _isatty(sys.stderr)
+
+
+def _isatty(stream: object) -> bool:
+    method = getattr(stream, "isatty", None)
+    if callable(method):
+        with suppress(Exception):
+            return bool(method())
+    return False
 
 
 @contextmanager

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -364,13 +364,19 @@ def _contain_bridge_output():
         yield
         return
 
-    with open(os.devnull, "w", encoding="utf-8") as sink:
+    path = _bridge_log()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", buffering=1) as sink:
         with redirect_stdout(sink), redirect_stderr(sink):
             yield
 
 
 def _should_contain_bridge_output() -> bool:
     return _isatty(sys.stdout) or _isatty(sys.stderr)
+
+
+def _bridge_log() -> Path:
+    return _cache() / "logs" / "bridge.log"
 
 
 def _isatty(stream: object) -> bool:

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import hashlib
 import json
 import logging
@@ -14,7 +15,7 @@ import tarfile
 import tempfile
 import threading
 import time
-from contextlib import contextmanager, redirect_stderr, redirect_stdout, suppress
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, TypedDict
@@ -93,25 +94,24 @@ def start_tui(agency, show_reasoning: bool | None = None, reload: bool = True) -
 
     command = _command()
 
-    capture: Path | None = None
+    capture = _bridge_log() if _should_contain_bridge_output() else None
     try:
-        with _contain_bridge_output() as capture:
-            try:
-                server = _start_server(agency)
-            except Exception as exc:
-                raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
+        try:
+            server = _start_server(agency, capture)
+        except Exception as exc:
+            raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
 
-            try:
-                result = subprocess.run(
-                    [*command, *_command_args()],
-                    cwd=os.getcwd(),
-                    env=_env(server.port, _agency_id(agency)),
-                    check=False,
-                )
-            except OSError as exc:
-                raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
-            finally:
-                server.stop()
+        try:
+            result = subprocess.run(
+                [*command, *_command_args()],
+                cwd=os.getcwd(),
+                env=_env(server.port, _agency_id(agency)),
+                check=False,
+            )
+        except OSError as exc:
+            raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
+        finally:
+            server.stop()
     except Exception:
         _report_bridge_output(capture)
         raise
@@ -119,7 +119,7 @@ def start_tui(agency, show_reasoning: bool | None = None, reload: bool = True) -
     if result.returncode not in (0, 130):
         _report_bridge_output(capture)
         raise subprocess.CalledProcessError(result.returncode, [*command, *_command_args()])
-    _clear_bridge_output(capture)
+    _report_bridge_output(capture)
 
 
 def _command() -> list[str]:
@@ -165,7 +165,7 @@ def _agency_id(agency) -> str:
     return str(name).replace(" ", "_")
 
 
-def _start_server(agency) -> _Server:
+def _start_server(agency, capture: Path | None = None) -> _Server:
     port = _port()
     app = run_fastapi(
         agencies=build_fastapi_agencies(agency),
@@ -186,7 +186,8 @@ def _start_server(agency) -> _Server:
 
     def target() -> None:
         try:
-            server.run()
+            with _contain_bridge_output(capture):
+                server.run()
         except BaseException as exc:  # pragma: no cover - surfaced by waiter below
             error.append(exc)
 
@@ -366,16 +367,36 @@ def _notify_setup(message: str) -> None:
 
 
 @contextmanager
-def _contain_bridge_output():
-    if not _should_contain_bridge_output():
-        yield None
+def _contain_bridge_output(path: Path | None):
+    if path is None:
+        yield
         return
 
-    path = _bridge_log()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8", buffering=1) as sink:
-        with redirect_stdout(sink), redirect_stderr(sink):
-            yield path
+    owner = threading.get_ident()
+    original = builtins.print
+    lock = threading.Lock()
+
+    def print_wrapper(*args, **kwargs):
+        file = kwargs.get("file")
+        if threading.get_ident() != owner or file not in (None, sys.stdout, sys.stderr):
+            return original(*args, **kwargs)
+
+        end = kwargs.get("end", "\n")
+        sep = kwargs.get("sep", " ")
+        flush = kwargs.get("flush", False)
+        text = sep.join(str(arg) for arg in args) + end
+        with lock:
+            with path.open("a", encoding="utf-8", buffering=1) as sink:
+                sink.write(text)
+                if flush:
+                    sink.flush()
+
+    builtins.print = print_wrapper
+    try:
+        yield path
+    finally:
+        builtins.print = original
 
 
 def _should_contain_bridge_output() -> bool:
@@ -396,13 +417,6 @@ def _report_bridge_output(path: Path | None) -> None:
             path.unlink()
             return
     print(f"Python bridge output was captured in {path}", file=sys.stderr, flush=True)
-
-
-def _clear_bridge_output(path: Path | None) -> None:
-    if not path:
-        return
-    with suppress(OSError):
-        path.unlink()
 
 
 def _isatty(stream: object) -> bool:

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -93,26 +93,33 @@ def start_tui(agency, show_reasoning: bool | None = None, reload: bool = True) -
 
     command = _command()
 
-    with _contain_bridge_output():
-        try:
-            server = _start_server(agency)
-        except Exception as exc:
-            raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
+    capture: Path | None = None
+    try:
+        with _contain_bridge_output() as capture:
+            try:
+                server = _start_server(agency)
+            except Exception as exc:
+                raise RuntimeError("Agent Swarm CLI bridge failed to start.") from exc
 
-        try:
-            result = subprocess.run(
-                [*command, *_command_args()],
-                cwd=os.getcwd(),
-                env=_env(server.port, _agency_id(agency)),
-                check=False,
-            )
-        except OSError as exc:
-            raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
-        finally:
-            server.stop()
+            try:
+                result = subprocess.run(
+                    [*command, *_command_args()],
+                    cwd=os.getcwd(),
+                    env=_env(server.port, _agency_id(agency)),
+                    check=False,
+                )
+            except OSError as exc:
+                raise RuntimeError("Agent Swarm CLI could not be launched.") from exc
+            finally:
+                server.stop()
+    except Exception:
+        _report_bridge_output(capture)
+        raise
 
     if result.returncode not in (0, 130):
+        _report_bridge_output(capture)
         raise subprocess.CalledProcessError(result.returncode, [*command, *_command_args()])
+    _clear_bridge_output(capture)
 
 
 def _command() -> list[str]:
@@ -361,14 +368,14 @@ def _notify_setup(message: str) -> None:
 @contextmanager
 def _contain_bridge_output():
     if not _should_contain_bridge_output():
-        yield
+        yield None
         return
 
     path = _bridge_log()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8", buffering=1) as sink:
+    with path.open("w", encoding="utf-8", buffering=1) as sink:
         with redirect_stdout(sink), redirect_stderr(sink):
-            yield
+            yield path
 
 
 def _should_contain_bridge_output() -> bool:
@@ -376,7 +383,26 @@ def _should_contain_bridge_output() -> bool:
 
 
 def _bridge_log() -> Path:
-    return _cache() / "logs" / "bridge.log"
+    fd, value = tempfile.mkstemp(prefix="agentswarm-bridge-", suffix=".log")
+    os.close(fd)
+    return Path(value)
+
+
+def _report_bridge_output(path: Path | None) -> None:
+    if not path or not path.exists():
+        return
+    with suppress(OSError):
+        if path.stat().st_size == 0:
+            path.unlink()
+            return
+    print(f"Python bridge output was captured in {path}", file=sys.stderr, flush=True)
+
+
+def _clear_bridge_output(path: Path | None) -> None:
+    if not path:
+        return
+    with suppress(OSError):
+        path.unlink()
 
 
 def _isatty(stream: object) -> bool:

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -236,7 +236,7 @@ def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys
     assert state["server"].stopped is True
 
 
-def test_agentswarm_cli_tui_capture_only_redirects_the_server_thread(capsys, tmp_path):
+def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
     log = tmp_path / "bridge.log"
 
     def other():
@@ -249,9 +249,8 @@ def test_agentswarm_cli_tui_capture_only_redirects_the_server_thread(capsys, tmp
         print("server thread output")
 
     captured = capsys.readouterr()
-    assert "other thread output" in captured.out
-    assert "server thread output" not in captured.out
-    assert log.read_text() == "server thread output\n"
+    assert captured.out == ""
+    assert log.read_text() == "other thread output\nserver thread output\n"
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -34,7 +34,7 @@ def test_agentswarm_cli_tui_launches_agent_swarm_cli(monkeypatch):
 
     monkeypatch.delenv(agentswarm_cli_demo._RELOAD_CHILD_ENV, raising=False)
     monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
-    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: server)
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value, capture=None: server)
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
 
     def fake_run(cmd, cwd, env, check):
@@ -65,7 +65,7 @@ def test_agentswarm_cli_tui_continues_after_reload(monkeypatch):
 
     monkeypatch.setenv(agentswarm_cli_demo._RELOAD_CHILD_ENV, "1")
     monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
-    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: server)
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value, capture=None: server)
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
     monkeypatch.setattr(
         agentswarm_cli_demo.subprocess,
@@ -104,7 +104,11 @@ def test_agentswarm_cli_tui_raises_when_bridge_fails(monkeypatch):
     agency = build_agency()
 
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
-    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        agentswarm_cli_demo,
+        "_start_server",
+        lambda value, capture=None: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
 
     with pytest.raises(RuntimeError, match="bridge failed to start"):
         agentswarm_cli_demo.start_tui(agency, reload=False)
@@ -115,7 +119,7 @@ def test_agentswarm_cli_tui_raises_when_cli_launch_fails(monkeypatch):
     server = DummyServer()
 
     monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
-    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: server)
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value, capture=None: server)
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
     monkeypatch.setattr(
         agentswarm_cli_demo.subprocess,
@@ -140,12 +144,13 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
     monkeypatch.setattr(agentswarm_cli_demo, "_bridge_log", lambda: log)
     monkeypatch.setattr(agentswarm_cli_demo, "_should_contain_bridge_output", lambda: True)
 
-    def fake_start_server(value):
+    def fake_start_server(value, capture):
         nonlocal worker
 
         def target():
-            print("bridge stdout noise")
-            print("bridge stderr noise", file=sys.stderr)
+            with agentswarm_cli_demo._contain_bridge_output(capture):
+                print("bridge stdout noise")
+                print("bridge stderr noise", file=sys.stderr)
 
         worker = threading.Thread(target=target)
         worker.start()
@@ -173,8 +178,9 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert captured.err == ""
-    assert not log.exists()
+    assert str(log) in captured.err
+    assert "bridge stdout noise" in log.read_text()
+    assert "bridge stderr noise" in log.read_text()
     assert state["server"].stopped is True
 
 
@@ -189,12 +195,13 @@ def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys
     monkeypatch.setattr(agentswarm_cli_demo, "_bridge_log", lambda: log)
     monkeypatch.setattr(agentswarm_cli_demo, "_should_contain_bridge_output", lambda: True)
 
-    def fake_start_server(value):
+    def fake_start_server(value, capture):
         nonlocal worker
 
         def target():
-            print("bridge stdout noise")
-            print("bridge stderr noise", file=sys.stderr)
+            with agentswarm_cli_demo._contain_bridge_output(capture):
+                print("bridge stdout noise")
+                print("bridge stderr noise", file=sys.stderr)
 
         worker = threading.Thread(target=target)
         worker.start()
@@ -227,6 +234,24 @@ def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys
     assert "bridge stdout noise" in log.read_text()
     assert "bridge stderr noise" in log.read_text()
     assert state["server"].stopped is True
+
+
+def test_agentswarm_cli_tui_capture_only_redirects_the_server_thread(capsys, tmp_path):
+    log = tmp_path / "bridge.log"
+
+    def other():
+        print("other thread output")
+
+    with agentswarm_cli_demo._contain_bridge_output(log):
+        worker = threading.Thread(target=other)
+        worker.start()
+        worker.join()
+        print("server thread output")
+
+    captured = capsys.readouterr()
+    assert "other thread output" in captured.out
+    assert "server thread output" not in captured.out
+    assert log.read_text() == "server thread output\n"
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -174,6 +174,56 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
+    assert not log.exists()
+    assert state["server"].stopped is True
+
+
+def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys, tmp_path):
+    agency = build_agency()
+    log = tmp_path / "bridge.log"
+    worker: threading.Thread | None = None
+    state: dict[str, DummyServer] = {}
+
+    monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
+    monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
+    monkeypatch.setattr(agentswarm_cli_demo, "_bridge_log", lambda: log)
+    monkeypatch.setattr(agentswarm_cli_demo, "_should_contain_bridge_output", lambda: True)
+
+    def fake_start_server(value):
+        nonlocal worker
+
+        def target():
+            print("bridge stdout noise")
+            print("bridge stderr noise", file=sys.stderr)
+
+        worker = threading.Thread(target=target)
+        worker.start()
+
+        class LoggingServer(DummyServer):
+            def stop(self) -> None:
+                if worker is not None:
+                    worker.join()
+                super().stop()
+
+        state["server"] = LoggingServer()
+        return state["server"]
+
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", fake_start_server)
+
+    def fake_run(cmd, cwd, env, check):
+        if worker is not None:
+            worker.join()
+        return subprocess.CompletedProcess(cmd, 1)
+
+    monkeypatch.setattr(agentswarm_cli_demo.subprocess, "run", fake_run)
+    log.unlink(missing_ok=True)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        agentswarm_cli_demo.start_tui(agency, reload=False)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert str(log) in captured.err
     assert "bridge stdout noise" in log.read_text()
     assert "bridge stderr noise" in log.read_text()
     assert state["server"].stopped is True

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -129,34 +129,54 @@ def test_agentswarm_cli_tui_raises_when_cli_launch_fails(monkeypatch):
     assert server.stopped is True
 
 
-def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, capsys):
+def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, capsys, tmp_path):
     agency = build_agency()
-    server = DummyServer()
+    log = tmp_path / "bridge.log"
+    worker: threading.Thread | None = None
+    state: dict[str, DummyServer] = {}
 
     monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
-    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: server)
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
+    monkeypatch.setattr(agentswarm_cli_demo, "_bridge_log", lambda: log)
     monkeypatch.setattr(agentswarm_cli_demo, "_should_contain_bridge_output", lambda: True)
 
-    def fake_run(cmd, cwd, env, check):
-        worker = threading.Thread(
-            target=lambda: (
-                print("bridge stdout noise"),
-                print("bridge stderr noise", file=sys.stderr),
-            )
-        )
+    def fake_start_server(value):
+        nonlocal worker
+
+        def target():
+            print("bridge stdout noise")
+            print("bridge stderr noise", file=sys.stderr)
+
+        worker = threading.Thread(target=target)
         worker.start()
-        worker.join()
+
+        class LoggingServer(DummyServer):
+            def stop(self) -> None:
+                if worker is not None:
+                    worker.join()
+                super().stop()
+
+        state["server"] = LoggingServer()
+        return state["server"]
+
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", fake_start_server)
+
+    def fake_run(cmd, cwd, env, check):
+        if worker is not None:
+            worker.join()
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(agentswarm_cli_demo.subprocess, "run", fake_run)
+    log.unlink(missing_ok=True)
 
     agentswarm_cli_demo.start_tui(agency, reload=False)
 
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
-    assert server.stopped is True
+    assert "bridge stdout noise" in log.read_text()
+    assert "bridge stderr noise" in log.read_text()
+    assert state["server"].stopped is True
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -1,7 +1,9 @@
 import importlib
 import json
 import subprocess
+import sys
 import tarfile
+import threading
 from io import BytesIO
 from pathlib import Path
 
@@ -124,6 +126,36 @@ def test_agentswarm_cli_tui_raises_when_cli_launch_fails(monkeypatch):
     with pytest.raises(RuntimeError, match="could not be launched"):
         agentswarm_cli_demo.start_tui(agency, reload=False)
 
+    assert server.stopped is True
+
+
+def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, capsys):
+    agency = build_agency()
+    server = DummyServer()
+
+    monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
+    monkeypatch.setattr(agentswarm_cli_demo, "_start_server", lambda value: server)
+    monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
+    monkeypatch.setattr(agentswarm_cli_demo, "_should_contain_bridge_output", lambda: True)
+
+    def fake_run(cmd, cwd, env, check):
+        worker = threading.Thread(
+            target=lambda: (
+                print("bridge stdout noise"),
+                print("bridge stderr noise", file=sys.stderr),
+            )
+        )
+        worker.start()
+        worker.join()
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(agentswarm_cli_demo.subprocess, "run", fake_run)
+
+    agentswarm_cli_demo.start_tui(agency, reload=False)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
     assert server.stopped is True
 
 


### PR DESCRIPTION
## Context
The Python `agency.tui()` bridge and the spawned TUI share one terminal. Stray `print()` output from the Python side can corrupt the live terminal UI.

## What changed
- contain Python stdout/stderr only while the bridge server is starting and the spawned TUI process is running
- keep that containment limited to TTY launches so non-interactive callers still get normal output
- add a focused regression test that proves bridge-side prints stay out of the terminal UI stream

## Evidence
- `uv run pytest tests/test_agency_modules/test_agentswarm_cli_tui.py -k contains_python_prints_while_cli_runs`
