### PR TITLE
fix(cli): scope bridge output capture to bridge thread and its async children

### DIFF
--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import hashlib
 import json
 import logging
@@ -17,7 +18,7 @@ import time
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, TypedDict
+from typing import Protocol, TextIO, TypedDict, cast
 from urllib.parse import quote
 
 import requests
@@ -32,6 +33,7 @@ from agency_swarm.ui.demos.terminal import (
 )
 
 logger = logging.getLogger(__name__)
+_BRIDGE_OUTPUT_CAPTURED = contextvars.ContextVar("agentswarm_bridge_output_captured", default=False)
 
 _BIN_ENV = "AGENTSWARM_BIN"
 _ARGS_ENV = "AGENCY_SWARM_OPENCODE_ARGS"
@@ -372,26 +374,39 @@ def _contain_bridge_output(path: Path | None):
         return
 
     class _CapturedTextStream:
-        def __init__(self, sink, lock: threading.Lock) -> None:
+        def __init__(self, sink, passthrough, lock: threading.Lock, owner_ident: int) -> None:
             self._sink = sink
+            self._passthrough = passthrough
             self._lock = lock
+            self._owner_ident = owner_ident
             self.encoding = sink.encoding
             self.errors = sink.errors
 
+        def _should_capture(self) -> bool:
+            return threading.get_ident() == self._owner_ident or _BRIDGE_OUTPUT_CAPTURED.get()
+
         def write(self, text: str) -> int:
             value = str(text)
+            if not self._should_capture():
+                return self._passthrough.write(value)
             with self._lock:
                 written = self._sink.write(value)
                 self._sink.flush()
             return written
 
         def writelines(self, lines) -> None:
+            if not self._should_capture():
+                self._passthrough.writelines(lines)
+                return
             with self._lock:
                 for line in lines:
                     self._sink.write(str(line))
                 self._sink.flush()
 
         def flush(self) -> None:
+            if not self._should_capture():
+                self._passthrough.flush()
+                return
             with self._lock:
                 self._sink.flush()
 
@@ -405,8 +420,10 @@ def _contain_bridge_output(path: Path | None):
     original_stdout = sys.stdout
     original_stderr = sys.stderr
     lock = threading.Lock()
+    owner_ident = threading.get_ident()
     with path.open("a", encoding="utf-8", buffering=1) as sink:
-        capture_stream = _CapturedTextStream(sink, lock)
+        stdout_capture = _CapturedTextStream(sink, original_stdout, lock, owner_ident)
+        stderr_capture = _CapturedTextStream(sink, original_stderr, lock, owner_ident)
         rebound_handlers: list[tuple[logging.StreamHandler, object]] = []
         managed_loggers = [
             logging.getLogger(),
@@ -420,10 +437,11 @@ def _contain_bridge_output(path: Path | None):
                 if handler.stream not in (original_stdout, original_stderr):
                     continue
                 rebound_handlers.append((handler, handler.stream))
-                handler.setStream(capture_stream)
+                handler.setStream(cast(TextIO, stdout_capture if handler.stream is original_stdout else stderr_capture))
 
-        sys.stdout = capture_stream
-        sys.stderr = capture_stream
+        sys.stdout = cast(TextIO, stdout_capture)
+        sys.stderr = cast(TextIO, stderr_capture)
+        capture_token = _BRIDGE_OUTPUT_CAPTURED.set(True)
         try:
             yield path
         finally:
@@ -431,6 +449,7 @@ def _contain_bridge_output(path: Path | None):
             sys.stderr = original_stderr
             for handler, stream in reversed(rebound_handlers):
                 handler.setStream(stream)
+            _BRIDGE_OUTPUT_CAPTURED.reset(capture_token)
 
 
 def _should_contain_bridge_output() -> bool:

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import json
 import logging
@@ -250,7 +251,32 @@ def test_agentswarm_cli_tui_reports_bridge_output_on_failure(monkeypatch, capsys
     assert state["server"].stopped is True
 
 
-def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
+def test_agentswarm_cli_tui_capture_includes_bridge_worker_threads(capsys, tmp_path):
+    log = tmp_path / "bridge.log"
+    logger = logging.getLogger("test.agentswarm_cli.capture.worker")
+    handler = logging.StreamHandler(sys.stderr)
+    logger.handlers = [handler]
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
+
+    def worker() -> None:
+        sys.stdout.write("bridge worker stdout\n")
+        sys.stderr.write("bridge worker stderr\n")
+        logger.warning("bridge worker logger")
+
+    try:
+        with agentswarm_cli_demo._contain_bridge_output(log):
+            asyncio.run(asyncio.to_thread(worker))
+    finally:
+        logger.handlers = []
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert log.read_text() == "bridge worker stdout\nbridge worker stderr\nbridge worker logger\n"
+
+
+def test_agentswarm_cli_tui_capture_keeps_other_threads_on_real_streams(capsys, tmp_path):
     log = tmp_path / "bridge.log"
     logger = logging.getLogger("test.agentswarm_cli.capture")
     handler = logging.StreamHandler(sys.stderr)
@@ -275,16 +301,9 @@ def test_agentswarm_cli_tui_capture_redirects_other_threads(capsys, tmp_path):
         logger.handlers = []
 
     captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err == ""
-    assert log.read_text() == (
-        "other thread stdout\n"
-        "other thread stderr\n"
-        "other thread logger\n"
-        "server thread stdout\n"
-        "server thread stderr\n"
-        "server thread logger\n"
-    )
+    assert captured.out == "other thread stdout\n"
+    assert captured.err == "other thread stderr\nother thread logger\n"
+    assert log.read_text() == "server thread stdout\nserver thread stderr\nserver thread logger\n"
 
 
 def test_agentswarm_cli_tui_downloads_platform_cli(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`_contain_bridge_output` in `src/agency_swarm/ui/demos/agentswarm_cli.py` swapped process-global `sys.stdout` / `sys.stderr` and rebound logging stream handlers while the TUI was active, which also silenced output from every other thread in the same process.

## Fix

Gate the `_CapturedTextStream` write on `threading.current_thread().ident` against the bridge-owner thread captured at entry. Bridge output is still routed to the capture log; any other thread's writes pass through to the real stdout / stderr / original logger stream.

## Test plan

- [x] Existing regression `tests/test_agency_modules/test_agentswarm_cli_tui.py::test_agentswarm_cli_tui_capture_redirects_other_threads` tightened to assert the narrower contract (bridge thread captured, sibling threads pass through).
- [x] `uv run pytest -q tests/test_agency_modules/test_agentswarm_cli_tui.py`
- [x] `UV_PYTHON=3.13 make format && make check`