### PR TITLE
Fixed missing event handling for codex api

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1184,12 +1184,84 @@ def _is_codex_base_url(value: str | None) -> bool:
     return value.rstrip("/") == "https://chatgpt.com/backend-api/codex"
 
 
+class _CodexAsyncStream:
+    """Async iterator wrapper that patches missing function calls in ResponseCompletedEvent.
+
+    Wraps the raw AsyncStream returned by _fetch_response so that function_call
+    items streamed via ResponseOutputItemDoneEvent but omitted from
+    ResponseCompletedEvent.response.output are injected back before the agents
+    SDK processes the completed response.
+    """
+
+    def __init__(self, stream):
+        self._iter = stream.__aiter__()
+        self._fn_calls: list = []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        from openai.types.responses import (
+            ResponseCompletedEvent,
+            ResponseFunctionToolCall,
+            ResponseOutputItemDoneEvent,
+        )
+
+        chunk = await self._iter.__anext__()
+
+        if isinstance(chunk, ResponseOutputItemDoneEvent):
+            if isinstance(chunk.item, ResponseFunctionToolCall):
+                self._fn_calls.append(chunk.item)
+        elif isinstance(chunk, ResponseCompletedEvent) and self._fn_calls:
+            existing = {getattr(i, "call_id", None) for i in chunk.response.output}
+            missing = [fc for fc in self._fn_calls if fc.call_id not in existing]
+            if missing:
+                logger.debug(
+                    "Codex: injecting %d missing function call(s): %s",
+                    len(missing),
+                    [getattr(fc, "name", None) for fc in missing],
+                )
+                patched = list(chunk.response.output) + missing
+                try:
+                    chunk.response.output = patched
+                except Exception:
+                    try:
+                        object.__setattr__(chunk.response, "output", patched)
+                    except Exception as e:
+                        logger.warning("Codex: could not patch response.output: %s", e)
+
+        return chunk
+
+
 def _apply_codex_compatibility_model_settings(agent: Agent) -> None:
-    """Strip unsupported Responses parameters for the Codex browser-auth backend."""
+    """Strip unsupported Responses parameters for the Codex browser-auth backend.
+
+    Patch the model's _fetch_response on the instance (not via subclass) to
+    wrap the stream in _CodexAsyncStream, which injects any function-call items that
+    the Codex endpoint streams via ResponseOutputItemDoneEvent but omits from
+    ResponseCompletedEvent.response.output.
+    """
     current: ModelSettings = getattr(agent, "model_settings", None) or ModelSettings()
     current.store = False
     current.truncation = None
     agent.model_settings = current
+
+    model = agent.model
+    if not isinstance(model, OpenAIResponsesModel):
+        return
+    if getattr(model, "_codex_stream_patched", False):
+        return
+
+    _model_ref = model
+
+    async def _fetch_response_patched(*args, stream=False, **kwargs):
+        result = await OpenAIResponsesModel._fetch_response(_model_ref, *args, stream=stream, **kwargs)
+        if stream:
+            return _CodexAsyncStream(result)
+        return result
+
+    model._fetch_response = _fetch_response_patched  # type: ignore[method-assign]
+    model._codex_stream_patched = True  # type: ignore[attr-defined]
 
 
 def _is_litellm_model(model_name: str) -> bool:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1194,6 +1194,7 @@ class _CodexAsyncStream:
     """
 
     def __init__(self, stream):
+        self._stream = stream
         self._iter = stream.__aiter__()
         self._fn_calls: list = []
 
@@ -1231,6 +1232,18 @@ class _CodexAsyncStream:
                         logger.warning("Codex: could not patch response.output: %s", e)
 
         return chunk
+
+    def __getattr__(self, name: str):
+        return getattr(self._stream, name)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, exc_tb) -> None:
+        await self._stream.__aexit__(exc_type, exc, exc_tb)
+
+    async def aclose(self) -> None:
+        await self._iter.aclose()
 
 
 def _apply_codex_compatibility_model_settings(agent: Agent) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
@@ -3,7 +3,76 @@
 The end-to-end behavior is covered in integration tests under `tests/integration/fastapi/`.
 """
 
+from collections.abc import AsyncIterator
+
 import pytest
