### PR TITLE
feat(fastapi): allow per-request agent model override via client_config.model

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator, Callable, Sequence
 from dataclasses import dataclass, field
 from importlib import metadata
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from weakref import WeakKeyDictionary
 
 from ag_ui.core import EventType, MessagesSnapshotEvent, RunErrorEvent, RunFinishedEvent, RunStartedEvent
@@ -48,6 +48,7 @@ from agency_swarm import (
     RunContextWrapper,
 )
 from agency_swarm.agent.execution_stream_response import StreamingRunResponse
+from agency_swarm.agent.initialization import apply_framework_defaults
 from agency_swarm.integrations.fastapi_utils.file_handler import upload_from_urls
 from agency_swarm.integrations.fastapi_utils.logging_middleware import get_logs_endpoint_impl
 from agency_swarm.integrations.fastapi_utils.override_policy import (
@@ -127,7 +128,7 @@ _AGENCY_REQUEST_STATES: WeakKeyDictionary[Agency, dict[asyncio.AbstractEventLoop
 _AGENCY_REQUEST_STATES_GUARD = threading.Lock()
 
 
-def _apply_request_model_override(agent: Agent, model_name: str) -> None:
+def _apply_request_model_override(agent: Agent, model_name: str, config: ClientConfig | None = None) -> bool:
     """Set ``agent.model`` to ``model_name`` for this request, preserving existing wiring.
 
     A per-request model swap must not silently discard the agent's embedded
@@ -136,38 +137,101 @@ def _apply_request_model_override(agent: Agent, model_name: str) -> None:
 
     - ``OpenAIResponsesModel`` / ``OpenAIChatCompletionsModel`` keep their
       embedded ``AsyncOpenAI`` client and their transport (Responses vs
-      ChatCompletions). The model name is swapped in place.
+      ChatCompletions). The model name is swapped in place. Any post-construction
+      usage alias (e.g. ``_agency_swarm_usage_model_name`` set by the OpenClaw
+      adapter) is carried across the rebuild so cost tracking stays correct.
     - ``LitellmModel`` keeps its existing ``base_url`` / ``api_key`` and only
       the model identifier is swapped.
     - Bare-string agents become bare strings (or a minimal ``LitellmModel`` for
       ``litellm/...`` names).
+
+    When ``config`` carries OpenAI gateway overrides (``base_url`` / ``api_key`` /
+    ``default_headers``), the rebuilt OpenAI wrapper is routed through
+    :func:`_build_openai_client_for_agent` so the request gateway reaches the
+    swapped model even when the new name is provider-prefixed (for example
+    ``anthropic/claude-sonnet-4``) and would otherwise fail the downstream
+    ``_agent_supports_openai_client_override`` gate.
+
+    Returns ``True`` when the OpenAI gateway client has already been applied
+    during the swap so the caller can skip the downstream client-apply step.
     """
     model = agent.model
+    gateway_client = _resolve_request_gateway_client(agent, config)
 
     if isinstance(model, OpenAIResponsesModel):
         if _is_litellm_model(model_name):
             _apply_request_litellm_model(agent, model_name)
-            return
-        agent.model = OpenAIResponsesModel(model=model_name, openai_client=model._client)
-        return
+            return False
+        client = gateway_client if gateway_client is not None else model._client
+        agent.model = _rebuild_openai_responses_model(model, model_name, client)
+        return gateway_client is not None
 
     if isinstance(model, OpenAIChatCompletionsModel):
         if _is_litellm_model(model_name):
             _apply_request_litellm_model(agent, model_name)
-            return
-        agent.model = OpenAIChatCompletionsModel(model=model_name, openai_client=model._client)
-        return
+            return False
+        client = gateway_client if gateway_client is not None else model._client
+        agent.model = OpenAIChatCompletionsModel(model=model_name, openai_client=client)
+        return gateway_client is not None
 
     if _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
         actual = model_name[8:] if model_name.startswith("litellm/") else model_name
         agent.model = LitellmModel(model=actual, base_url=model.base_url, api_key=model.api_key)
-        return
+        return False
 
     if _is_litellm_model(model_name):
         _apply_request_litellm_model(agent, model_name)
-        return
+        return False
 
     agent.model = model_name
+    return False
+
+
+def _resolve_request_gateway_client(agent: Agent, config: ClientConfig | None) -> AsyncOpenAI | None:
+    """Return a request-scoped OpenAI gateway client when ``config`` asks for one."""
+    if config is None:
+        return None
+    if config.base_url is None and config.api_key is None and config.default_headers is None:
+        return None
+    return _build_openai_client_for_agent(agent, config)
+
+
+def _rebuild_openai_responses_model(
+    source: OpenAIResponsesModel,
+    model_name: str,
+    client: AsyncOpenAI,
+) -> OpenAIResponsesModel:
+    """Rebuild ``OpenAIResponsesModel`` while preserving the usage-tracking alias."""
+    rebuilt = OpenAIResponsesModel(model=model_name, openai_client=client)
+    usage_alias = getattr(source, "_agency_swarm_usage_model_name", None)
+    if isinstance(usage_alias, str) and usage_alias:
+        rebuilt._agency_swarm_usage_model_name = usage_alias  # type: ignore[attr-defined]
+    return rebuilt
+
+
+def _refresh_framework_defaults_after_model_swap(agent: Agent) -> None:
+    """Re-layer framework defaults for the new ``agent.model`` without losing headers.
+
+    ``Agent.__init__`` calls ``apply_framework_defaults`` to layer model-family
+    defaults (e.g. GPT-5 reasoning effort). After a request-time model swap we
+    replay the same logic so the new model's defaults take effect, and we carry
+    caller-set ``extra_headers`` from the pre-swap ``model_settings`` forward so
+    request-applied headers are not wiped.
+    """
+    previous: ModelSettings | None = getattr(agent, "model_settings", None)
+    preserved_headers = dict(previous.extra_headers) if previous is not None and previous.extra_headers else None
+
+    kwargs: dict[str, Any] = {"model": agent.model}
+    if previous is not None:
+        kwargs["model_settings"] = previous
+    apply_framework_defaults(kwargs)
+
+    refreshed = cast(ModelSettings, kwargs["model_settings"])
+    if preserved_headers:
+        existing = dict(refreshed.extra_headers or {})
+        existing.update(preserved_headers)
+        refreshed.extra_headers = existing
+    agent.model_settings = refreshed
 
 
 def _apply_request_litellm_model(agent: Agent, model_name: str) -> None:
@@ -217,8 +281,10 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
 
     # Apply to all agents in the agency
     for agent in agency.agents.values():
+        gateway_applied = False
         if config.model is not None:
-            _apply_request_model_override(agent, config.model)
+            gateway_applied = _apply_request_model_override(agent, config.model, config)
+            _refresh_framework_defaults_after_model_swap(agent)
 
         # File attachment handling uses agent.client / agent.client_sync directly.
         # Keep those clients request-scoped too, so file_ids work without server env keys.
@@ -234,6 +300,14 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
             continue
 
         if not openai_overrides_present:
+            continue
+
+        if gateway_applied:
+            # Gateway client was already routed through the freshly rebuilt model.
+            if config.default_headers is not None:
+                _apply_default_headers_to_agent_model_settings(agent, config.default_headers)
+            if _is_codex_base_url(config.base_url):
+                _apply_codex_compatibility_model_settings(agent)
             continue
 
         if not _agent_supports_openai_client_override(agent):

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -127,25 +127,44 @@ _AGENCY_REQUEST_STATES: WeakKeyDictionary[Agency, dict[asyncio.AbstractEventLoop
 _AGENCY_REQUEST_STATES_GUARD = threading.Lock()
 
 
+def _apply_request_model_override(agent: Agent, model_name: str) -> None:
+    """Set ``agent.model`` to ``model_name`` for this request (restored via snapshot)."""
+    if _is_litellm_model(model_name):
+        if not _LITELLM_AVAILABLE or LitellmModel is None:
+            logger.warning(
+                "Cannot apply client_config.model to agent '%s': model %r requires litellm "
+                "(install openai-agents[litellm])",
+                agent.name,
+                model_name,
+            )
+            return
+        actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+        agent.model = LitellmModel(model=actual, base_url=None, api_key=None)
+        return
+    agent.model = model_name
+
+
 def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
     """Apply custom OpenAI client configuration to all agents in the agency.
 
     Creates a new AsyncOpenAI client with the provided base_url and/or api_key,
-    then updates each agent's model to use this client. This allows per-request
-    client configuration without rebuilding templates.
+    optionally sets every agent's model from ``config.model``, then updates each
+    agent's model to use this client. This allows per-request client configuration
+    without rebuilding templates.
 
     Parameters
     ----------
     agency : Agency
         The agency instance to configure.
     config : ClientConfig
-        Configuration containing base_url and/or api_key overrides.
+        Configuration containing base_url, api_key, optional ``model``, and other overrides.
     """
     if (
         config.base_url is None
         and config.api_key is None
         and config.default_headers is None
         and config.litellm_keys is None
+        and config.model is None
     ):
         return  # Nothing to override
 
@@ -158,6 +177,9 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
 
     # Apply to all agents in the agency
     for agent in agency.agents.values():
+        if config.model is not None:
+            _apply_request_model_override(agent, config.model)
+
         # File attachment handling uses agent.client / agent.client_sync directly.
         # Keep those clients request-scoped too, so file_ids work without server env keys.
         if openai_overrides_present:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -183,6 +183,14 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
         _apply_request_litellm_model(agent, model_name)
         return False
 
+    if gateway_client is not None:
+        # Wrap bare-string swaps through the request gateway client so provider-prefixed
+        # names (e.g. "anthropic/claude-sonnet-4") still reach the gateway — the downstream
+        # _agent_supports_openai_client_override gate rejects those names and would
+        # otherwise drop the request-scoped client entirely.
+        agent.model = OpenAIResponsesModel(model=model_name, openai_client=gateway_client)
+        return True
+
     agent.model = model_name
     return False
 
@@ -201,10 +209,22 @@ def _rebuild_openai_responses_model(
     model_name: str,
     client: AsyncOpenAI,
 ) -> OpenAIResponsesModel:
-    """Rebuild ``OpenAIResponsesModel`` while preserving the usage-tracking alias."""
+    """Rebuild ``OpenAIResponsesModel`` while preserving OpenClaw-scoped aliases.
+
+    - ``_agency_swarm_default_model_name`` drives OpenClaw default-settings lookup
+      and must survive the rebuild whenever the source carried it.
+    - ``_agency_swarm_usage_model_name`` maps the wrapper's ``.model`` to an
+      upstream provider model for cost tracking. It is only valid for the exact
+      source model name — carrying it across a model-name change would mis-label
+      usage (e.g. ``openclaw:main`` -> ``gpt-4.1`` still reporting OpenClaw's
+      upstream). Copy it only when the rebuilt model name matches the source.
+    """
     rebuilt = OpenAIResponsesModel(model=model_name, openai_client=client)
+    default_alias = getattr(source, "_agency_swarm_default_model_name", None)
+    if isinstance(default_alias, str) and default_alias:
+        rebuilt._agency_swarm_default_model_name = default_alias  # type: ignore[attr-defined]
     usage_alias = getattr(source, "_agency_swarm_usage_model_name", None)
-    if isinstance(usage_alias, str) and usage_alias:
+    if isinstance(usage_alias, str) and usage_alias and rebuilt.model == source.model:
         rebuilt._agency_swarm_usage_model_name = usage_alias  # type: ignore[attr-defined]
     return rebuilt
 
@@ -214,16 +234,18 @@ def _refresh_framework_defaults_after_model_swap(agent: Agent) -> None:
 
     ``Agent.__init__`` calls ``apply_framework_defaults`` to layer model-family
     defaults (e.g. GPT-5 reasoning effort). After a request-time model swap we
-    replay the same logic so the new model's defaults take effect, and we carry
-    caller-set ``extra_headers`` from the pre-swap ``model_settings`` forward so
-    request-applied headers are not wiped.
+    replay that logic with a fresh ``ModelSettings()`` so every field recomputes
+    from the new model name — otherwise fields from the OLD settings (e.g. a
+    ``reasoning.effort`` baked for GPT-5) would stick when swapping to GPT-4o.
+    Only caller-set ``extra_headers`` from the pre-swap ``model_settings`` are
+    carried forward so previously applied request headers survive the refresh.
     """
     previous: ModelSettings | None = getattr(agent, "model_settings", None)
     preserved_headers = dict(previous.extra_headers) if previous is not None and previous.extra_headers else None
 
-    kwargs: dict[str, Any] = {"model": agent.model}
-    if previous is not None:
-        kwargs["model_settings"] = previous
+    # Pass a fresh ModelSettings() so apply_framework_defaults doesn't treat
+    # stale fields from the previous model as caller-explicit overrides.
+    kwargs: dict[str, Any] = {"model": agent.model, "model_settings": ModelSettings()}
     apply_framework_defaults(kwargs)
 
     refreshed = cast(ModelSettings, kwargs["model_settings"])

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -211,49 +211,61 @@ def _rebuild_openai_responses_model(
 ) -> OpenAIResponsesModel:
     """Rebuild ``OpenAIResponsesModel`` while preserving OpenClaw-scoped aliases.
 
-    - ``_agency_swarm_default_model_name`` drives OpenClaw default-settings lookup
-      and must survive the rebuild whenever the source carried it.
-    - ``_agency_swarm_usage_model_name`` maps the wrapper's ``.model`` to an
-      upstream provider model for cost tracking. It is only valid for the exact
-      source model name — carrying it across a model-name change would mis-label
-      usage (e.g. ``openclaw:main`` -> ``gpt-4.1`` still reporting OpenClaw's
-      upstream). Copy it only when the rebuilt model name matches the source.
+    Both ``_agency_swarm_default_model_name`` (drives OpenClaw default-settings
+    lookup) and ``_agency_swarm_usage_model_name`` (maps the wrapper's ``.model``
+    to an upstream provider model for cost tracking) are scoped to the exact
+    (model name, base URL) OpenClaw registration that produced them. Carrying
+    either across a change in model name OR base URL would apply the wrong
+    family defaults / mis-label usage — e.g. keeping ``openclaw:main`` but
+    pointing at a new gateway invalidates the original registration. Only copy
+    the aliases when BOTH identifiers still match the source.
     """
     rebuilt = OpenAIResponsesModel(model=model_name, openai_client=client)
+    same_identity = rebuilt.model == source.model and _client_base_url(client) == _client_base_url(source._client)
+    if not same_identity:
+        return rebuilt
     default_alias = getattr(source, "_agency_swarm_default_model_name", None)
     if isinstance(default_alias, str) and default_alias:
         rebuilt._agency_swarm_default_model_name = default_alias  # type: ignore[attr-defined]
     usage_alias = getattr(source, "_agency_swarm_usage_model_name", None)
-    if isinstance(usage_alias, str) and usage_alias and rebuilt.model == source.model:
+    if isinstance(usage_alias, str) and usage_alias:
         rebuilt._agency_swarm_usage_model_name = usage_alias  # type: ignore[attr-defined]
     return rebuilt
 
 
-def _refresh_framework_defaults_after_model_swap(agent: Agent) -> None:
-    """Re-layer framework defaults for the new ``agent.model`` without losing headers.
+def _client_base_url(client: AsyncOpenAI) -> str:
+    """Return the normalized base URL for an OpenAI client, for identity comparison."""
+    base_url = getattr(client, "base_url", None)
+    return str(base_url).rstrip("/") if base_url is not None else ""
 
-    ``Agent.__init__`` calls ``apply_framework_defaults`` to layer model-family
-    defaults (e.g. GPT-5 reasoning effort). After a request-time model swap we
-    replay that logic with a fresh ``ModelSettings()`` so every field recomputes
-    from the new model name — otherwise fields from the OLD settings (e.g. a
-    ``reasoning.effort`` baked for GPT-5) would stick when swapping to GPT-4o.
-    Only caller-set ``extra_headers`` from the pre-swap ``model_settings`` are
-    carried forward so previously applied request headers survive the refresh.
+
+# Fields that `agents.models.default_models.get_default_model_settings` varies by
+# model family (currently the GPT-5 family sets these non-None). Keep this list
+# in lockstep with that SDK helper — refreshing any other fields would drop
+# caller-explicit generation tuning on a per-request model swap.
+_MODEL_FAMILY_DEFAULT_FIELDS: tuple[str, ...] = ("reasoning", "verbosity")
+
+
+def _refresh_framework_defaults_after_model_swap(agent: Agent) -> None:
+    """Re-layer model-family defaults for the new ``agent.model`` without wiping caller fields.
+
+    ``apply_framework_defaults`` treats any non-None field on the input
+    ``ModelSettings`` as caller-explicit and preserves it. So to force a fresh
+    model-family default (e.g. GPT-5's ``reasoning.effort`` / ``verbosity``
+    bleeding into a GPT-4o swap) we clear ONLY the family-scoped fields on a
+    copy of the previous settings and let ``apply_framework_defaults`` recompute
+    them for the new model. Every other caller-tuned field (``temperature``,
+    ``max_tokens``, ``top_p``, ``parallel_tool_calls``, ``extra_headers``, ...)
+    survives untouched.
     """
     previous: ModelSettings | None = getattr(agent, "model_settings", None)
-    preserved_headers = dict(previous.extra_headers) if previous is not None and previous.extra_headers else None
+    cleared = copy.deepcopy(previous) if previous is not None else ModelSettings()
+    for field_name in _MODEL_FAMILY_DEFAULT_FIELDS:
+        setattr(cleared, field_name, None)
 
-    # Pass a fresh ModelSettings() so apply_framework_defaults doesn't treat
-    # stale fields from the previous model as caller-explicit overrides.
-    kwargs: dict[str, Any] = {"model": agent.model, "model_settings": ModelSettings()}
+    kwargs: dict[str, Any] = {"model": agent.model, "model_settings": cleared}
     apply_framework_defaults(kwargs)
-
-    refreshed = cast(ModelSettings, kwargs["model_settings"])
-    if preserved_headers:
-        existing = dict(refreshed.extra_headers or {})
-        existing.update(preserved_headers)
-        refreshed.extra_headers = existing
-    agent.model_settings = refreshed
+    agent.model_settings = cast(ModelSettings, kwargs["model_settings"])
 
 
 def _apply_request_litellm_model(agent: Agent, model_name: str) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -128,20 +128,60 @@ _AGENCY_REQUEST_STATES_GUARD = threading.Lock()
 
 
 def _apply_request_model_override(agent: Agent, model_name: str) -> None:
-    """Set ``agent.model`` to ``model_name`` for this request (restored via snapshot)."""
-    if _is_litellm_model(model_name):
-        if not _LITELLM_AVAILABLE or LitellmModel is None:
-            logger.warning(
-                "Cannot apply client_config.model to agent '%s': model %r requires litellm "
-                "(install openai-agents[litellm])",
-                agent.name,
-                model_name,
-            )
+    """Set ``agent.model`` to ``model_name`` for this request, preserving existing wiring.
+
+    A per-request model swap must not silently discard the agent's embedded
+    OpenAI client, wrapped model subtype, or LiteLLM credentials. Replace only
+    the ``.model`` attribute of the current wrapper and keep everything else.
+
+    - ``OpenAIResponsesModel`` / ``OpenAIChatCompletionsModel`` keep their
+      embedded ``AsyncOpenAI`` client and their transport (Responses vs
+      ChatCompletions). The model name is swapped in place.
+    - ``LitellmModel`` keeps its existing ``base_url`` / ``api_key`` and only
+      the model identifier is swapped.
+    - Bare-string agents become bare strings (or a minimal ``LitellmModel`` for
+      ``litellm/...`` names).
+    """
+    model = agent.model
+
+    if isinstance(model, OpenAIResponsesModel):
+        if _is_litellm_model(model_name):
+            _apply_request_litellm_model(agent, model_name)
             return
-        actual = model_name[8:] if model_name.startswith("litellm/") else model_name
-        agent.model = LitellmModel(model=actual, base_url=None, api_key=None)
+        agent.model = OpenAIResponsesModel(model=model_name, openai_client=model._client)
         return
+
+    if isinstance(model, OpenAIChatCompletionsModel):
+        if _is_litellm_model(model_name):
+            _apply_request_litellm_model(agent, model_name)
+            return
+        agent.model = OpenAIChatCompletionsModel(model=model_name, openai_client=model._client)
+        return
+
+    if _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
+        actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+        agent.model = LitellmModel(model=actual, base_url=model.base_url, api_key=model.api_key)
+        return
+
+    if _is_litellm_model(model_name):
+        _apply_request_litellm_model(agent, model_name)
+        return
+
     agent.model = model_name
+
+
+def _apply_request_litellm_model(agent: Agent, model_name: str) -> None:
+    """Build a fresh ``LitellmModel`` for the request when the original wrapper was not LiteLLM."""
+    if not _LITELLM_AVAILABLE or LitellmModel is None:
+        logger.warning(
+            "Cannot apply client_config.model to agent '%s': model %r requires litellm "
+            "(install openai-agents[litellm])",
+            agent.name,
+            model_name,
+        )
+        return
+    actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+    agent.model = LitellmModel(model=actual, base_url=None, api_key=None)
 
 
 def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -27,6 +27,7 @@ class RequestOverridePolicy:
             or self.config.api_key is not None
             or self.config.default_headers is not None
             or self.config.litellm_keys is not None
+            or getattr(self.config, "model", None) is not None
         )
 
     @property

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -46,6 +46,13 @@ class ClientConfig(BaseModel):
             "variables; OpenAI-compatible providers may fall back to 'api_key'."
         ),
     )
+    model: str | None = Field(
+        default=None,
+        description=(
+            "If set, every agent in the agency uses this model name for the request only "
+            "(same string forms as Agent.model: OpenAI names, 'openai/…', 'litellm/…', provider paths, etc.)."
+        ),
+    )
 
     @field_validator("litellm_keys")
     @classmethod
@@ -86,7 +93,7 @@ class RunAgentInputCustom(RunAgentInput):
     )
     client_config: ClientConfig | None = Field(
         default=None,
-        description="Override client configuration (base_url, api_key, litellm_keys) for this request only.",
+        description="Override client configuration (base_url, api_key, litellm_keys, model) for this request only.",
     )
 
 
@@ -120,7 +127,7 @@ class BaseRequest(BaseModel):
     )
     client_config: ClientConfig | None = Field(
         default=None,
-        description="Override client configuration (base_url, api_key, litellm_keys) for this request only.",
+        description="Override client configuration (base_url, api_key, litellm_keys, model) for this request only.",
     )
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -458,3 +458,107 @@ def test_model_override_preserves_openclaw_usage_alias() -> None:
     assert isinstance(agent.model, OpenAIResponsesModel)
     # Same name, new instance — the custom alias must carry over.
     assert get_usage_tracking_model_name(agent.model) == "openai/gpt-5.4"
