### PR TITLE
fix: allow litellm_keys request overrides without litellm installed

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -57,11 +58,15 @@ class ClientConfig(BaseModel):
     @field_validator("litellm_keys")
     @classmethod
     def validate_litellm_installed(cls, v: dict | None) -> dict | None:
-        """Raise error if litellm_keys provided but litellm not installed."""
+        """Warn and drop litellm_keys when litellm is unavailable."""
         if v is not None and not _LITELLM_INSTALLED:
-            raise ValueError(
-                "litellm_keys requires litellm to be installed. Install with: pip install 'openai-agents[litellm]'"
+            warnings.warn(
+                "litellm_keys was provided, but litellm is not installed. "
+                "These overrides are ignored. Install with `openai-agents[litellm]` "
+                "to enable provider-key routing.",
+                stacklevel=2,
             )
+            return None
         return v
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -4,7 +4,6 @@ The end-to-end behavior is covered in integration tests under `tests/integration
 """
 
 import pytest
-from pydantic import ValidationError
 
 from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
 
@@ -43,18 +42,32 @@ def test_client_config_accepts_optional_overrides(payload: dict, expected: dict)
         assert getattr(config, key) == value
 
 
-def test_client_config_accepts_litellm_keys_when_available() -> None:
-    """litellm_keys should validate when LiteLLM is installed."""
-    try:
-        config = ClientConfig(
+def test_client_config_drops_litellm_keys_without_litellm(monkeypatch) -> None:
+    """litellm_keys should be ignored (with warning) when litellm is unavailable."""
+    import agency_swarm.integrations.fastapi_utils.request_models as request_models
+
+    monkeypatch.setattr(request_models, "_LITELLM_INSTALLED", False)
+    with pytest.warns(UserWarning, match="litellm_keys was provided"):
+        config = request_models.ClientConfig(
             litellm_keys={
                 "anthropic": "sk-ant-xxx",
                 "gemini": "AIza...",
             }
         )
-    except ValidationError as exc:
-        assert "litellm_keys requires litellm to be installed" in str(exc)
-        return
+    assert config.litellm_keys is None
+
+
+def test_client_config_litellm_keys_roundtrip_when_available(monkeypatch) -> None:
+    """litellm_keys should still be accepted when litellm is available."""
+    import agency_swarm.integrations.fastapi_utils.request_models as request_models
+
+    monkeypatch.setattr(request_models, "_LITELLM_INSTALLED", True)
+    config = request_models.ClientConfig(
+        litellm_keys={
+            "anthropic": "sk-ant-xxx",
+            "gemini": "AIza...",
+        }
+    )
     assert config.litellm_keys is not None
     assert config.litellm_keys["anthropic"] == "sk-ant-xxx"
     assert config.litellm_keys["gemini"] == "AIza..."


### PR DESCRIPTION
## Summary
Closes a regression/validation bug for LiteLLM key overrides when `litellm` is not installed.

## Changes
- Update `ClientConfig.validate_litellm_installed` in `request_models.py` to:
  - emit a warning instead of raising when `litellm_keys` are provided without `litellm`
  - drop the unsupported `litellm_keys` payload (`return None`) so non-LiteLLM requests still succeed
- Update unit tests to reflect and cover both behaviors:
  - warning+drop path when `litellm` is unavailable
  - preserve key acceptance path when `litellm` is considered available

## Why
Issue #615 reports that valid requests now receive a 422 because `litellm_keys` is validated strictly.
This changes the behavior to a safer, more permissive mode while still surfacing a clear warning.

## Risk / validation
- This intentionally disables provider-key forwarding when `litellm` is absent. OpenAI-only flows remain unaffected.
- If this is undesirable, maintainers may prefer to return `{}` instead of `None`; behavior is limited and documented.

## Testing and checks
- `ruff check src/agency_swarm/integrations/fastapi_utils/request_models.py tests/test_fastapi_utils_modules/test_openai_client_config_models.py`
- `python -m compileall src/agency_swarm/integrations/fastapi_utils/request_models.py tests/test_fastapi_utils_modules/test_openai_client_config_models.py`

Note: attempts to run `pytest` for this module on this environment consistently segfaulted and could not be completed after dependency setup.

Closes #615
