### PR TITLE
fix(stream-persistence): fall back to collected_items when streaming new_items is empty

### DIFF
--- a/src/agency_swarm/agent/execution_stream_persistence.py
+++ b/src/agency_swarm/agent/execution_stream_persistence.py
@@ -265,11 +265,23 @@ def _persist_streamed_items(
         return
 
     # Get new_items directly from streaming_result - these are the same Python objects
-    # that were emitted during streaming via RunItemStreamEvent
+    # that were emitted during streaming via RunItemStreamEvent.
+    #
+    # When an external caller consumes the RunResultStreaming generator itself (via
+    # StreamingRunResponse / stream_events) rather than letting the openai-agents SDK's
+    # internal loop drain it, the SDK never runs the post-turn logic that populates
+    # `new_items` on the streaming result. `collected_items`, captured in-band during
+    # streaming from the same RunItemStreamEvent payloads, is the safe fallback.
     new_items: list[RunItem] = getattr(streaming_result, "new_items", None) or []
+    if not new_items and collected_items:
+        logger.info(
+            "streaming_result.new_items is empty after an externally-consumed stream; "
+            "falling back to collected_items for final persistence."
+        )
+        new_items = list(collected_items)
     if not new_items:
         logger.warning(
-            "streaming_result.new_items is empty or missing - skipping final persistence. "
+            "streaming_result.new_items and collected_items are both empty - skipping final persistence. "
             "This may indicate a guardrail trip (expected) or an SDK issue (unexpected)."
         )
         return

--- a/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
+++ b/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
@@ -283,3 +283,62 @@ def test_persist_streamed_items_normalizes_placeholder_tool_ids(mock_extract, mo
     assert persisted[0]["call_id"] == "call_x"
     assert persisted[0]["id"] == "call_x"
     assert persisted[0]["id"] != FAKE_RESPONSES_ID
+
+
+@patch(
+    "agency_swarm.agent.execution_stream_persistence.MessageFilter.remove_orphaned_messages",
+    side_effect=lambda x: x,
+)
+@patch("agency_swarm.agent.execution_stream_persistence.MessageFilter.should_filter", return_value=False)
+@patch("agency_swarm.agent.execution_stream_persistence.MessageFormatter.extract_hosted_tool_results", return_value=[])
+def test_persist_streamed_items_falls_back_to_collected_items_when_new_items_is_empty(
+    mock_extract, mock_filter, mock_orphan
+) -> None:
+    """When RunResultStreaming.new_items is empty (externally-consumed stream), persist from collected_items instead.
+
+    Regression for the bug where assistant messages never landed in agency_swarm_history on
+    the Codex OAuth path because openai-agents SDK only populates new_items when its own
+    internal loop drains the stream. agency-swarm consumes the stream externally via
+    StreamingRunResponse, so new_items stays empty even on successful runs.
+    """
+    agent = Agent(name="AgentA", instructions="noop")
+
+    tool_call = ResponseFunctionToolCall(
+        arguments="{}",
+        call_id="call_fallback",
+        name="tool_fallback",
+        type="function_call",
+        id="call_fallback",
+        status="in_progress",
+    )
+    tool_item = ToolCallItem(agent=agent, raw_item=tool_call)
+
+    thread_manager = _DummyThreadManager()
+    agency_context = AgencyContext(agency_instance=None, thread_manager=thread_manager)
+
+    # streaming_result carries new_items=[] — exactly what openai-agents SDK leaves behind
+    # when agency-swarm consumes the stream externally.
+    stream_result = _DummyStreamResult(
+        new_items=[],
+        input_list=[tool_item.to_input_item()],
+    )
+
+    _persist_streamed_items(
+        streaming_result=stream_result,
+        metadata_store=StreamMetadataStore(),
+        collected_items=[tool_item],
+        agent=agent,
+        sender_name="Manager",
+        parent_run_id=None,
+        run_trace_id="trace",
+        fallback_agent_run_id="agent_run_runner",
+        agency_context=agency_context,
+        initial_saved_count=0,
+    )
+
+    persisted = thread_manager.get_all_messages()
+    assert persisted, (
+        "Expected collected_items to be persisted when new_items is empty; "
+        "otherwise assistant messages disappear from history after the turn."
+    )
+    assert persisted[0]["call_id"] == "call_fallback"


### PR DESCRIPTION
## Summary

When an external caller consumes the `RunResultStreaming` generator via `stream_events` (as agency-swarm's own `StreamingRunResponse` does), the openai-agents SDK never runs its post-turn loop that populates `new_items` on the streaming result. `_persist_streamed_items` then saw an empty `new_items` list and skipped writing the turn's items even when the stream finished successfully, leaving the assistant reply out of thread history.

On the Codex OAuth path this produced silent reopen-memory loss: the user turn was recorded in `agency_swarm_history/*.json` while the assistant reply was not.

Filed as issue #616 with the full reproduction. This PR is the fix.

## Reproduction (before the fix)

`agentswarm` in a starter-template project, authenticate with OpenAI OAuth, send `hi`:

- TUI renders `Hi! How can I help you today?` at ~1.6s / ~600 tokens.
- `~/.local/share/agentswarm/storage/agency_swarm_history/<hash>.json` contains only the user turn; no assistant message.
- Bridge log emits `streaming_result.new_items is empty or missing - skipping final persistence`.

## Fix

`collected_items` is captured in-band during streaming from the same `RunItemStreamEvent` payloads the SDK would use to populate `new_items`. It's the safe fallback. The warning text is kept for the genuine case where both lists are empty (guardrail trip).

## Test plan

- [x] `uv run pytest -q tests/test_agent_modules/test_execution_stream_persistence_fake_id.py` — 5 pass, including the new regression `test_persist_streamed_items_falls_back_to_collected_items_when_new_items_is_empty`
- [x] `UV_PYTHON=3.13 make format && make check` green