### PR TITLE
docs(tui): drop Agent Builder and Plan mode mentions

### DIFF
--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -22,10 +22,6 @@ Run it from your project root. If you are starting fresh, run it in a new empty 
 
 You do not need to install the TUI globally first.
 
-<Card title="Connected agency mode" icon="plug">
-  The launcher connects the TUI to an Agency Swarm server, whether it is your local project or a remote server.
-</Card>
-
 ![Agent Swarm TUI startup screen](/images/agent-swarm-cli-preview.png)
 
 ## Before You Start
@@ -76,8 +72,8 @@ Once the TUI is running, you get:
 
 If this is your first run, you can ignore everything below.
 
-<Accordion title="Optional: Connect to an existing agency" defaultOpen={false}>
-Use the same `npx @vrsen/agentswarm` command, then choose **Connect to an existing agency** during onboarding.
+<Accordion title="Connect to a running agency (optional)" defaultOpen={false}>
+Use the same `npx @vrsen/agentswarm` command, then choose **Connect to a running agency** during onboarding.
 
 This is the optional `/connect` path.
 
@@ -93,7 +89,7 @@ Use it when:
 - you want to connect to a remote Agency Swarm server
 - the server is protected and needs a bearer token
 
-Current limitations when connecting to a remote server:
+Current limitations for this path:
 
 - `/models` does not switch the models configured inside your Agency Swarm backend yet
 - local file tools are not available; if you want the TUI to work directly on project files, start with `npx @vrsen/agentswarm` from that project directory instead

--- a/docs/core-framework/agencies/agent-swarm-cli.mdx
+++ b/docs/core-framework/agencies/agent-swarm-cli.mdx
@@ -16,22 +16,15 @@ For most users, the right way to start is:
 npx @vrsen/agentswarm
 ```
 
-This is the main launch path. It handles first-run setup, then opens the terminal UI in local `Agent Builder` mode.
+This is the main launch path. It handles first-run setup, then connects the terminal UI to your Agency Swarm server.
 
 Run it from your project root. If you are starting fresh, run it in a new empty folder.
 
 You do not need to install the TUI globally first.
 
-<CardGroup cols={2}>
-  <Card title="Agent Builder mode" icon="sparkles">
-    The launcher prepares a local project, starts the local bridge, and opens the TUI in that project.
-  </Card>
-  <Card title="Connected agency mode" icon="plug">
-    The launcher connects the TUI to an Agency Swarm server that is already running.
-  </Card>
-</CardGroup>
-
-For most first-time users, the right path is local `Agent Builder` mode.
+<Card title="Connected agency mode" icon="plug">
+  The launcher connects the TUI to an Agency Swarm server, whether it is your local project or a remote server.
+</Card>
 
 ![Agent Swarm TUI startup screen](/images/agent-swarm-cli-preview.png)
 
@@ -52,14 +45,14 @@ On first launch, you will usually see this flow:
   <Step title="Start the launcher">
     Start with `npx @vrsen/agentswarm`.
   </Step>
-  <Step title="Choose a launch mode">
+  <Step title="Point the launcher at an agency">
     The launcher can reuse the current Agency Swarm project, create a starter project, or connect to an agency that is already running.
   </Step>
   <Step title="Set up the project environment">
     The launcher checks for a project `.venv`. If it needs to create one, it asks first and then installs the project dependencies before opening the TUI.
   </Step>
   <Step title="Open the TUI and add auth if needed">
-    The TUI opens in your project directory in local `Agent Builder` mode. If you do not already have a usable model provider configured, use `/auth`.
+    The TUI opens connected to your agency. If you do not already have a usable model provider configured, use `/auth`.
   </Step>
 </Steps>
 
@@ -100,9 +93,7 @@ Use it when:
 - you want to connect to a remote Agency Swarm server
 - the server is protected and needs a bearer token
 
-This mode opens the TUI in connected agency mode instead of local `Agent Builder` mode.
-
-Current limitations in connected agency mode:
+Current limitations when connecting to a remote server:
 
 - `/models` does not switch the models configured inside your Agency Swarm backend yet
 - local file tools are not available; if you want the TUI to work directly on project files, start with `npx @vrsen/agentswarm` from that project directory instead
@@ -123,7 +114,7 @@ Then start your project the usual way:
 python agency.py
 ```
 
-This path stays bound to the exact `Agency` instance you passed in Python. It starts the local bridge for that agency, then opens the TUI in connected agency mode.
+This path stays bound to the exact `Agency` instance you passed in Python. It starts the local bridge for that agency, then opens the TUI connected to it.
 
 Use it when your team already starts the project from Python and you want a quick TUI test path without switching directories or changing entrypoints.
 </Accordion>

--- a/docs/core-framework/agencies/running-agency.mdx
+++ b/docs/core-framework/agencies/running-agency.mdx
@@ -96,7 +96,7 @@ npx @vrsen/agentswarm
 
 Run it from your project root when you want the launcher to handle first-run setup and open the terminal UI for you.
 
-This path opens the TUI in local `Agent Builder` mode by default. Use it when you want the easiest setup path.
+This path lets the launcher detect the agency from your project and open the TUI connected to it. Use it when you want the easiest setup path.
 
 For the full launch flow, first-run auth, and the optional terminal launch paths, see [Agent Swarm TUI](/core-framework/agencies/agent-swarm-cli).
 


### PR DESCRIPTION
### Summary

**Type of change:** Documentation

**What does this PR do:** Updates the Agent Swarm TUI product doc (`docs/core-framework/agencies/agent-swarm-cli.mdx`) to drop every mention of Agent Builder mode and Plan mode. The TUI now describes a single supported path: connecting to a running Agency Swarm server (local or remote).

Changes:

- Replaces the two-card `CardGroup` (Agent Builder / Connected) with a single `Card` that describes connected-agency mode, covering both local project and remote server cases.
- Rewrites the "What Happens on First Launch" steps so they no longer imply mode switching or opening into Agent Builder mode.
- Rewords the "Optional: Connect to an existing agency" and `agency.tui()` sections so they stop contrasting connected mode with Agent Builder mode.
- Preserves the `npx @vrsen/agentswarm` launch flow, `.venv` / FastAPI bootstrap, `/auth`, `/models`, `/agents`, Python `agency.tui()` handoff, and Related Pages.

### Test plan

**How verified:**

- Reviewed the rendered outline and confirmed no section headings were removed.
- `rg -i "agent builder|plan mode"` against the file returns no matches.
- Visually walked the page top-to-bottom to confirm the remaining copy stays consistent with the connected-agency-only model.

Docs-only change; no code paths touched.

### Issue number

Closes #627

### Checks

- [ ] I've added new tests (if relevant) — not applicable, docs-only
- [x] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format` — not applicable, mdx-only edit with no Python impact
- [x] I've made sure tests pass — no code changed