### PR TITLE
fix(cli): contain python bridge stream output

### DIFF
--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -405,6 +405,8 @@ def _contain_bridge_output(path: Path | None):
     original_stdout = sys.stdout
     original_stderr = sys.stderr
     lock = threading.Lock()
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
     with path.open("a", encoding="utf-8", buffering=1) as sink:
         capture_stream = _CapturedTextStream(sink, lock)
         rebound_handlers: list[tuple[logging.StreamHandler, object]] = []
@@ -422,6 +424,13 @@ def _contain_bridge_output(path: Path | None):
                 rebound_handlers.append((handler, handler.stream))
                 handler.setStream(capture_stream)
 
+        fd_sink = os.open(str(path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            os.dup2(fd_sink, 1)
+            os.dup2(fd_sink, 2)
+        finally:
+            os.close(fd_sink)
+
         sys.stdout = capture_stream
         sys.stderr = capture_stream
         try:
@@ -431,6 +440,10 @@ def _contain_bridge_output(path: Path | None):
             sys.stderr = original_stderr
             for handler, stream in reversed(rebound_handlers):
                 handler.setStream(stream)
+            os.dup2(saved_stdout_fd, 1)
+            os.dup2(saved_stderr_fd, 2)
+            os.close(saved_stdout_fd)
+            os.close(saved_stderr_fd)
 
 
 def _should_contain_bridge_output() -> bool:

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 import hashlib
 import json
 import logging
@@ -372,30 +371,66 @@ def _contain_bridge_output(path: Path | None):
         yield
         return
 
+    class _CapturedTextStream:
+        def __init__(self, sink, lock: threading.Lock) -> None:
+            self._sink = sink
+            self._lock = lock
+            self.encoding = sink.encoding
+            self.errors = sink.errors
+
+        def write(self, text: str) -> int:
+            value = str(text)
+            with self._lock:
+                written = self._sink.write(value)
+                self._sink.flush()
+            return written
+
+        def writelines(self, lines) -> None:
+            with self._lock:
+                for line in lines:
+                    self._sink.write(str(line))
+                self._sink.flush()
+
+        def flush(self) -> None:
+            with self._lock:
+                self._sink.flush()
+
+        def isatty(self) -> bool:
+            return False
+
+        def writable(self) -> bool:
+            return True
+
     path.parent.mkdir(parents=True, exist_ok=True)
-    original = builtins.print
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
     lock = threading.Lock()
+    with path.open("a", encoding="utf-8", buffering=1) as sink:
+        capture_stream = _CapturedTextStream(sink, lock)
+        rebound_handlers: list[tuple[logging.StreamHandler, object]] = []
+        managed_loggers = [
+            logging.getLogger(),
+            *[value for value in logging.root.manager.loggerDict.values() if isinstance(value, logging.Logger)],
+        ]
 
-    def print_wrapper(*args, **kwargs):
-        file = kwargs.get("file")
-        if file not in (None, sys.stdout, sys.stderr):
-            return original(*args, **kwargs)
+        for current_logger in managed_loggers:
+            for handler in current_logger.handlers:
+                if not isinstance(handler, logging.StreamHandler):
+                    continue
+                if handler.stream not in (original_stdout, original_stderr):
+                    continue
+                rebound_handlers.append((handler, handler.stream))
+                handler.setStream(capture_stream)
 
-        end = kwargs.get("end", "\n")
-        sep = kwargs.get("sep", " ")
-        flush = kwargs.get("flush", False)
-        text = sep.join(str(arg) for arg in args) + end
-        with lock:
-            with path.open("a", encoding="utf-8", buffering=1) as sink:
-                sink.write(text)
-                if flush:
-                    sink.flush()
-
-    builtins.print = print_wrapper
-    try:
-        yield path
-    finally:
-        builtins.print = original
+        sys.stdout = capture_stream
+        sys.stderr = capture_stream
+        try:
+            yield path
+        finally:
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+            for handler, stream in reversed(rebound_handlers):
+                handler.setStream(stream)
 
 
 def _should_contain_bridge_output() -> bool:

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -405,8 +405,6 @@ def _contain_bridge_output(path: Path | None):
     original_stdout = sys.stdout
     original_stderr = sys.stderr
     lock = threading.Lock()
-    saved_stdout_fd = os.dup(1)
-    saved_stderr_fd = os.dup(2)
     with path.open("a", encoding="utf-8", buffering=1) as sink:
         capture_stream = _CapturedTextStream(sink, lock)
         rebound_handlers: list[tuple[logging.StreamHandler, object]] = []
@@ -424,13 +422,6 @@ def _contain_bridge_output(path: Path | None):
                 rebound_handlers.append((handler, handler.stream))
                 handler.setStream(capture_stream)
 
-        fd_sink = os.open(str(path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
-        try:
-            os.dup2(fd_sink, 1)
-            os.dup2(fd_sink, 2)
-        finally:
-            os.close(fd_sink)
-
         sys.stdout = capture_stream
         sys.stderr = capture_stream
         try:
@@ -440,10 +431,6 @@ def _contain_bridge_output(path: Path | None):
             sys.stderr = original_stderr
             for handler, stream in reversed(rebound_handlers):
                 handler.setStream(stream)
-            os.dup2(saved_stdout_fd, 1)
-            os.dup2(saved_stderr_fd, 2)
-            os.close(saved_stdout_fd)
-            os.close(saved_stderr_fd)
 
 
 def _should_contain_bridge_output() -> bool:

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import logging
+import os
 import subprocess
 import sys
 import tarfile
@@ -285,6 +286,34 @@ def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
         "server thread stderr\n"
         "server thread logger\n"
     )
+
+
+def test_agentswarm_cli_tui_capture_redirects_streams_logging_and_fds(capsys, tmp_path):
+    log = tmp_path / "bridge.log"
+    logger = logging.getLogger("agency_swarm.tests.bridge_capture")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.handlers = [handler]
+
+    try:
+        with agentswarm_cli_demo._contain_bridge_output(log):
+            sys.stdout.write("stdout write noise\n")
+            sys.stdout.flush()
+            sys.stderr.write("stderr write noise\n")
+            sys.stderr.flush()
+            logger.info("logging noise")
+            os.write(1, b"fd1 noise\n")
+            os.write(2, b"fd2 noise\n")
+    finally:
+        handler.close()
+        logger.handlers = []
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert log.read_text() == ("stdout write noise\nstderr write noise\nlogging noise\nfd1 noise\nfd2 noise\n")
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -1,7 +1,6 @@
 import importlib
 import json
 import logging
-import os
 import subprocess
 import sys
 import tarfile
@@ -286,34 +285,6 @@ def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
         "server thread stderr\n"
         "server thread logger\n"
     )
-
-
-def test_agentswarm_cli_tui_capture_redirects_streams_logging_and_fds(capsys, tmp_path):
-    log = tmp_path / "bridge.log"
-    logger = logging.getLogger("agency_swarm.tests.bridge_capture")
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    logger.handlers = [handler]
-
-    try:
-        with agentswarm_cli_demo._contain_bridge_output(log):
-            sys.stdout.write("stdout write noise\n")
-            sys.stdout.flush()
-            sys.stderr.write("stderr write noise\n")
-            sys.stderr.flush()
-            logger.info("logging noise")
-            os.write(1, b"fd1 noise\n")
-            os.write(2, b"fd2 noise\n")
-    finally:
-        handler.close()
-        logger.handlers = []
-
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err == ""
-    assert log.read_text() == ("stdout write noise\nstderr write noise\nlogging noise\nfd1 noise\nfd2 noise\n")
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+import logging
 import subprocess
 import sys
 import tarfile
@@ -138,6 +139,11 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
     log = tmp_path / "bridge.log"
     worker: threading.Thread | None = None
     state: dict[str, DummyServer] = {}
+    logger = logging.getLogger("test.agentswarm_cli.bridge")
+    handler = logging.StreamHandler(sys.stderr)
+    logger.handlers = [handler]
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
 
     monkeypatch.setattr(agentswarm_cli_demo.os, "getcwd", lambda: "/tmp/project")
     monkeypatch.setattr(agentswarm_cli_demo, "_ensure_cli", lambda: Path("/usr/local/bin/agentswarm"))
@@ -149,8 +155,9 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
 
         def target():
             with agentswarm_cli_demo._contain_bridge_output(capture):
-                print("bridge stdout noise")
-                print("bridge stderr noise", file=sys.stderr)
+                sys.stdout.write("bridge stdout noise\n")
+                sys.stderr.write("bridge stderr noise\n")
+                logger.warning("bridge logger noise")
 
         worker = threading.Thread(target=target)
         worker.start()
@@ -173,14 +180,21 @@ def test_agentswarm_cli_tui_contains_python_prints_while_cli_runs(monkeypatch, c
 
     monkeypatch.setattr(agentswarm_cli_demo.subprocess, "run", fake_run)
     log.unlink(missing_ok=True)
-
-    agentswarm_cli_demo.start_tui(agency, reload=False)
+    try:
+        agentswarm_cli_demo.start_tui(agency, reload=False)
+    finally:
+        logger.handlers = []
 
     captured = capsys.readouterr()
     assert captured.out == ""
+    assert "bridge stdout noise" not in captured.err
+    assert "bridge stderr noise" not in captured.err
+    assert "bridge logger noise" not in captured.err
     assert str(log) in captured.err
-    assert "bridge stdout noise" in log.read_text()
-    assert "bridge stderr noise" in log.read_text()
+    text = log.read_text()
+    assert "bridge stdout noise" in text
+    assert "bridge stderr noise" in text
+    assert "bridge logger noise" in text
     assert state["server"].stopped is True
 
 
@@ -238,19 +252,39 @@ def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys
 
 def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
     log = tmp_path / "bridge.log"
+    logger = logging.getLogger("test.agentswarm_cli.capture")
+    handler = logging.StreamHandler(sys.stderr)
+    logger.handlers = [handler]
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
 
     def other():
-        print("other thread output")
+        sys.stdout.write("other thread stdout\n")
+        sys.stderr.write("other thread stderr\n")
+        logger.warning("other thread logger")
 
-    with agentswarm_cli_demo._contain_bridge_output(log):
-        worker = threading.Thread(target=other)
-        worker.start()
-        worker.join()
-        print("server thread output")
+    try:
+        with agentswarm_cli_demo._contain_bridge_output(log):
+            worker = threading.Thread(target=other)
+            worker.start()
+            worker.join()
+            sys.stdout.write("server thread stdout\n")
+            sys.stderr.write("server thread stderr\n")
+            logger.warning("server thread logger")
+    finally:
+        logger.handlers = []
 
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert log.read_text() == "other thread output\nserver thread output\n"
+    assert captured.err == ""
+    assert log.read_text() == (
+        "other thread stdout\n"
+        "other thread stderr\n"
+        "other thread logger\n"
+        "server thread stdout\n"
+        "server thread stderr\n"
+        "server thread logger\n"
+    )
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- redirect Python bridge stdout and stderr writes into the capture log instead of trapping only print calls
- retarget existing logging stream handlers during bridge containment so logger noise stays out of the TUI
- update the bridge tests to cover raw stream writes and logging from worker threads

## Testing
- UV_PYTHON=3.13 make format
- UV_PYTHON=3.13 make check
- uv run pytest tests/test_agency_modules/test_agentswarm_cli_tui.py