+
+
+def _build_response(output: list[object]) -> object:
+    from openai.types.responses import Response
+
+    return Response(
+        id="resp_codex",
+        created_at=123,
+        model="gpt-4o-mini",
+        object="response",
+        output=output,
+        tool_choice="none",
+        tools=[],
+        parallel_tool_calls=False,
+        usage=None,
+    )
+
+
+def _stream_events(events: list[object]) -> AsyncIterator[object]:
+    async def _stream() -> AsyncIterator[object]:
+        for event in events:
+            yield event
+
+    return _stream()
+
+
+async def _collect_codex_stream_events(
+    monkeypatch: pytest.MonkeyPatch,
+    source_events: list[object],
+) -> list[object]:
+    pytest.importorskip("agents")
+
+    from agents import ModelSettings, OpenAIResponsesModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    async def _fake_fetch_response(
+        _self,
+        *_args: object,
+        stream: bool = False,
+        **_kwargs: object,
+    ) -> object:
+        if stream:
+            return _stream_events(source_events)
+        return _build_response([])
+
+    monkeypatch.setattr(OpenAIResponsesModel, "_fetch_response", _fake_fetch_response)
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    apply_openai_client_config(
+        agency,
+        ClientConfig(api_key="sk-openai", base_url="https://chatgpt.com/backend-api/codex"),
+    )
+
+    stream = await agent.model._fetch_response(
+        system_instructions=None,
+        input="hello",
+        model_settings=ModelSettings(),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        stream=True,
+    )
+    return [event async for event in stream]
 
 
 @pytest.mark.asyncio
@@ -85,3 +154,117 @@ async def test_make_stream_endpoint_background_cleanup_without_stream_consumptio
 
     assert released == 1
     assert restored == 1
+
+
+@pytest.mark.asyncio
+async def test_codex_streaming_reinjects_missing_tool_call_into_completed_event(monkeypatch) -> None:
+    """Codex-configured streaming should surface a streamed function call in completed output."""
+    from openai.types.responses import ResponseFunctionToolCall
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-1",
+        status="completed",
+    )
+    observed = await _collect_codex_stream_events(
+        monkeypatch,
+        [
+            ResponseOutputItemDoneEvent(
+                item=tool_call,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.done",
+            ),
+            ResponseCompletedEvent(
+                response=_build_response([]),
+                sequence_number=2,
+                type="response.completed",
+            ),
+        ],
+    )
+
+    assert [event.type for event in observed] == ["response.output_item.done", "response.completed"]
+    assert observed[-1].response.output == [tool_call]
+
+
+@pytest.mark.asyncio
+async def test_codex_streaming_does_not_duplicate_tool_call_already_in_completed_event(monkeypatch) -> None:
+    """Codex-configured streaming should keep one completed tool call when already present."""
+    from openai.types.responses import ResponseFunctionToolCall
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    streamed_tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-1",
+        status="completed",
+    )
+    completed_tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-1",
+        status="completed",
+    )
+    observed = await _collect_codex_stream_events(
+        monkeypatch,
+        [
+            ResponseOutputItemDoneEvent(
+                item=streamed_tool_call,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.done",
+            ),
+            ResponseCompletedEvent(
+                response=_build_response([completed_tool_call]),
+                sequence_number=2,
+                type="response.completed",
+            ),
+        ],
+    )
+
+    assert [item.call_id for item in observed[-1].response.output] == ["call-1"]
+    assert observed[-1].response.output == [completed_tool_call]
+
+
+@pytest.mark.asyncio
+async def test_codex_streaming_passes_text_only_events_through_unchanged(monkeypatch) -> None:
+    """Codex-configured streaming should leave text-only responses unchanged."""
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        content=[ResponseOutputText(annotations=[], logprobs=[], text="hello", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    source_events = [
+        ResponseOutputItemDoneEvent(
+            item=message,
+            output_index=0,
+            sequence_number=1,
+            type="response.output_item.done",
+        ),
+        ResponseCompletedEvent(
+            response=_build_response([message]),
+            sequence_number=2,
+            type="response.completed",
+        ),
+    ]
+    expected = [event.model_dump(mode="json") for event in source_events]
+
+    observed = await _collect_codex_stream_events(monkeypatch, source_events)
+
+    assert [event.model_dump(mode="json") for event in observed] == expected


### PR DESCRIPTION
Problem description:
The Codex API (https://chatgpt.com/backend-api/codex) streams tool/function calls via ResponseOutputItemDoneEvent during the stream, but then omits them from ResponseCompletedEvent.response.output at the end. 
The agents SDK builds its final response from ResponseCompletedEvent.response.output — so it sees no tool calls, decides the turn is done with an empty response (NextStepFinalOutput("")), and never executes the tools.           
                                                                                                                     
The fix wraps the stream in _CodexAsyncStream, which:                                                              

1. Collects any ResponseFunctionToolCall items seen in ResponseOutputItemDoneEvent events as they stream by
2. When ResponseCompletedEvent arrives, checks which function calls are missing from response.output and injects them back. he SDK then sees the complete output with tool calls intact and executes them normally.