### PR TITLE
fix(fastapi): route LiteLLM by authoritative provider; separate OpenAI vs LiteLLM base_url

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -146,6 +146,7 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
         and config.api_key is None
         and config.default_headers is None
         and config.litellm_keys is None
+        and config.litellm_base_url is None
     ):
         return  # Nothing to override
 
@@ -153,7 +154,10 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
         config.base_url is not None or config.api_key is not None or config.default_headers is not None
     )
     litellm_overrides_present = (
-        config.base_url is not None or config.api_key is not None or config.litellm_keys is not None
+        config.base_url is not None
+        or config.api_key is not None
+        or config.litellm_keys is not None
+        or config.litellm_base_url is not None
     )
 
     # Apply to all agents in the agency
@@ -1090,7 +1094,12 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
     For LiteLLM models, creates a new LitellmModel with base_url and api_key from config.
     """
     model = agent.model
-    has_litellm_overrides = config.base_url is not None or config.api_key is not None or config.litellm_keys is not None
+    has_litellm_overrides = (
+        config.base_url is not None
+        or config.api_key is not None
+        or config.litellm_keys is not None
+        or config.litellm_base_url is not None
+    )
 
     if isinstance(model, str):
         if _is_litellm_model(model):
@@ -1146,8 +1155,7 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
             agent.model = OpenAIChatCompletionsModel(model=model.model, openai_client=client)
     elif _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
         if has_litellm_overrides:
-            # Preserve existing settings unless explicitly overridden.
-            base_url = config.base_url if config.base_url is not None else model.base_url
+            base_url = _resolve_litellm_base_url(model.model, config, existing_base_url=model.base_url)
             api_key = _resolve_litellm_api_key(model.model, config, existing_api_key=model.api_key)
             agent.model = LitellmModel(model=model.model, base_url=base_url, api_key=api_key)
     elif isinstance(model, Model):
@@ -1232,14 +1240,18 @@ def _resolve_litellm_api_key(
                 if key_str == provider:
                     return value
         # Provider missing in litellm_keys:
-        # - For openai-based providers, allow falling back to config.api_key.
-        # - Otherwise keep existing (or env if None).
-        if _is_openai_based_litellm_provider(provider):
+        # - For models whose route positively targets OpenAI (including nested
+        #   gateway paths like openrouter/openai/... and providerless names that
+        #   LiteLLM treats as OpenAI), allow falling back to config.api_key.
+        # - Otherwise keep existing (or env if None) — don't leak an OpenAI-side
+        #   api_key into an Anthropic/Gemini or other non-OpenAI LiteLLM call.
+        if _model_name_targets_openai(model_name):
             return config.api_key if config.api_key is not None else existing_api_key
         return existing_api_key
 
-    # No litellm_keys provided: only use config.api_key for openai-based providers.
-    if _is_openai_based_litellm_provider(provider):
+    # No litellm_keys provided: only use config.api_key for models that positively
+    # target OpenAI. Providerless or non-OpenAI names keep their existing key.
+    if _model_name_targets_openai(model_name):
         return config.api_key if config.api_key is not None else existing_api_key
     return existing_api_key
 
@@ -1257,12 +1269,73 @@ def _apply_litellm_config(agent: Agent, model_name: str, config: ClientConfig) -
     actual_model = model_name[8:] if model_name.startswith("litellm/") else model_name
 
     api_key = _resolve_litellm_api_key(model_name, config, existing_api_key=None)
+    base_url = _resolve_litellm_base_url(model_name, config, existing_base_url=None)
 
     agent.model = LitellmModel(
         model=actual_model,
-        base_url=config.base_url,
+        base_url=base_url,
         api_key=api_key,
     )
+
+
+_OPENAI_BASED_LITELLM_PROVIDERS: frozenset[str] = frozenset(
+    {"openai", "text-completion-openai", "azure", "azure_ai", "openai_compatible"}
+)
+
+
+def _litellm_route_target_provider(model_name: str) -> str | None:
+    """Return the provider LiteLLM will actually use when routing ``model_name``.
+
+    Uses LiteLLM's own ``get_llm_provider`` so the detection matches the real
+    dispatcher instead of guessing from path segments. ``None`` when LiteLLM
+    cannot resolve a provider (e.g. LiteLLM missing or model unknown).
+    """
+    if not _LITELLM_AVAILABLE:
+        return None
+    cleaned = model_name[8:] if model_name.startswith("litellm/") else model_name
+    try:
+        from litellm import get_llm_provider
+
+        _model, provider, *_ = get_llm_provider(cleaned)
+        return provider if isinstance(provider, str) and provider else None
+    except Exception:
+        return None
+
+
+def _model_name_targets_openai(model_name: str) -> bool:
+    """Return True when LiteLLM resolves ``model_name`` to an OpenAI-based provider."""
+    provider = _litellm_route_target_provider(model_name)
+    return provider in _OPENAI_BASED_LITELLM_PROVIDERS
+
+
+def _resolve_litellm_base_url(
+    model_name: str,
+    config: ClientConfig,
+    existing_base_url: str | None = None,
+) -> str | None:
+    """Decide what base_url to hand to LiteLLM for a per-request client override.
+
+    Rules, in priority order:
+    1. An explicit `litellm_base_url` always wins. Use it for a LiteLLM proxy
+       regardless of which provider the agent uses.
+    2. If the model name positively targets an OpenAI-based endpoint (any path
+       segment is openai/azure/azure_ai/openai_compatible, including nested
+       gateway routes like ``openrouter/openai/...``), fall back to
+       `config.base_url` so an OpenAI gateway override still reaches those
+       LiteLLM agents.
+    3. Otherwise (explicit non-OpenAI providers like anthropic/gemini, or
+       providerless names where the route cannot be positively identified as
+       OpenAI), never leak `config.base_url` into the LiteLLM call; keep the
+       existing `model.base_url`. Callers that want a LiteLLM-side proxy for
+       these agents must set `config.litellm_base_url` explicitly.
+    """
+    if config.litellm_base_url is not None:
+        return config.litellm_base_url
+
+    if _model_name_targets_openai(model_name) and config.base_url is not None:
+        return config.base_url
+
+    return existing_base_url
 
 
 def _snapshot_agency_state(

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -27,6 +27,7 @@ class RequestOverridePolicy:
             or self.config.api_key is not None
             or self.config.default_headers is not None
             or self.config.litellm_keys is not None
+            or self.config.litellm_base_url is not None
         )
 
     @property

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -24,7 +24,7 @@ class ClientConfig(BaseModel):
 
     base_url: str | None = Field(
         default=None,
-        description="OpenAI-compatible API base URL override.",
+        description="OpenAI-compatible API base URL override. Applies to OpenAI-side agents only.",
     )
     api_key: str | None = Field(
         default=None,
@@ -46,6 +46,14 @@ class ClientConfig(BaseModel):
             "variables; OpenAI-compatible providers may fall back to 'api_key'."
         ),
     )
+    litellm_base_url: str | None = Field(
+        default=None,
+        description=(
+            "Base URL override for LiteLLM-routed agents (non-OpenAI providers like anthropic/gemini/etc.). "
+            "Use this for a per-request LiteLLM proxy gateway. Kept separate from `base_url` so a request "
+            "that targets a mix of OpenAI and LiteLLM providers never conflates the two endpoints."
+        ),
+    )
 
     @field_validator("litellm_keys")
     @classmethod
@@ -54,6 +62,16 @@ class ClientConfig(BaseModel):
         if v is not None and not _LITELLM_INSTALLED:
             raise ValueError(
                 "litellm_keys requires litellm to be installed. Install with: pip install 'openai-agents[litellm]'"
+            )
+        return v
+
+    @field_validator("litellm_base_url")
+    @classmethod
+    def validate_litellm_base_url_installed(cls, v: str | None) -> str | None:
+        """Raise error if litellm_base_url provided but litellm not installed."""
+        if v is not None and not _LITELLM_INSTALLED:
+            raise ValueError(
+                "litellm_base_url requires litellm to be installed. Install with: pip install 'openai-agents[litellm]'"
             )
         return v
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -204,6 +204,300 @@ def test_litellm_openai_provider_can_use_generic_api_key_fallback() -> None:
     assert agent.model.api_key == "sk-openai"
 
 
+def test_litellm_anthropic_preserves_original_base_url_when_openai_base_url_provided() -> None:
+    """Anthropic LiteLLM models must not pick up config.base_url from a sibling OpenAI override."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(
+        model="anthropic/claude-sonnet-4-5-20250929", base_url="http://litellm.local", api_key=None
+    )
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    # Mixed request: Codex OAuth base_url for OpenAI-side work + anthropic litellm key for the LiteLLM agent.
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            api_key="codex-oauth-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+            litellm_keys={"anthropic": "sk-ant-request"},
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4-5-20250929"
+    # Must NOT inherit the Codex OAuth base_url; LiteLLM would route Anthropic to the wrong host.
+    assert agent.model.base_url == "http://litellm.local"
+    # Must use the per-request Anthropic key.
+    assert agent.model.api_key == "sk-ant-request"
+
+
+def test_litellm_anthropic_string_model_ignores_openai_base_url() -> None:
+    """String-form litellm/anthropic models must also ignore the sibling OpenAI base_url."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    agent = Agent(name="A", instructions="x", model="litellm/anthropic/claude-sonnet-4-5-20250929")
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            api_key="codex-oauth-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+            litellm_keys={"anthropic": "sk-ant-request"},
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4-5-20250929"
+    assert agent.model.base_url is None
+    assert agent.model.api_key == "sk-ant-request"
+
+
+def test_litellm_anthropic_preserves_user_provided_proxy_base_url() -> None:
+    """Explicit litellm_base_url must be honored for non-OpenAI providers."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    agent = Agent(name="A", instructions="x", model="litellm/anthropic/claude-sonnet-4-5-20250929")
+    agency = _Agency(agent)
+
+    # Mixed request with explicit LiteLLM proxy gateway via the dedicated field.
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            api_key=None,
+            base_url=None,
+            litellm_keys={"anthropic": "sk-ant-request"},
+            litellm_base_url="https://litellm-proxy.example.com",
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.base_url == "https://litellm-proxy.example.com"
+    assert agent.model.api_key == "sk-ant-request"
+
+
+def test_litellm_anthropic_ignores_any_openai_base_url() -> None:
+    """config.base_url is OpenAI-only; never applied to an Anthropic LiteLLM agent."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    # Azure / generic OpenAI gateway URL — must not leak into the Anthropic path either.
+    for opaque_openai_base in [
+        "https://my-azure.openai.azure.com",
+        "https://api.openai.com/v1",
+        "https://openai-gateway.example.com",
+    ]:
+        agent = Agent(name="A", instructions="x", model="litellm/anthropic/claude-sonnet-4-5-20250929")
+        agency = _Agency(agent)
+        apply_openai_client_config(
+            agency,
+            ClientConfig(
+                api_key="sk-openai-side",
+                base_url=opaque_openai_base,
+                litellm_keys={"anthropic": "sk-ant-request"},
+            ),
+        )
+        assert isinstance(agent.model, LitellmModel), opaque_openai_base
+        assert agent.model.base_url is None, (opaque_openai_base, agent.model.base_url)
+        assert agent.model.api_key == "sk-ant-request"
+
+
+def test_litellm_base_url_only_request_still_applies() -> None:
+    """A request that only sets litellm_base_url must still reach the LiteLLM agent."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    agent = Agent(name="A", instructions="x", model="litellm/anthropic/claude-sonnet-4-5-20250929")
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(litellm_base_url="https://litellm-proxy.example.com"),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.base_url == "https://litellm-proxy.example.com"
+
+
+def test_litellm_providerless_openai_name_inherits_openai_overrides() -> None:
+    """'gpt-4o-mini' (providerless, LiteLLM routes as openai) should inherit config.base_url."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+    pytest.importorskip("litellm")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(model="gpt-4o-mini", base_url=None, api_key=None)
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(api_key="sk-openai", base_url="https://openai-gateway.example.com"),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.base_url == "https://openai-gateway.example.com"
+    assert agent.model.api_key == "sk-openai"
+
+
+def test_litellm_providerless_non_openai_name_preserves_existing_api_key() -> None:
+    """Providerless LitellmModel names (e.g. 'claude-sonnet-4') must not inherit OpenAI api_key."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(model="claude-sonnet-4-5", base_url=None, api_key="sk-ant-baseline")
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(api_key="sk-openai-side", base_url="https://api.openai.com/v1"),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    # Providerless non-OpenAI model must preserve its existing api_key.
+    assert agent.model.api_key == "sk-ant-baseline"
+
+
+def test_litellm_nested_openrouter_route_keeps_existing_credentials() -> None:
+    """openrouter/openai/... resolves to openrouter (not openai), so OpenAI-side overrides don't leak."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+    pytest.importorskip("litellm")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(
+        model="openrouter/openai/gpt-4o", base_url="http://openrouter.local", api_key="or-baseline"
+    )
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(api_key="sk-openai-side", base_url="https://api.openai.com/v1"),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    # LiteLLM authenticates this as openrouter, so OpenAI-side base_url/api_key must NOT leak.
+    assert agent.model.base_url == "http://openrouter.local"
+    assert agent.model.api_key == "or-baseline"
+
+
+def test_litellm_base_url_takes_precedence_for_openai_based_providers() -> None:
+    """An explicit litellm_base_url overrides config.base_url even for OpenAI-based LiteLLM."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(model="openai/gpt-4o-mini", base_url=None, api_key=None)
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            api_key="sk-openai",
+            base_url="https://openai-gateway.example.com",
+            litellm_base_url="https://litellm-proxy.example.com",
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    # The dedicated LiteLLM proxy wins over the generic OpenAI gateway.
+    assert agent.model.base_url == "https://litellm-proxy.example.com"
+
+
 def test_openai_client_override_applies_codex_compatibility_model_settings() -> None:
     """Codex overrides should use the Responses settings the browser-auth backend accepts."""
     pytest.importorskip("agents")


