### PR TITLE
fix(fastapi): scope Codex client_config.base_url by LiteLLM provider

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1317,7 +1317,7 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
     elif _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
         if has_litellm_overrides:
             # Preserve existing settings unless explicitly overridden.
-            base_url = config.base_url if config.base_url is not None else model.base_url
+            base_url = _resolve_litellm_base_url(model.model, config, existing_base_url=model.base_url)
             api_key = _resolve_litellm_api_key(model.model, config, existing_api_key=model.api_key)
             agent.model = LitellmModel(model=model.model, base_url=base_url, api_key=api_key)
     elif isinstance(model, Model):
@@ -1414,6 +1414,24 @@ def _resolve_litellm_api_key(
     return existing_api_key
 
 
+def _resolve_litellm_base_url(
+    model_name: str,
+    config: ClientConfig,
+    existing_base_url: str | None = None,
+) -> str | None:
+    provider = _get_litellm_provider(model_name)
+
+    if config.base_url is None:
+        return existing_base_url
+
+    # Preserve generic LiteLLM proxy support, but never leak the Codex browser-auth
+    # endpoint into non-OpenAI-compatible providers like Anthropic or Gemini.
+    if _is_codex_base_url(config.base_url) and not _is_openai_based_litellm_provider(provider):
+        return existing_base_url
+
+    return config.base_url
+
+
 def _apply_litellm_config(agent: Agent, model_name: str, config: ClientConfig) -> None:
     """Apply config to a LiteLLM model by creating a new LitellmModel instance."""
     if not _LITELLM_AVAILABLE or LitellmModel is None:
@@ -1427,10 +1445,11 @@ def _apply_litellm_config(agent: Agent, model_name: str, config: ClientConfig) -
     actual_model = model_name[8:] if model_name.startswith("litellm/") else model_name
 
     api_key = _resolve_litellm_api_key(model_name, config, existing_api_key=None)
+    base_url = _resolve_litellm_base_url(model_name, config, existing_base_url=None)
 
     agent.model = LitellmModel(
         model=actual_model,
-        base_url=config.base_url,
+        base_url=base_url,
         api_key=api_key,
     )
 

--- a/tests/integration/fastapi/test_fastapi_client_config.py
+++ b/tests/integration/fastapi/test_fastapi_client_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
 
 import pytest
 
@@ -379,3 +380,61 @@ def test_default_headers_only_uses_existing_upload_auth(
     assert isinstance(captured["headers"], dict)
     assert captured["headers"]["x-agency-id"] == "agency-orig"
     assert captured["headers"]["x-request-id"] == "req-1"
+
+
+def test_client_config_does_not_leak_codex_base_url_into_anthropic_litellm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic LiteLLM runs must ignore a forwarded Codex OAuth base_url."""
+    pytest.importorskip("agents.extensions.models.litellm_model")
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_response(self, message, **kwargs):
+        del message, kwargs
+        captured["model"] = self.model
+        return SimpleNamespace(final_output="ok")
+
+    monkeypatch.setattr(Agent, "get_response", fake_get_response)
+
+    def create_agency(load_threads_callback=None, save_threads_callback=None):
+        agent = Agent(
+            name="TestAgent",
+            instructions="You are a test agent.",
+            model="litellm/anthropic/claude-sonnet-4",
+        )
+        return Agency(
+            agent,
+            load_threads_callback=load_threads_callback,
+            save_threads_callback=save_threads_callback,
+        )
+
+    app = run_fastapi(
+        agencies={"test_agency": create_agency},
+        return_app=True,
+        app_token_env="",
+        enable_agui=False,
+    )
+    client = TestClient(app)
+
+    res = client.post(
+        "/test_agency/get_response",
+        json={
+            "message": "hi",
+            "client_config": {
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "sk-openai-gateway",
+                "litellm_keys": {"anthropic": "sk-ant"},
+            },
+        },
+    )
+
+    assert res.status_code == 200
+    assert res.json()["response"] == "ok"
+
+    model = captured["model"]
+    assert isinstance(model, LitellmModel)
+    assert model.model == "anthropic/claude-sonnet-4"
+    assert model.base_url is None
+    assert model.api_key == "sk-ant"

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -185,6 +185,40 @@ def test_litellm_anthropic_does_not_use_generic_api_key_fallback() -> None:
     assert agent.model.api_key is None
 
 
+def test_litellm_anthropic_does_not_use_codex_base_url_fallback() -> None:
+    """Codex browser-auth base_url must not override non-OpenAI LiteLLM providers."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(model="anthropic/claude-sonnet-4", base_url=None, api_key=None)
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            api_key="sk-openai-gateway",
+            base_url="https://chatgpt.com/backend-api/codex",
+            litellm_keys={"anthropic": "sk-ant"},
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4"
+    assert agent.model.base_url is None
+    assert agent.model.api_key == "sk-ant"
+
+
 def test_litellm_openai_provider_can_use_generic_api_key_fallback() -> None:
     """For openai-ish LiteLLM providers, config.api_key remains a valid fallback."""
     pytest.importorskip("agents")


### PR DESCRIPTION
### Summary

Fixes request-scoped LiteLLM `base_url` handling so a forwarded Codex OAuth `client_config.base_url` is only kept for OpenAI-compatible LiteLLM providers.

- add `_resolve_litellm_base_url()` and reuse `_is_codex_base_url()` + `_is_openai_based_litellm_provider()` in both LiteLLM override paths
- preserve generic LiteLLM proxy behavior for non-Codex `base_url` values
- add regression coverage for an existing `LitellmModel` agent and an end-to-end FastAPI request using `litellm/anthropic/...`

### Test plan

- `OPENAI_API_KEY=sk-test uv run pytest tests/test_fastapi_utils_modules/test_openai_client_config_models.py tests/integration/fastapi/test_fastapi_client_config.py`
- `make lint`

### Issue number

Closes #629

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [x] I've made sure tests pass