### PR TITLE
fix(fastapi): warn-and-drop client_config.litellm_keys when litellm missing

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -17,6 +18,8 @@ try:
 except ImportError:
     LiteLLMProvider = str  # type: ignore[misc, assignment]
     _LITELLM_INSTALLED = False
+
+logger = logging.getLogger(__name__)
 
 
 class ClientConfig(BaseModel):
@@ -57,11 +60,19 @@ class ClientConfig(BaseModel):
     @field_validator("litellm_keys")
     @classmethod
     def validate_litellm_installed(cls, v: dict | None) -> dict | None:
-        """Raise error if litellm_keys provided but litellm not installed."""
+        """Drop litellm_keys with a warning when litellm is not installed.
+
+        Older bridges or callers that always forward `litellm_keys` should not get a 422
+        when the receiving environment lacks the `[litellm]` extra. The keys are useless
+        without the dependency, so we drop them and let downstream code fall back to
+        OpenAI-only behavior.
+        """
         if v is not None and not _LITELLM_INSTALLED:
-            raise ValueError(
-                "litellm_keys requires litellm to be installed. Install with: pip install 'openai-agents[litellm]'"
+            logger.warning(
+                "Ignoring client_config.litellm_keys: litellm is not installed. "
+                "Install with `pip install 'openai-agents[litellm]'` to enable provider-key routing."
             )
+            return None
         return v
 
 

--- a/tests/integration/fastapi/test_fastapi_client_config.py
+++ b/tests/integration/fastapi/test_fastapi_client_config.py
@@ -438,3 +438,56 @@ def test_client_config_does_not_leak_codex_base_url_into_anthropic_litellm(
     assert model.model == "anthropic/claude-sonnet-4"
     assert model.base_url is None
     assert model.api_key == "sk-ant"
+
+
+def test_client_config_litellm_keys_dropped_when_litellm_unavailable(
+    openai_stub_base_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Forwarding `litellm_keys` to a bridge without litellm should warn-and-drop, not 422."""
+    from agency_swarm.integrations.fastapi_utils import request_models
+
+    monkeypatch.setattr(request_models, "_LITELLM_INSTALLED", False)
+
+    def create_agency(load_threads_callback=None, save_threads_callback=None):
+        original_client = AsyncOpenAI(api_key="sk-original", base_url="http://example.invalid")
+        agent = Agent(
+            name="TestAgent",
+            instructions="You are a test agent.",
+            model=OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=original_client),
+        )
+        return Agency(
+            agent,
+            load_threads_callback=load_threads_callback,
+            save_threads_callback=save_threads_callback,
+        )
+
+    app = run_fastapi(
+        agencies={"test_agency": create_agency},
+        return_app=True,
+        app_token_env="",
+        enable_agui=False,
+    )
+    client = TestClient(app)
+
+    with caplog.at_level("WARNING", logger=request_models.__name__):
+        res = client.post(
+            "/test_agency/get_response",
+            json={
+                "message": "hi",
+                "client_config": {
+                    "base_url": f"{openai_stub_base_url}/v1",
+                    "api_key": "sk-test",
+                    "litellm_keys": {"anthropic": "sk-ant-xxx"},
+                },
+            },
+        )
+
+    assert res.status_code == 200
+    assert res.json()["response"] == "hello from stub"
+    assert any("litellm is not installed" in record.message for record in caplog.records)
+
+    seen = _ChatCompletionsStubHandler.requests_seen
+    assert len(seen) == 1
+    assert seen[0]["authorization"] == "Bearer sk-test"

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -3,9 +3,11 @@
 The end-to-end behavior is covered in integration tests under `tests/integration/fastapi/`.
 """
 
-import pytest
-from pydantic import ValidationError
+import logging
 
+import pytest
+
+from agency_swarm.integrations.fastapi_utils import request_models
 from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
 
 
@@ -43,21 +45,29 @@ def test_client_config_accepts_optional_overrides(payload: dict, expected: dict)
         assert getattr(config, key) == value
 
 
-def test_client_config_accepts_litellm_keys_when_available() -> None:
-    """litellm_keys should validate when LiteLLM is installed."""
-    try:
-        config = ClientConfig(
-            litellm_keys={
-                "anthropic": "sk-ant-xxx",
-                "gemini": "AIza...",
-            }
-        )
-    except ValidationError as exc:
-        assert "litellm_keys requires litellm to be installed" in str(exc)
-        return
+def test_client_config_accepts_litellm_keys_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """litellm_keys should round-trip when litellm is available."""
+    monkeypatch.setattr(request_models, "_LITELLM_INSTALLED", True)
+    config = ClientConfig(
+        litellm_keys={
+            "anthropic": "sk-ant-xxx",
+            "gemini": "AIza...",
+        }
+    )
     assert config.litellm_keys is not None
     assert config.litellm_keys["anthropic"] == "sk-ant-xxx"
     assert config.litellm_keys["gemini"] == "AIza..."
+
+
+def test_client_config_drops_litellm_keys_when_litellm_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Without litellm, litellm_keys should be dropped (not 422'd) and a warning logged."""
+    monkeypatch.setattr(request_models, "_LITELLM_INSTALLED", False)
+    with caplog.at_level(logging.WARNING, logger=request_models.__name__):
+        config = ClientConfig(litellm_keys={"anthropic": "sk-ant-xxx"})
+    assert config.litellm_keys is None
+    assert any("litellm is not installed" in record.message for record in caplog.records)
 
 
 def test_base_request_client_config_roundtrip() -> None:


### PR DESCRIPTION
## Summary
- Closes #615.
- Replaces the strict `ValueError` in `ClientConfig.validate_litellm_installed` with a `logger.warning` that drops the unsupported field, so clients that always forward `litellm_keys` to a bridge whose venv lacks the `[litellm]` extra no longer surface as a 422.
- Uses `logger.warning` (consistent with the rest of `fastapi_utils`) rather than `warnings.warn`, so the message is observable through the server's logging pipeline.

## Why
Per #615, callers and bridges that forward `litellm_keys` unconditionally were getting a 422 against any agency whose environment did not install `[litellm]`. The keys are useless without the dependency, so the safe behavior is to drop them and let the OpenAI-only path run.

## Tests
- Unit: covers both the warn-and-drop branch (`_LITELLM_INSTALLED=False`) and the round-trip branch (`_LITELLM_INSTALLED=True`) in `tests/test_fastapi_utils_modules/test_openai_client_config_models.py`.
- Integration: new `test_client_config_litellm_keys_dropped_when_litellm_unavailable` in `tests/integration/fastapi/test_fastapi_client_config.py` posts the original failing payload through `TestClient` with `_LITELLM_INSTALLED` patched to `False` and asserts `200` plus the warning.
- `make format` and `make check` both green.
- `pytest tests/test_fastapi_utils_modules/test_openai_client_config_models.py tests/test_fastapi_utils_modules/test_override_policy.py tests/integration/fastapi/test_fastapi_client_config.py`: 34 passed, 6 skipped.

Supersedes #635.