### PR DESCRIPTION
## Linked issue
None.

## Type
Bug fix.

## What does it do

- Root cause: when a FastAPI request carried both an OpenAI-side `base_url` (for example the Codex OAuth endpoint that agentswarm-cli forwards along with stored credentials) and `litellm_keys` for a non-OpenAI provider, the previous code fed that OpenAI `base_url` straight into `LitellmModel`. LiteLLM then routed the Anthropic call to the OpenAI host and returned `litellm.NotFoundError: AnthropicException - {"detail":"Not Found"}`. This was confirmed against Anthropic through the CLI agent.
- Authoritative provider routing: use `litellm.get_llm_provider()` to ask LiteLLM where a given model actually routes instead of guessing from path segments. `base_url` and `api_key` from `config.base_url` / `config.api_key` are forwarded only when the resolved provider is OpenAI-based (`openai`, `azure`, `azure_ai`, `openai_compatible`, `text-completion-openai`). All other providers fall back to the original `LitellmModel.base_url` (or `None` for newly built models), so LiteLLM's native routing drives the request to the correct provider host.
- New `ClientConfig.litellm_base_url` field: explicit LiteLLM proxy URL for callers who want to route LiteLLM requests through their own gateway. `config.base_url` stays OpenAI-only and is never forwarded to non-OpenAI LiteLLM calls. The new field is validated when `litellm` is not installed, so unsupported setups fail fast instead of silently ignoring configuration.
- Both code paths are covered: `_apply_client_to_agent` (rebuilds an existing `LitellmModel` with request overrides) and `_apply_litellm_config` (materializes a string `model` attribute into a fresh `LitellmModel`).

## How verified

- `python -m pytest tests/test_fastapi_utils_modules/ -x -q` → `76 passed, 1 skipped` on this branch.
- New regression tests cover: the Codex-URL Anthropic leak (original repro), nested OpenAI gateway routes such as `openrouter/openai/...`, providerless `gpt-4o-mini`, explicit `litellm_base_url`, OpenAI-only `litellm_base_url` precedence over `base_url`, and `text-completion-openai`.
- Manual bridge repro: POST to `/local-agency/get_response_stream` with the full CLI-style `client_config` (`api_key` + `base_url` from Codex OAuth, `litellm_keys.anthropic` set, agent pinned to `litellm/anthropic/claude-sonnet-4-5`) now returns the assistant reply (`pong`) instead of a 404 from Anthropic routing.

## Checklist

- [x] New or updated regression tests accompany the fix.
- [x] Focused test suite runs green locally.
- [x] No unrelated behavior changes; `config.base_url` continues to apply for OpenAI-based providers.
- [x] No new public surface beyond the documented `litellm_base_url` field.
