### PR TITLE
chore(release): 1.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.9.2"
+version = "1.9.3"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.9.2"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary
- bump agency-swarm package version from 1.9.2 to 1.9.3
- keep uv.lock editable package version in sync
- cut the 1.9.3 release branch for PR #630 and the unreleased docs merge since v1.9.2

## Included since v1.9.2
- #630 fix(fastapi): scope Codex LiteLLM client_config.base_url by provider
- #628 docs(tui): remove misleading connected-mode guidance and agent builder/plan references

## Validation
- UV_PYTHON=3.13 make format
- UV_PYTHON=3.13 make check
- UV_PYTHON=3.13 make build
- codex review --base main -c model_reasoning_effort="xhigh"