### PR TITLE
fix(fastapi): support codex browser-auth responses

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -821,6 +821,9 @@ async def generate_chat_name(
 ):
     client = openai_client or get_default_openai_client() or AsyncOpenAI()
 
+    def _word_count(value: str) -> int:
+        return len(value.split(" "))
+
     class ResponseFormat(BaseModel):
         chat_name: str = Field(description="A fitting name for the provided chat history.")
 
@@ -833,7 +836,7 @@ async def generate_chat_name(
 
         chat_name = response_text.chat_name if isinstance(response_text, ResponseFormat) else str(response_text)
 
-        if len(chat_name.split(" ")) < 2 or len(chat_name.split(" ")) > 6:
+        if _word_count(chat_name) < 2 or _word_count(chat_name) > 6:
             tripwire_triggered = True
             output_info = "The name should contain between 2 and 6 words"
 
@@ -842,17 +845,12 @@ async def generate_chat_name(
             tripwire_triggered=tripwire_triggered,
         )
 
-    formatted_messages = str(MessageFormatter.strip_agency_metadata(new_messages))  # type: ignore[arg-type]
+    stripped_messages = MessageFormatter.strip_agency_metadata(new_messages)  # type: ignore[arg-type]
+    formatted_messages = str(stripped_messages)
     if len(formatted_messages) > 1000:
         formatted_messages = "HISTORY TRUNCATED TO 1000 CHARACTERS:\n" + formatted_messages[:1000]
 
-    model = OpenAIResponsesModel(model="gpt-5.4-mini", openai_client=client)
-
-    name_agent = Agent(
-        name="NameGenerator",
-        model=model,
-        instructions=(
-            """
+    title_instructions = """
 You are a helpful assistant that generates a human-friendly title for a conversation.
 You will receive a list of messages where the first one is the user input and the rest are
 related to the assistant response.
@@ -864,17 +862,54 @@ Rules:
 - If the first user message is generic (e.g., “hi”), use the best available intent from the rest of the messages.
 - If you lack context of the user input (continuation of an ongoing conversation), derive it from agent's response.
 """
-        ),
+
+    if _is_codex_base_url(str(client.base_url)):
+        codex_input: list[TResponseInputItem]
+        if len(formatted_messages) > 1000:
+            codex_input = [cast(TResponseInputItem, {"role": "user", "content": formatted_messages})]
+        else:
+            codex_input = cast(list[TResponseInputItem], stripped_messages)
+
+        retry_suffix = ""
+        for _attempt in range(4):
+            response = await client.responses.create(
+                model="gpt-5.4-mini",
+                instructions=title_instructions + retry_suffix,
+                input=codex_input,
+                store=False,
+                stream=True,
+            )
+            text_parts: list[str] = []
+            async for event in response:
+                if getattr(event, "type", "") != "response.output_text.delta":
+                    continue
+                delta = getattr(event, "delta", None)
+                if isinstance(delta, str) and delta:
+                    text_parts.append(delta)
+            chat_name = "".join(text_parts).strip()
+            if 2 <= _word_count(chat_name) <= 6:
+                return chat_name
+            retry_suffix = (
+                "\nThe previous title was invalid because it must contain between 2 and 6 words. "
+                "Return a corrected title now."
+            )
+        raise ValueError("Generated chat name must contain between 2 and 6 words")
+
+    model = OpenAIResponsesModel(model="gpt-5.4-mini", openai_client=client)
+
+    name_agent = Agent(
+        name="NameGenerator",
+        model=model,
+        model_settings=ModelSettings(store=False),
+        instructions=title_instructions,
         output_type=ResponseFormat,
         validation_attempts=3,
         output_guardrails=[response_content_guardrail],
     )
 
     agency = Agency(name_agent)
-
-    response = await agency.get_response(formatted_messages)
-
-    return response.final_output.chat_name
+    run_result = await agency.get_response(formatted_messages)
+    return run_result.final_output.chat_name
 
 
 def _get_agency_swarm_version() -> str | None:
@@ -973,6 +1008,20 @@ def _apply_default_headers_to_agent_model_settings(agent: Agent, headers: dict[s
     agent.model_settings = current
 
 
+def _is_codex_base_url(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.rstrip("/") == "https://chatgpt.com/backend-api/codex"
+
+
+def _apply_codex_compatibility_model_settings(agent: Agent) -> None:
+    """Strip unsupported Responses parameters for the Codex browser-auth backend."""
+    current: ModelSettings = getattr(agent, "model_settings", None) or ModelSettings()
+    current.store = False
+    current.truncation = None
+    agent.model_settings = current
+
+
 def _is_litellm_model(model_name: str) -> bool:
     """Check if a model name is a LiteLLM model (uses litellm/ prefix)."""
     return model_name.startswith("litellm/")
@@ -1059,6 +1108,8 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
             if client is None:
                 return
             agent.model = OpenAIResponsesModel(model=model, openai_client=client)
+            if _is_codex_base_url(str(client.base_url)):
+                _apply_codex_compatibility_model_settings(agent)
     elif isinstance(model, OpenAIResponsesModel):
         if _is_litellm_model(model.model):
             if has_litellm_overrides:
@@ -1075,6 +1126,8 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
             if client is None:
                 return
             agent.model = OpenAIResponsesModel(model=model.model, openai_client=client)
+            if _is_codex_base_url(str(client.base_url)):
+                _apply_codex_compatibility_model_settings(agent)
     elif isinstance(model, OpenAIChatCompletionsModel):
         if _is_litellm_model(model.model):
             if has_litellm_overrides:
@@ -1115,6 +1168,8 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
                 if client is None:
                     return
                 agent.model = OpenAIResponsesModel(model=model_name, openai_client=client)
+                if _is_codex_base_url(str(client.base_url)):
+                    _apply_codex_compatibility_model_settings(agent)
         else:
             logger.warning(
                 f"Cannot apply client config to agent '{agent.name}': unsupported model type {type(model).__name__}"

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -204,6 +204,34 @@ def test_litellm_openai_provider_can_use_generic_api_key_fallback() -> None:
     assert agent.model.api_key == "sk-openai"
 
 
+def test_openai_client_override_applies_codex_compatibility_model_settings() -> None:
+    """Codex overrides should use the Responses settings the browser-auth backend accepts."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(api_key="sk-openai", base_url="https://chatgpt.com/backend-api/codex"),
+    )
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model_settings is not None
+    assert agent.model_settings.store is False
+    assert agent.model_settings.truncation is None
+
+
 def test_snapshot_restore_preserves_model_settings_headers() -> None:
     """Snapshot/restore should not leak mutated model_settings."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py
@@ -7,6 +7,80 @@ import pytest
 
 
 @pytest.mark.asyncio
+async def test_generate_chat_name_uses_codex_direct_client_stream() -> None:
+    """Codex chat-name generation should use the proven low-level client request shape."""
+    from agency_swarm.integrations.fastapi_utils import endpoint_handlers
+
+    captured: dict[str, object] = {}
+
+    class _Event:
+        def __init__(self, event_type: str, delta: str = ""):
+            self.type = event_type
+            self.delta = delta
+
+    class _DummyResponse:
+        def __aiter__(self):
+            return self._events()
+
+        async def _events(self):
+            yield _Event("response.output_text.delta", "Friendly")
+            yield _Event("response.output_text.delta", " Greeting")
+
+    class _DummyResponses:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return _DummyResponse()
+
+    class _DummyClient:
+        base_url = "https://chatgpt.com/backend-api/codex"
+        responses = _DummyResponses()
+
+    result = await endpoint_handlers.generate_chat_name(
+        [{"role": "user", "content": "hello"}],
+        openai_client=_DummyClient(),
+    )
+
+    assert result == "Friendly Greeting"
+    assert captured["model"] == "gpt-5.4-mini"
+    assert captured["store"] is False
+    assert captured["stream"] is True
+    assert captured["input"] == [{"role": "user", "content": "hello"}]
+    assert "generates a human-friendly title" in str(captured["instructions"])
+
+
+@pytest.mark.asyncio
+async def test_generate_chat_name_keeps_agency_path_for_non_codex(monkeypatch) -> None:
+    """Non-Codex backends should keep the existing Agency-based retry path."""
+    pytest.importorskip("agents")
+
+    from openai import AsyncOpenAI
+
+    from agency_swarm.integrations.fastapi_utils import endpoint_handlers
+
+    class _FinalOutput:
+        chat_name = "Sample Chat Name"
+
+    class _DummyResult:
+        final_output = _FinalOutput()
+
+    captured = {"used_agency": False}
+
+    async def _fake_get_response(self, _message):
+        captured["used_agency"] = True
+        return _DummyResult()
+
+    monkeypatch.setattr(endpoint_handlers.Agency, "get_response", _fake_get_response)
+
+    result = await endpoint_handlers.generate_chat_name(
+        [{"role": "user", "content": "hello"}],
+        openai_client=AsyncOpenAI(api_key="sk-test", base_url="https://api.openai.com/v1"),
+    )
+
+    assert captured["used_agency"] is True
+    assert result == "Sample Chat Name"
+
+
+@pytest.mark.asyncio
 async def test_make_response_endpoint_applies_client_config_to_agent_client_sync(monkeypatch) -> None:
     """Request client_config should provide a sync OpenAI client for attachment lookups."""
     pytest.importorskip("agents")


### PR DESCRIPTION
## Summary
- bypass the Agency title-generation wrapper for Codex browser-auth clients and call the Responses API with Codex-safe settings
- apply Codex compatibility model settings when request-scoped client overrides retarget agents to the Codex backend
- cover the direct Codex path and the non-Codex fallback path with focused FastAPI utility tests

## Testing
- UV_PYTHON=3.13 make format
- UV_PYTHON=3.13 make check
- uv run pytest tests/test_fastapi_utils_modules/test_openai_client_config_models.py
- uv run pytest tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py