+
+
+def test_string_model_override_wraps_gateway_for_provider_prefix() -> None:
+    """Bare-string agents whose request model is provider-prefixed must still bind the gateway client."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="anthropic/claude-sonnet-4",
+            base_url="https://gateway.test/v1",
+            api_key="sk-gateway",
+        ),
+    )
+
+    # The provider-prefixed name must route through the request-scoped gateway client,
+    # not silently stay as a bare string (which would skip the override entirely).
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4"
+    assert agent.model._client.api_key == "sk-gateway"
+    assert str(agent.model._client.base_url).startswith("https://gateway.test")
+
+
+def test_model_override_does_not_stick_old_gpt5_reasoning_settings() -> None:
+    """Swapping GPT-5 -> GPT-4o must recompute settings, not inherit GPT-5 reasoning."""
+    pytest.importorskip("agents")
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    # Agent starts on gpt-5, which layers reasoning.effort="low" at construction.
+    agent = Agent(name="A", instructions="x", model="gpt-5")
+    assert agent.model_settings is not None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "low"
+
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4o"))
+
+    # After swapping to gpt-4o, the old GPT-5 reasoning defaults must not stick.
+    assert agent.model == "gpt-4o"
+    assert agent.model_settings is not None
+    assert agent.model_settings.reasoning is None
+
+
+def test_model_override_carries_openclaw_default_settings_alias() -> None:
+    """OpenClaw default-settings alias must survive a same-name request model swap."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.model_utils import get_default_settings_model_name
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://openclaw.test/v1")
+    source = OpenAIResponsesModel(model="openclaw:main", openai_client=embedded)
+    source._agency_swarm_default_model_name = "gpt-5"  # type: ignore[attr-defined]
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openclaw:main"))
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    # OpenClaw default-settings lookup relies on this alias being carried.
+    assert get_default_settings_model_name(agent.model) == "gpt-5"
+
+
+def test_model_override_drops_usage_alias_when_model_name_changes() -> None:
+    """OpenClaw usage alias must NOT be copied when the swap changes the model name."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.model_utils import get_usage_tracking_model_name
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://openclaw.test/v1")
+    source = OpenAIResponsesModel(model="openclaw:main", openai_client=embedded)
+    source._agency_swarm_usage_model_name = "openai/gpt-5.4"  # type: ignore[attr-defined]
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4.1"))
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model.model == "gpt-4.1"
+    # The alias belonged to openclaw:main — it must not inherit onto gpt-4.1.
+    assert get_usage_tracking_model_name(agent.model) == "gpt-4.1"

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -26,7 +26,13 @@ from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, 
         ),
         (
             {},
-            {"base_url": None, "api_key": None, "default_headers": None, "litellm_keys": None},
+            {
+                "base_url": None,
+                "api_key": None,
+                "default_headers": None,
+                "litellm_keys": None,
+                "model": None,
+            },
         ),
     ],
 )
@@ -259,6 +265,24 @@ def test_snapshot_restore_preserves_model_settings_headers() -> None:
     _restore_agency_state(agency, snapshot)
 
     assert agent.model_settings.extra_headers == {"x-orig": "1"}
+
+
+def test_model_override_applies_to_all_agents() -> None:
+    """client_config.model should replace every agent's model for the request."""
+    pytest.importorskip("agents")
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    a1 = Agent(name="A1", instructions="x", model="gpt-4o-mini")
+    a2 = Agent(name="A2", instructions="y", model="gpt-4o")
+    agency = type("Agency", (), {"agents": {"A1": a1, "A2": a2}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4.1"))
+
+    assert a1.model == "gpt-4.1"
+    assert a2.model == "gpt-4.1"
 
 
 def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -285,6 +285,75 @@ def test_model_override_applies_to_all_agents() -> None:
     assert a2.model == "gpt-4.1"
 
 
+def test_model_override_preserves_openai_responses_client() -> None:
+    """config.model on an OpenAIResponsesModel agent keeps the embedded client + transport."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://api.agent.test/v1")
+    original = OpenAIResponsesModel(model="gpt-4o", openai_client=embedded)
+    agent = Agent(name="A", instructions="x", model=original)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4.1"))
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model.model == "gpt-4.1"
+    assert agent.model._client is embedded
+
+
+def test_model_override_preserves_chat_completions_transport() -> None:
+    """config.model on an OpenAIChatCompletionsModel agent keeps the ChatCompletions transport + client."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://chat.agent.test/v1")
+    original = OpenAIChatCompletionsModel(model="gpt-4o", openai_client=embedded)
+    agent = Agent(name="A", instructions="x", model=original)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4.1"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "gpt-4.1"
+    assert agent.model._client is embedded
+
+
+def test_model_override_preserves_litellm_credentials() -> None:
+    """config.model on a LitellmModel agent keeps the existing base_url + api_key."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    original = LitellmModel(model="anthropic/claude-sonnet-4", base_url="http://litellm.local", api_key="sk-existing")
+    agent = Agent(name="A", instructions="x", model=original)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="litellm/anthropic/claude-opus-4"))
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "anthropic/claude-opus-4"
+    assert agent.model.base_url == "http://litellm.local"
+    assert agent.model.api_key == "sk-existing"
+
+
 def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:
     """Custom non-OpenAI model names should skip OpenAI client construction entirely."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -562,3 +562,69 @@ def test_model_override_drops_usage_alias_when_model_name_changes() -> None:
     assert agent.model.model == "gpt-4.1"
     # The alias belonged to openclaw:main — it must not inherit onto gpt-4.1.
     assert get_usage_tracking_model_name(agent.model) == "gpt-4.1"
+
+
+def test_model_override_preserves_caller_generation_settings_on_gpt5_to_gpt4o_swap() -> None:
+    """Caller-tuned generation settings must survive a GPT-5 -> GPT-4o swap."""
+    pytest.importorskip("agents")
+
+    from agents import ModelSettings
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(
+        name="A",
+        instructions="x",
+        model="gpt-5",
+        model_settings=ModelSettings(temperature=0.7, max_tokens=123),
+    )
+    # Sanity-check pre-swap state: GPT-5 family defaults are layered on top.
+    assert agent.model_settings.temperature == 0.7
+    assert agent.model_settings.max_tokens == 123
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "low"
+
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4o"))
+
+    # After the swap the GPT-5 family defaults are gone, but caller-tuned
+    # generation settings remain intact.
+    assert agent.model == "gpt-4o"
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.verbosity is None
+    assert agent.model_settings.temperature == 0.7
+    assert agent.model_settings.max_tokens == 123
+
+
+def test_model_override_drops_openclaw_aliases_when_base_url_changes() -> None:
+    """OpenClaw aliases must NOT be copied when the rebuild swaps the gateway base URL."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.model_utils import get_default_settings_model_name, get_usage_tracking_model_name
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://openclaw.test/v1")
+    source = OpenAIResponsesModel(model="openclaw:main", openai_client=embedded)
+    source._agency_swarm_default_model_name = "gpt-5"  # type: ignore[attr-defined]
+    source._agency_swarm_usage_model_name = "openai/gpt-5.4"  # type: ignore[attr-defined]
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    # Same model name, but base_url changes — the old OpenClaw registration is stale.
+    apply_openai_client_config(
+        agency,
+        ClientConfig(model="openclaw:main", base_url="https://other-gateway.test/v1", api_key="sk-new"),
+    )
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model.model == "openclaw:main"
+    # Both aliases must be dropped — the rebuilt wrapper is now pointing at a different gateway.
+    assert get_default_settings_model_name(agent.model) == "openclaw:main"
+    assert get_usage_tracking_model_name(agent.model) == "openclaw:main"

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -376,3 +376,85 @@ def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:
 
     # Should not raise; unsupported custom models are skipped.
     endpoint_handlers.apply_openai_client_config(agency, ClientConfig(default_headers={"x-test": "1"}))
+
+
+def test_provider_path_model_override_routes_request_gateway_client() -> None:
+    """Provider-prefixed request model must still flow through the request gateway client."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://api.agent.test/v1")
+    agent = Agent(name="A", instructions="x", model=OpenAIResponsesModel(model="gpt-4o", openai_client=embedded))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="anthropic/claude-sonnet-4",
+            base_url="https://gateway.test/v1",
+            api_key="sk-gateway",
+        ),
+    )
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4"
+    # The embedded client must be replaced by the request-scoped gateway client.
+    assert agent.model._client is not embedded
+    assert agent.model._client.api_key == "sk-gateway"
+    assert str(agent.model._client.base_url).startswith("https://gateway.test")
+
+
+def test_model_override_refreshes_gpt5_framework_defaults() -> None:
+    """Swapping to a GPT-5 model should re-layer reasoning defaults without wiping headers."""
+    pytest.importorskip("agents")
+
+    from agents import ModelSettings
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agent.model_settings = ModelSettings(extra_headers={"x-caller": "1"})
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-5"))
+
+    # Reasoning effort from the SDK GPT-5 defaults must reach the agent after the swap.
+    assert agent.model == "gpt-5"
+    assert agent.model_settings is not None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "low"
+    # Caller-set extra_headers must survive the refresh.
+    assert agent.model_settings.extra_headers == {"x-caller": "1"}
+
+
+def test_model_override_preserves_openclaw_usage_alias() -> None:
+    """OpenClaw usage-name alias must survive a request model swap."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.model_utils import get_usage_tracking_model_name
+
+    embedded = AsyncOpenAI(api_key="sk-agent", base_url="https://openclaw.test/v1")
+    source = OpenAIResponsesModel(model="openclaw:main", openai_client=embedded)
+    source._agency_swarm_usage_model_name = "openai/gpt-5.4"  # type: ignore[attr-defined]
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openclaw:main"))
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    # Same name, new instance — the custom alias must carry over.
+    assert get_usage_tracking_model_name(agent.model) == "openai/gpt-5.4"

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -20,6 +20,10 @@ def test_request_override_policy_flags() -> None:
     assert policy.has_client_overrides is True
     assert policy.has_openai_overrides is True
 
+    model_only = RequestOverridePolicy(ClientConfig(model="gpt-4o-mini"))
+    assert model_only.has_client_overrides is True
+    assert model_only.has_openai_overrides is False
+
     litellm_cfg = cast(
         ClientConfig,
         SimpleNamespace(


### PR DESCRIPTION
### Type of change

- [x] New feature

### What does this PR do?

Adds a `client_config.model` field to FastAPI requests so a caller can swap an agents model on a per-request basis without rebuilding the agency or losing the agents existing wiring. Three supporting fixes ensure the swap is safe:

1. **Preserve wrapped-model wiring** — `OpenAIResponsesModel` and `OpenAIChatCompletionsModel` agents keep their embedded `AsyncOpenAI` client and their transport; `LitellmModel` agents keep their existing `base_url` and `api_key`. Model-only overrides no longer collapse a wrapped model to a bare string.
2. **Restore request gateway clients for provider-path models** — when `client_config.model` is provider-prefixed (`anthropic/...`, `litellm/...`) and the request also carries `base_url`/`api_key`, the rebuild now routes through the existing gateway-client helpers so the request-scoped OpenAI-compatible gateway actually reaches the run.
3. **Rerun framework defaults after a swap** — `apply_framework_defaults()` is replayed on the new `agent.model` so model-family-specific `model_settings` (GPT-5 `reasoning.effort="low"`, `verbosity="low"`, etc.) match what a statically configured agent would use. Caller-set `extra_headers` on `model_settings` are preserved.
4. **Keep OpenClaw usage aliases across rebuilds** — `_agency_swarm_usage_model_name` (attached by `build_openclaw_responses_model()`) is carried over when the wrapper is rebuilt, so usage tracking still reports the upstream provider model rather than falling back to `openclaw:main`.

### How did you verify your code works?

- `pytest tests/test_fastapi_utils_modules/` — 74 passing, 1 skipped, including regression tests for each scenario above (wrapped-model preservation for Responses / ChatCompletions / LiteLLM; provider-path gateway client override; GPT-5 framework-defaults refresh; OpenClaw usage-alias preservation).
- Local Codex xhigh review rounds each cleared the findings that blocked earlier iterations.

### Checklist

- [x] Wrapped-model wiring preserved on model-only overrides
- [x] Provider-path models reach the gateway client on combined overrides
- [x] Framework defaults refreshed after swap
- [x] OpenClaw usage aliases preserved
- [x] Regression tests cover each scenario
- [x] No fork drift: changes scoped to `integrations/fastapi_utils`