### PR TITLE
fix: allow structured FastAPI message attachments

### DIFF
--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -285,7 +285,7 @@ print("Response:", agency_response.json())
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `message` | string | Yes | User message to start or continue the conversation. |
+| `message` | string or list | Yes | User message to start or continue the conversation. Use a structured Responses input list for inline `input_image` or `input_file` attachments. |
 | `chat_history` | list | No | Flat list of prior messages with metadata (`agent`, `callerAgent`, `timestamp`) to preserve context. |
 | `recipient_agent` | string | No | Target agent when you want to direct the next turn. |
 | `file_ids` | list | No | IDs of already uploaded files to attach. |
@@ -423,6 +423,22 @@ Attach files to agency requests using `file_ids` or `file_urls` in the payload:
 {
   "message": "Summarize this document",
   "file_urls": {"report.pdf": "https://example.com/report.pdf"}
+}
+```
+
+For inline Responses attachments that should not be uploaded through the Files API, pass a structured `message`:
+
+```json
+{
+  "message": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "input_image", "image_url": "data:image/png;base64,..."},
+        {"type": "input_text", "text": "Describe this image"}
+      ]
+    }
+  ]
 }
 ```
 

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -285,7 +285,7 @@ print("Response:", agency_response.json())
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `message` | string or list | Yes | User message to start or continue the conversation. Use a structured Responses input list for inline `input_image` or `input_file` attachments. |
+| `message` | string or structured list | Yes | User message to start or continue the conversation. Use a structured Responses input list for inline `input_text`, `input_image`, or `input_file` content. |
 | `chat_history` | list | No | Flat list of prior messages with metadata (`agent`, `callerAgent`, `timestamp`) to preserve context. |
 | `recipient_agent` | string | No | Target agent when you want to direct the next turn. |
 | `file_ids` | list | No | IDs of already uploaded files to attach. |
@@ -434,7 +434,7 @@ For inline Responses attachments that should not be uploaded through the Files A
     {
       "role": "user",
       "content": [
-        {"type": "input_image", "image_url": "data:image/png;base64,..."},
+        {"type": "input_image", "image_url": "data:image/png;base64,...", "detail": "auto"},
         {"type": "input_text", "text": "Describe this image"}
       ]
     }

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -442,6 +442,8 @@ For inline Responses attachments that should not be uploaded through the Files A
 }
 ```
 
+With manual `chat_history`, clients can keep structured attachment parts in history so follow-up turns work without reattaching. This may resend inline attachment content or references; it does not reuse server-managed state, `previous_response_id`, Conversations, or `file_id` values.
+
 The response includes `file_ids_map` with the uploaded file IDs:
 
 ```json

--- a/src/agency_swarm/agent/execution_stream_persistence.py
+++ b/src/agency_swarm/agent/execution_stream_persistence.py
@@ -264,16 +264,26 @@ def _persist_streamed_items(
     if agency_context.thread_manager is None:
         return
 
-    # Get new_items directly from streaming_result - these are the same Python objects
-    # that were emitted during streaming via RunItemStreamEvent
+    # Prefer final SDK items. If a streaming wrapper completed successfully but the
+    # final result omitted new_items, fall back to the run items already observed
+    # in the stream so the turn is still committed for replay.
     new_items: list[RunItem] = getattr(streaming_result, "new_items", None) or []
     if not new_items:
-        logger.warning(
-            "streaming_result.new_items is empty or missing - skipping final persistence. "
-            "This may indicate a guardrail trip (expected) or an SDK issue (unexpected)."
-        )
-        return
-
+        if collected_items:
+            logger.warning(
+                "streaming_result.new_items is empty or missing - using %d collected streamed item(s) "
+                "for final persistence.",
+                len(collected_items),
+            )
+            new_items = collected_items
+        else:
+            if hasattr(agency_context.thread_manager, "persist"):
+                agency_context.thread_manager.persist()
+            logger.warning(
+                "streaming_result.new_items is empty or missing - skipping final item persistence. "
+                "This may indicate a guardrail trip (expected) or an SDK issue (unexpected)."
+            )
+            return
     assistant_messages = [item for item in collected_items if isinstance(item, MessageOutputItem)]
     citations_by_message = (
         extract_direct_file_annotations(assistant_messages, agent_name=agent.name) if assistant_messages else {}

--- a/src/agency_swarm/agent/execution_stream_persistence.py
+++ b/src/agency_swarm/agent/execution_stream_persistence.py
@@ -451,7 +451,7 @@ def _persist_streamed_items(
         run_id = existing_item.get("agent_run_id")
         if existing_key is not None and existing_key in keys_to_replace:
             continue
-        if isinstance(run_id, str) and run_id in run_ids_to_replace:
+        if isinstance(run_id, str) and run_id in run_ids_to_replace and not _is_initiating_input_message(existing_item):
             continue
         origin = existing_item.get("message_origin")
         if isinstance(origin, str):
@@ -484,3 +484,9 @@ def _message_key(message: TResponseInputItem) -> tuple[str, str | None, str | No
         return ("call", call_id, message.get("type"))
 
     return None
+
+
+def _is_initiating_input_message(message: TResponseInputItem) -> bool:
+    if not isinstance(message, dict):
+        return False
+    return message.get("type") == "message" and message.get("role") in {"user", "system", "developer"}

--- a/src/agency_swarm/agent/execution_stream_persistence.py
+++ b/src/agency_swarm/agent/execution_stream_persistence.py
@@ -16,6 +16,12 @@ from agency_swarm.utils.citation_extractor import extract_direct_file_annotation
 
 logger = logging.getLogger(__name__)
 
+_GUARDRAIL_CONTROL_MESSAGE_ORIGINS = {
+    "input_guardrail_error",
+    "input_guardrail_message",
+    "output_guardrail_error",
+}
+
 # Type alias for metadata stored during streaming.
 # Tuple of (agent_name, agent_run_id, caller_name, emission_timestamp).
 # Used to match RunItems between streaming and final persistence.
@@ -498,5 +504,7 @@ def _message_key(message: TResponseInputItem) -> tuple[str, str | None, str | No
 
 def _is_initiating_input_message(message: TResponseInputItem) -> bool:
     if not isinstance(message, dict):
+        return False
+    if message.get("message_origin") in _GUARDRAIL_CONTROL_MESSAGE_ORIGINS:
         return False
     return message.get("type") == "message" and message.get("role") in {"user", "system", "developer"}

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1185,10 +1185,10 @@ def _is_codex_base_url(value: str | None) -> bool:
 
 
 class _CodexAsyncStream:
-    """Async iterator wrapper that patches missing function calls in ResponseCompletedEvent.
+    """Async iterator wrapper that patches missing output items in ResponseCompletedEvent.
 
-    Wraps the raw AsyncStream returned by _fetch_response so that function_call
-    items streamed via ResponseOutputItemDoneEvent but omitted from
+    Wraps the raw AsyncStream returned by _fetch_response so that items streamed
+    via ResponseOutputItemDoneEvent but omitted from
     ResponseCompletedEvent.response.output are injected back before the agents
     SDK processes the completed response.
     """
@@ -1196,7 +1196,7 @@ class _CodexAsyncStream:
     def __init__(self, stream):
         self._stream = stream
         self._iter = stream.__aiter__()
-        self._fn_calls: list = []
+        self._output_items: list = []
 
     def __aiter__(self):
         return self
@@ -1204,23 +1204,21 @@ class _CodexAsyncStream:
     async def __anext__(self):
         from openai.types.responses import (
             ResponseCompletedEvent,
-            ResponseFunctionToolCall,
             ResponseOutputItemDoneEvent,
         )
 
         chunk = await self._iter.__anext__()
 
         if isinstance(chunk, ResponseOutputItemDoneEvent):
-            if isinstance(chunk.item, ResponseFunctionToolCall):
-                self._fn_calls.append(chunk.item)
-        elif isinstance(chunk, ResponseCompletedEvent) and self._fn_calls:
-            existing = {getattr(i, "call_id", None) for i in chunk.response.output}
-            missing = [fc for fc in self._fn_calls if fc.call_id not in existing]
+            self._output_items.append(chunk.item)
+        elif isinstance(chunk, ResponseCompletedEvent) and self._output_items:
+            existing = {_codex_output_item_key(item) for item in chunk.response.output}
+            missing = [item for item in self._output_items if _codex_output_item_key(item) not in existing]
             if missing:
                 logger.debug(
-                    "Codex: injecting %d missing function call(s): %s",
+                    "Codex: injecting %d missing completed output item(s): %s",
                     len(missing),
-                    [getattr(fc, "name", None) for fc in missing],
+                    [getattr(item, "type", None) for item in missing],
                 )
                 patched = list(chunk.response.output) + missing
                 try:
@@ -1246,11 +1244,20 @@ class _CodexAsyncStream:
         await self._iter.aclose()
 
 
+def _codex_output_item_key(item: Any) -> tuple[str | None, str | None, str | None]:
+    """Return a stable identity key for Codex streamed/completed output items."""
+    return (
+        getattr(item, "type", None),
+        getattr(item, "id", None),
+        getattr(item, "call_id", None),
+    )
+
+
 def _apply_codex_compatibility_model_settings(agent: Agent) -> None:
     """Strip unsupported Responses parameters for the Codex browser-auth backend.
 
     Patch the model's _fetch_response on the instance (not via subclass) to
-    wrap the stream in _CodexAsyncStream, which injects any function-call items that
+    wrap the stream in _CodexAsyncStream, which injects any output items that
     the Codex endpoint streams via ResponseOutputItemDoneEvent but omits from
     ResponseCompletedEvent.response.output.
     """

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1196,7 +1196,8 @@ class _CodexAsyncStream:
     def __init__(self, stream):
         self._stream = stream
         self._iter = stream.__aiter__()
-        self._output_items: list = []
+        self._output_items: list[_CodexStreamedOutputItem] = []
+        self._output_order_by_key: dict[tuple[str | None, str | None, str | None], tuple[int, int]] = {}
 
     def __aiter__(self):
         return self
@@ -1210,17 +1211,19 @@ class _CodexAsyncStream:
         chunk = await self._iter.__anext__()
 
         if isinstance(chunk, ResponseOutputItemDoneEvent):
-            self._output_items.append(chunk.item)
+            sort_key = _codex_output_sort_key(getattr(chunk, "output_index", None), len(self._output_items))
+            self._output_items.append(_CodexStreamedOutputItem(item=chunk.item, sort_key=sort_key))
+            self._output_order_by_key[_codex_output_item_key(chunk.item)] = sort_key
         elif isinstance(chunk, ResponseCompletedEvent) and self._output_items:
             existing = {_codex_output_item_key(item) for item in chunk.response.output}
-            missing = [item for item in self._output_items if _codex_output_item_key(item) not in existing]
+            missing = [entry for entry in self._output_items if _codex_output_item_key(entry.item) not in existing]
             if missing:
                 logger.debug(
                     "Codex: injecting %d missing completed output item(s): %s",
                     len(missing),
-                    [getattr(item, "type", None) for item in missing],
+                    [getattr(entry.item, "type", None) for entry in missing],
                 )
-                patched = list(chunk.response.output) + missing
+                patched = _merge_codex_completed_output(chunk.response.output, missing, self._output_order_by_key)
                 try:
                     chunk.response.output = patched
                 except Exception:
@@ -1244,6 +1247,12 @@ class _CodexAsyncStream:
         await self._iter.aclose()
 
 
+@dataclass(frozen=True)
+class _CodexStreamedOutputItem:
+    item: Any
+    sort_key: tuple[int, int]
+
+
 def _codex_output_item_key(item: Any) -> tuple[str | None, str | None, str | None]:
     """Return a stable identity key for Codex streamed/completed output items."""
     return (
@@ -1251,6 +1260,33 @@ def _codex_output_item_key(item: Any) -> tuple[str | None, str | None, str | Non
         getattr(item, "id", None),
         getattr(item, "call_id", None),
     )
+
+
+def _codex_output_sort_key(output_index: Any, stream_position: int) -> tuple[int, int]:
+    if isinstance(output_index, bool):
+        return (1, stream_position)
+    if isinstance(output_index, int):
+        return (0, output_index)
+    return (1, stream_position)
+
+
+def _merge_codex_completed_output(
+    completed_output: Sequence[Any],
+    missing: Sequence[_CodexStreamedOutputItem],
+    output_order_by_key: dict[tuple[str | None, str | None, str | None], tuple[int, int]],
+) -> list[Any]:
+    entries: list[tuple[tuple[int, int], int, Any]] = []
+    fallback_offset = len(output_order_by_key)
+
+    for completed_index, item in enumerate(completed_output):
+        sort_key = output_order_by_key.get(_codex_output_item_key(item), (1, fallback_offset + completed_index))
+        entries.append((sort_key, completed_index, item))
+
+    missing_offset = len(completed_output)
+    for missing_index, entry in enumerate(missing):
+        entries.append((entry.sort_key, missing_offset + missing_index, entry.item))
+
+    return [item for _, _, item in sorted(entries)]
 
 
 def _apply_codex_compatibility_model_settings(agent: Agent) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1255,10 +1255,15 @@ class _CodexStreamedOutputItem:
 
 def _codex_output_item_key(item: Any) -> tuple[str | None, str | None, str | None]:
     """Return a stable identity key for Codex streamed/completed output items."""
+    item_type = getattr(item, "type", None)
+    call_id = getattr(item, "call_id", None)
+    if item_type == "function_call" and call_id is not None:
+        return (item_type, None, call_id)
+
     return (
-        getattr(item, "type", None),
+        item_type,
         getattr(item, "id", None),
-        getattr(item, "call_id", None),
+        call_id,
     )
 
 

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -29,78 +29,13 @@ _MESSAGE_SCHEMA: dict[str, Any] = {
             "minItems": 1,
             "items": {
                 "type": "object",
-                "additionalProperties": False,
-                "required": ["role", "content"],
-                "properties": {
-                    "role": {"type": "string", "enum": ["user", "system", "developer"]},
-                    "type": {"type": "string", "const": "message"},
-                    "status": {"type": "string", "enum": ["in_progress", "completed", "incomplete"]},
-                    "content": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "additionalProperties": False,
-                                    "required": ["type", "text"],
-                                    "properties": {
-                                        "type": {"type": "string", "const": "input_text"},
-                                        "text": {"type": "string"},
-                                    },
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": False,
-                                    "required": ["type", "detail"],
-                                    "properties": {
-                                        "type": {"type": "string", "const": "input_image"},
-                                        "detail": {"type": "string", "enum": ["low", "high", "auto"]},
-                                        "file_id": {"type": ["string", "null"]},
-                                        "image_url": {"type": ["string", "null"]},
-                                    },
-                                    "anyOf": [
-                                        {"required": ["file_id"]},
-                                        {"required": ["image_url"]},
-                                    ],
-                                },
-                                {
-                                    "type": "object",
-                                    "additionalProperties": False,
-                                    "required": ["type"],
-                                    "properties": {
-                                        "type": {"type": "string", "const": "input_file"},
-                                        "file_data": {"type": "string"},
-                                        "file_id": {"type": ["string", "null"]},
-                                        "file_url": {"type": "string"},
-                                        "filename": {"type": "string"},
-                                    },
-                                    "anyOf": [
-                                        {"required": ["file_data"]},
-                                        {"required": ["file_id"]},
-                                        {"required": ["file_url"]},
-                                    ],
-                                },
-                            ]
-                        },
-                    },
-                },
+                "additionalProperties": True,
             },
         },
     ]
 }
 
 MessageInput = Annotated[str | list[dict[str, Any]], WithJsonSchema(_MESSAGE_SCHEMA)]
-
-_MESSAGE_KEYS = {"role", "content", "type", "status"}
-_MESSAGE_ROLES = {"user", "system", "developer"}
-_MESSAGE_STATUSES = {"in_progress", "completed", "incomplete"}
-_CONTENT_KEYS = {
-    "input_text": {"type", "text"},
-    "input_image": {"type", "detail", "file_id", "image_url"},
-    "input_file": {"type", "file_data", "file_id", "file_url", "filename"},
-}
-_IMAGE_DETAILS = {"low", "high", "auto"}
 
 
 class ClientConfig(BaseModel):
@@ -236,74 +171,9 @@ class BaseRequest(BaseModel):
         if not v:
             raise ValueError("message must contain at least one structured Responses message")
         for item in v:
-            _validate_structured_message(item)
+            if not isinstance(item, dict):
+                raise ValueError("structured Responses message items must be objects")
         return v
-
-
-def _validate_structured_message(message: dict[str, Any]) -> None:
-    extra_keys = set(message) - _MESSAGE_KEYS
-    if extra_keys:
-        raise ValueError(f"structured message contains unsupported fields: {sorted(extra_keys)}")
-
-    role = message.get("role")
-    if role not in _MESSAGE_ROLES:
-        raise ValueError("structured message role must be one of user, system, or developer")
-
-    if "type" in message and message["type"] != "message":
-        raise ValueError("structured message type must be 'message' when provided")
-
-    if "status" in message and message["status"] not in _MESSAGE_STATUSES:
-        raise ValueError("structured message status must be one of in_progress, completed, or incomplete")
-
-    content = message.get("content")
-    if not isinstance(content, list) or not content:
-        raise ValueError("structured message content must contain at least one item")
-
-    for item in content:
-        _validate_structured_content(item)
-
-
-def _validate_structured_content(content: Any) -> None:
-    if not isinstance(content, dict):
-        raise ValueError("structured message content items must be objects")
-
-    content_type = content.get("type")
-    if content_type not in _CONTENT_KEYS:
-        raise ValueError("structured message content type must be input_text, input_image, or input_file")
-
-    extra_keys = set(content) - _CONTENT_KEYS[content_type]
-    if extra_keys:
-        raise ValueError(f"structured message content contains unsupported fields: {sorted(extra_keys)}")
-
-    if content_type == "input_text":
-        _validate_text_content(content)
-    elif content_type == "input_image":
-        _validate_image_content(content)
-    else:
-        _validate_file_content(content)
-
-
-def _validate_text_content(content: dict[str, Any]) -> None:
-    if not isinstance(content.get("text"), str):
-        raise ValueError("input_text content requires string text")
-
-
-def _validate_image_content(content: dict[str, Any]) -> None:
-    if content.get("detail") not in _IMAGE_DETAILS:
-        raise ValueError("input_image content requires detail of low, high, or auto")
-    if not _has_non_empty_string(content, "file_id") and not _has_non_empty_string(content, "image_url"):
-        raise ValueError("input_image content requires file_id or image_url")
-
-
-def _validate_file_content(content: dict[str, Any]) -> None:
-    if not any(_has_non_empty_string(content, key) for key in ("file_data", "file_id", "file_url")):
-        raise ValueError("input_file content requires file_data, file_id, or file_url")
-    if "filename" in content and not isinstance(content["filename"], str):
-        raise ValueError("input_file content filename must be a string")
-
-
-def _has_non_empty_string(value: dict[str, Any], key: str) -> bool:
-    return isinstance(value.get(key), str) and bool(value[key])
 
 
 class LogRequest(BaseModel):

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -21,6 +21,8 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+MessageInput = str | list[dict[str, Any]]
+
 
 class ClientConfig(BaseModel):
     """Configuration for overriding the OpenAI client per-request."""
@@ -109,7 +111,13 @@ class RunAgentInputCustom(RunAgentInput):
 
 
 class BaseRequest(BaseModel):
-    message: str
+    message: MessageInput = Field(
+        ...,
+        description=(
+            "User message to start or continue the conversation. Accepts plain text or structured Responses "
+            "input messages, including inline input_image/input_file content."
+        ),
+    )
     chat_history: list[dict[str, Any]] | None = Field(
         default=None,
         description=(

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, WithJsonSchema, field_validator
 
 try:
     from ag_ui.core import RunAgentInput
@@ -21,7 +21,86 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-MessageInput = str | list[dict[str, Any]]
+_MESSAGE_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "string"},
+        {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["role", "content"],
+                "properties": {
+                    "role": {"type": "string", "enum": ["user", "system", "developer"]},
+                    "type": {"type": "string", "const": "message"},
+                    "status": {"type": "string", "enum": ["in_progress", "completed", "incomplete"]},
+                    "content": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "required": ["type", "text"],
+                                    "properties": {
+                                        "type": {"type": "string", "const": "input_text"},
+                                        "text": {"type": "string"},
+                                    },
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "required": ["type", "detail"],
+                                    "properties": {
+                                        "type": {"type": "string", "const": "input_image"},
+                                        "detail": {"type": "string", "enum": ["low", "high", "auto"]},
+                                        "file_id": {"type": ["string", "null"]},
+                                        "image_url": {"type": ["string", "null"]},
+                                    },
+                                    "anyOf": [
+                                        {"required": ["file_id"]},
+                                        {"required": ["image_url"]},
+                                    ],
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "required": ["type"],
+                                    "properties": {
+                                        "type": {"type": "string", "const": "input_file"},
+                                        "file_data": {"type": "string"},
+                                        "file_id": {"type": ["string", "null"]},
+                                        "file_url": {"type": "string"},
+                                        "filename": {"type": "string"},
+                                    },
+                                    "anyOf": [
+                                        {"required": ["file_data"]},
+                                        {"required": ["file_id"]},
+                                        {"required": ["file_url"]},
+                                    ],
+                                },
+                            ]
+                        },
+                    },
+                },
+            },
+        },
+    ]
+}
+
+MessageInput = Annotated[str | list[dict[str, Any]], WithJsonSchema(_MESSAGE_SCHEMA)]
+
+_MESSAGE_KEYS = {"role", "content", "type", "status"}
+_MESSAGE_ROLES = {"user", "system", "developer"}
+_MESSAGE_STATUSES = {"in_progress", "completed", "incomplete"}
+_CONTENT_KEYS = {
+    "input_text": {"type", "text"},
+    "input_image": {"type", "detail", "file_id", "image_url"},
+    "input_file": {"type", "file_data", "file_id", "file_url", "filename"},
+}
+_IMAGE_DETAILS = {"low", "high", "auto"}
 
 
 class ClientConfig(BaseModel):
@@ -148,6 +227,83 @@ class BaseRequest(BaseModel):
         default=None,
         description="Override client configuration (base_url, api_key, litellm_keys, model) for this request only.",
     )
+
+    @field_validator("message")
+    @classmethod
+    def validate_message(cls, v: MessageInput) -> MessageInput:
+        if isinstance(v, str):
+            return v
+        if not v:
+            raise ValueError("message must contain at least one structured Responses message")
+        for item in v:
+            _validate_structured_message(item)
+        return v
+
+
+def _validate_structured_message(message: dict[str, Any]) -> None:
+    extra_keys = set(message) - _MESSAGE_KEYS
+    if extra_keys:
+        raise ValueError(f"structured message contains unsupported fields: {sorted(extra_keys)}")
+
+    role = message.get("role")
+    if role not in _MESSAGE_ROLES:
+        raise ValueError("structured message role must be one of user, system, or developer")
+
+    if "type" in message and message["type"] != "message":
+        raise ValueError("structured message type must be 'message' when provided")
+
+    if "status" in message and message["status"] not in _MESSAGE_STATUSES:
+        raise ValueError("structured message status must be one of in_progress, completed, or incomplete")
+
+    content = message.get("content")
+    if not isinstance(content, list) or not content:
+        raise ValueError("structured message content must contain at least one item")
+
+    for item in content:
+        _validate_structured_content(item)
+
+
+def _validate_structured_content(content: Any) -> None:
+    if not isinstance(content, dict):
+        raise ValueError("structured message content items must be objects")
+
+    content_type = content.get("type")
+    if content_type not in _CONTENT_KEYS:
+        raise ValueError("structured message content type must be input_text, input_image, or input_file")
+
+    extra_keys = set(content) - _CONTENT_KEYS[content_type]
+    if extra_keys:
+        raise ValueError(f"structured message content contains unsupported fields: {sorted(extra_keys)}")
+
+    if content_type == "input_text":
+        _validate_text_content(content)
+    elif content_type == "input_image":
+        _validate_image_content(content)
+    else:
+        _validate_file_content(content)
+
+
+def _validate_text_content(content: dict[str, Any]) -> None:
+    if not isinstance(content.get("text"), str):
+        raise ValueError("input_text content requires string text")
+
+
+def _validate_image_content(content: dict[str, Any]) -> None:
+    if content.get("detail") not in _IMAGE_DETAILS:
+        raise ValueError("input_image content requires detail of low, high, or auto")
+    if not _has_non_empty_string(content, "file_id") and not _has_non_empty_string(content, "image_url"):
+        raise ValueError("input_image content requires file_id or image_url")
+
+
+def _validate_file_content(content: dict[str, Any]) -> None:
+    if not any(_has_non_empty_string(content, key) for key in ("file_data", "file_id", "file_url")):
+        raise ValueError("input_file content requires file_data, file_id, or file_url")
+    if "filename" in content and not isinstance(content["filename"], str):
+        raise ValueError("input_file content filename must be a string")
+
+
+def _has_non_empty_string(value: dict[str, Any], key: str) -> bool:
+    return isinstance(value.get(key), str) and bool(value[key])
 
 
 class LogRequest(BaseModel):

--- a/tests/integration/communication/test_streaming_order_consistency.py
+++ b/tests/integration/communication/test_streaming_order_consistency.py
@@ -61,6 +61,18 @@ def _strip_optional_initial_message_output(
     return flow
 
 
+def _normalize_optional_agent_message_outputs(
+    flow: list[tuple[str, str, str | None]],
+    agent_name: str,
+) -> list[tuple[str, str, str | None]]:
+    """Allow optional top-level assistant message items while preserving tool order."""
+    normalized = _strip_optional_initial_message_output(flow, agent_name)
+    final_message = ("message_output_item", agent_name, None)
+    if len(normalized) >= 2 and normalized[-2:] == [final_message, final_message]:
+        return normalized[:-1]
+    return normalized
+
+
 # Additional tools for complex scenarios
 @function_tool
 def process_data(data: str) -> str:
@@ -295,7 +307,7 @@ async def test_multiple_sequential_subagent_calls() -> None:
                 stream_items.append((evt_type, agent_name, tool_name))
 
     # Verify stream matches expected (allow optional initial message_output from reasoning models)
-    normalized = _strip_optional_initial_message_output(stream_items, "Coordinator")
+    normalized = _normalize_optional_agent_message_outputs(stream_items, "Coordinator")
     assert normalized == EXPECTED_FLOW_MULTIPLE_CALLS, (
         f"Multiple calls stream mismatch:\n got={stream_items}\n exp={EXPECTED_FLOW_MULTIPLE_CALLS}"
     )
@@ -532,7 +544,7 @@ async def test_parallel_subagent_calls() -> None:
                 stream_items.append((evt_type, agent_name, tool_name))
 
     # Verify stream matches expected (allow optional initial message_output from reasoning models)
-    normalized = _strip_optional_initial_message_output(stream_items, "Orchestrator")
+    normalized = _normalize_optional_agent_message_outputs(stream_items, "Orchestrator")
     if normalized != EXPECTED_FLOW_PARALLEL:
         logger.error(
             "Parallel sub-agent stream mismatch",

--- a/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
+++ b/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
@@ -18,6 +18,7 @@ from agency_swarm.agent.execution_stream_persistence import (
     _compute_content_hash,
     _persist_streamed_items,
 )
+from agency_swarm.messages import MessageFormatter
 
 
 class _DummyThreadManager:
@@ -26,6 +27,19 @@ class _DummyThreadManager:
 
     def get_all_messages(self) -> list[dict]:
         return list(self._messages)
+
+    def get_conversation_history(self, agent: str, caller_agent: str | None = None) -> list[dict]:
+        if caller_agent is None:
+            return [message for message in self._messages if message.get("callerAgent") is None]
+        return [
+            message
+            for message in self._messages
+            if (message.get("agent") == agent and message.get("callerAgent") == caller_agent)
+            or (message.get("agent") == caller_agent and message.get("callerAgent") == agent)
+        ]
+
+    def add_messages(self, messages: list[dict]) -> None:
+        self._messages.extend(messages)
 
     def replace_messages(self, messages: list[dict]) -> None:
         self._messages = list(messages)
@@ -41,6 +55,85 @@ class _DummyStreamResult:
 
     def to_input_list(self) -> list[dict]:
         return list(self._input_list)
+
+
+class _FakeRunItem:
+    def __init__(self, item: dict) -> None:
+        self.raw_item = item
+        self.type = item.get("type")
+        self.id = item.get("id")
+        self.call_id = item.get("call_id")
+
+    def to_input_item(self) -> dict:
+        return dict(self.raw_item)
+
+
+def test_persist_streamed_items_keeps_structured_file_input_for_follow_up_replay() -> None:
+    """Streaming final persistence must not drop the initiating structured attachment message."""
+    file_part = {
+        "type": "input_file",
+        "filename": "proof.pdf",
+        "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+    }
+    user_message = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "Read phrase two."}, file_part],
+        "agent": "AttachmentReader",
+        "callerAgent": None,
+        "agent_run_id": "agent_run_attachment",
+        "history_protocol": MessageFormatter.HISTORY_PROTOCOL_RESPONSES,
+        "timestamp": 1,
+    }
+    assistant_item = _FakeRunItem(
+        {
+            "type": "message",
+            "id": "msg_attachment_answer",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "silver compass"}],
+        }
+    )
+
+    thread_manager = _DummyThreadManager(messages=[user_message])
+    agency_context = AgencyContext(agency_instance=None, thread_manager=thread_manager)
+    agent = Agent(name="AttachmentReader", instructions="noop")
+
+    _persist_streamed_items(
+        streaming_result=_DummyStreamResult([assistant_item]),
+        metadata_store=StreamMetadataStore(
+            by_item={id(assistant_item): ("AttachmentReader", "agent_run_attachment", None, 2)}
+        ),
+        collected_items=[assistant_item],
+        agent=agent,
+        sender_name=None,
+        parent_run_id=None,
+        run_trace_id="trace",
+        fallback_agent_run_id="agent_run_attachment",
+        agency_context=agency_context,
+        initial_saved_count=0,
+    )
+
+    persisted = thread_manager.get_all_messages()
+    persisted_user = next(message for message in persisted if message.get("role") == "user")
+    assert persisted_user["content"][1] == file_part
+
+    follow_up_history = MessageFormatter.prepare_history_for_runner(
+        [{"role": "user", "content": "What follows phrase one?"}],
+        agent,
+        None,
+        agency_context,
+        agent_run_id="agent_run_follow_up",
+        run_trace_id="trace_follow_up",
+    )
+
+    replayed_user = next(
+        message
+        for message in follow_up_history
+        if message.get("role") == "user"
+        and isinstance(message.get("content"), list)
+        and any(part.get("type") == "input_file" for part in message["content"])
+    )
+    assert replayed_user["content"][1] == file_part
 
 
 @patch(

--- a/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
+++ b/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
@@ -136,6 +136,75 @@ def test_persist_streamed_items_keeps_structured_file_input_for_follow_up_replay
     assert replayed_user["content"][1] == file_part
 
 
+def test_persist_streamed_items_uses_collected_items_when_final_new_items_empty() -> None:
+    """Empty final new_items should still commit collected streamed output without dropping file input."""
+    file_part = {
+        "type": "input_file",
+        "filename": "proof.pdf",
+        "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+    }
+    user_message = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "Read phrase two."}, file_part],
+        "agent": "AttachmentReader",
+        "callerAgent": None,
+        "agent_run_id": "agent_run_attachment",
+        "history_protocol": MessageFormatter.HISTORY_PROTOCOL_RESPONSES,
+        "timestamp": 1,
+    }
+    assistant_item = _FakeRunItem(
+        {
+            "type": "message",
+            "id": "msg_attachment_answer",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "silver compass"}],
+        }
+    )
+
+    thread_manager = _DummyThreadManager(messages=[user_message])
+    agency_context = AgencyContext(agency_instance=None, thread_manager=thread_manager)
+    agent = Agent(name="AttachmentReader", instructions="noop")
+
+    _persist_streamed_items(
+        streaming_result=_DummyStreamResult([]),
+        metadata_store=StreamMetadataStore(
+            by_item={id(assistant_item): ("AttachmentReader", "agent_run_attachment", None, 2)}
+        ),
+        collected_items=[assistant_item],
+        agent=agent,
+        sender_name=None,
+        parent_run_id=None,
+        run_trace_id="trace",
+        fallback_agent_run_id="agent_run_attachment",
+        agency_context=agency_context,
+        initial_saved_count=0,
+    )
+
+    persisted = thread_manager.get_all_messages()
+    assert any(message.get("role") == "assistant" for message in persisted)
+    persisted_user = next(message for message in persisted if message.get("role") == "user")
+    assert persisted_user["content"][1] == file_part
+
+    follow_up_history = MessageFormatter.prepare_history_for_runner(
+        [{"role": "user", "content": "What follows phrase one?"}],
+        agent,
+        None,
+        agency_context,
+        agent_run_id="agent_run_follow_up",
+        run_trace_id="trace_follow_up",
+    )
+
+    replayed_user = next(
+        message
+        for message in follow_up_history
+        if message.get("role") == "user"
+        and isinstance(message.get("content"), list)
+        and any(part.get("type") == "input_file" for part in message["content"])
+    )
+    assert replayed_user["content"][1] == file_part
+
+
 @patch(
     "agency_swarm.agent.execution_stream_persistence.MessageFilter.remove_orphaned_messages",
     side_effect=lambda x: x,

--- a/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
+++ b/tests/test_agent_modules/test_execution_stream_persistence_fake_id.py
@@ -205,6 +205,61 @@ def test_persist_streamed_items_uses_collected_items_when_final_new_items_empty(
     assert replayed_user["content"][1] == file_part
 
 
+def test_persist_streamed_items_excludes_guardrail_retry_control_messages() -> None:
+    """Final persistence should keep initiating user input but drop same-run guardrail retry prompts."""
+    run_id = "agent_run_guardrail_retry"
+    user_message = {
+        "type": "message",
+        "role": "user",
+        "content": "Use only approved phrasing.",
+        "agent": "GuardedAgent",
+        "callerAgent": None,
+        "agent_run_id": run_id,
+        "history_protocol": MessageFormatter.HISTORY_PROTOCOL_RESPONSES,
+        "timestamp": 1,
+    }
+    guardrail_message = {
+        "type": "message",
+        "role": "system",
+        "content": "Rewrite the answer to satisfy the output guardrail.",
+        "message_origin": "output_guardrail_error",
+        "agent": "GuardedAgent",
+        "callerAgent": None,
+        "agent_run_id": run_id,
+        "history_protocol": MessageFormatter.HISTORY_PROTOCOL_RESPONSES,
+        "timestamp": 2,
+    }
+    assistant_item = _FakeRunItem(
+        {
+            "type": "message",
+            "id": "msg_guardrail_success",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "approved answer"}],
+        }
+    )
+
+    thread_manager = _DummyThreadManager(messages=[user_message, guardrail_message])
+    agency_context = AgencyContext(agency_instance=None, thread_manager=thread_manager)
+    agent = Agent(name="GuardedAgent", instructions="noop")
+
+    _persist_streamed_items(
+        streaming_result=_DummyStreamResult([assistant_item]),
+        metadata_store=StreamMetadataStore(by_item={id(assistant_item): ("GuardedAgent", run_id, None, 3)}),
+        collected_items=[assistant_item],
+        agent=agent,
+        sender_name=None,
+        parent_run_id=None,
+        run_trace_id="trace",
+        fallback_agent_run_id=run_id,
+        agency_context=agency_context,
+        initial_saved_count=0,
+    )
+
+    persisted = thread_manager.get_all_messages()
+    assert user_message in persisted
+    assert not any(message.get("message_origin") == "output_guardrail_error" for message in persisted)
+
+
 @patch(
     "agency_swarm.agent.execution_stream_persistence.MessageFilter.remove_orphaned_messages",
     side_effect=lambda x: x,

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
@@ -8,6 +8,7 @@ import gc
 from weakref import WeakKeyDictionary
 
 import pytest
+from pydantic import ValidationError
 
 
 @pytest.mark.asyncio
@@ -107,6 +108,7 @@ async def test_make_response_endpoint_forwards_structured_message_without_file_u
                 {
                     "type": "input_image",
                     "image_url": "data:image/png;base64,AAAA",
+                    "detail": "auto",
                 },
                 {"type": "input_text", "text": "Describe this image."},
             ],
@@ -145,6 +147,40 @@ async def test_make_response_endpoint_forwards_structured_message_without_file_u
     assert response["response"] == "ok"
     assert seen_message == structured_message
     assert "file_ids_map" not in response
+
+
+def test_base_request_rejects_invalid_structured_messages() -> None:
+    """The public request model should reject loose object arrays at validation."""
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    invalid_messages = [
+        [],
+        [{"foo": "bar"}],
+        [{"role": "user"}],
+        [{"role": "user", "content": []}],
+        [{"role": "user", "content": [{"text": "Missing type"}]}],
+        [{"role": "user", "content": [{"type": "input_text"}]}],
+        [{"role": "user", "content": [{"type": "input_image", "detail": "auto"}]}],
+        [{"role": "user", "content": [{"type": "input_file", "filename": "report.pdf"}]}],
+    ]
+
+    for message in invalid_messages:
+        with pytest.raises(ValidationError):
+            BaseRequest.model_validate({"message": message})
+
+
+def test_base_request_message_schema_describes_structured_content() -> None:
+    """Generated OpenAPI should expose the structured Responses content contract."""
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    message_schema = BaseRequest.model_json_schema()["properties"]["message"]
+
+    assert message_schema["anyOf"][0] == {"type": "string"}
+    structured_schema = message_schema["anyOf"][1]
+    assert structured_schema["minItems"] == 1
+    content_schema = structured_schema["items"]["properties"]["content"]
+    content_types = {option["properties"]["type"]["const"] for option in content_schema["items"]["oneOf"]}
+    assert content_types == {"input_text", "input_image", "input_file"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
@@ -112,7 +112,8 @@ async def test_make_response_endpoint_forwards_structured_message_without_file_u
                 },
                 {"type": "input_text", "text": "Describe this image."},
             ],
-        }
+        },
+        {"role": "user", "content": "Describe this scene. How many trees do you see?"},
     ]
     seen_message = None
 
@@ -150,18 +151,12 @@ async def test_make_response_endpoint_forwards_structured_message_without_file_u
 
 
 def test_base_request_rejects_invalid_structured_messages() -> None:
-    """The public request model should reject loose object arrays at validation."""
+    """The public request model should reject non-object structured items."""
     from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
 
     invalid_messages = [
         [],
-        [{"foo": "bar"}],
-        [{"role": "user"}],
-        [{"role": "user", "content": []}],
-        [{"role": "user", "content": [{"text": "Missing type"}]}],
-        [{"role": "user", "content": [{"type": "input_text"}]}],
-        [{"role": "user", "content": [{"type": "input_image", "detail": "auto"}]}],
-        [{"role": "user", "content": [{"type": "input_file", "filename": "report.pdf"}]}],
+        ["not an object"],
     ]
 
     for message in invalid_messages:
@@ -169,8 +164,35 @@ def test_base_request_rejects_invalid_structured_messages() -> None:
             BaseRequest.model_validate({"message": message})
 
 
-def test_base_request_message_schema_describes_structured_content() -> None:
-    """Generated OpenAPI should expose the structured Responses content contract."""
+def test_base_request_accepts_sdk_easy_input_message_string_content() -> None:
+    """EasyInputMessageParam content may be plain text in current OpenAI SDK types."""
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    message = [{"role": "user", "content": "Describe this scene. How many trees do you see?"}]
+
+    request = BaseRequest.model_validate({"message": message})
+
+    assert request.message == message
+
+
+def test_base_request_does_not_own_image_detail_literals() -> None:
+    """The OpenAI SDK/API should own image detail literals, not the FastAPI shim."""
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    message = [
+        {
+            "role": "user",
+            "content": [{"type": "input_image", "image_url": "data:image/png;base64,AAAA", "detail": "original"}],
+        }
+    ]
+
+    request = BaseRequest.model_validate({"message": message})
+
+    assert request.message == message
+
+
+def test_base_request_message_schema_keeps_responses_items_pass_through() -> None:
+    """Generated OpenAPI should avoid owning a partial Responses content schema."""
     from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
 
     message_schema = BaseRequest.model_json_schema()["properties"]["message"]
@@ -178,9 +200,7 @@ def test_base_request_message_schema_describes_structured_content() -> None:
     assert message_schema["anyOf"][0] == {"type": "string"}
     structured_schema = message_schema["anyOf"][1]
     assert structured_schema["minItems"] == 1
-    content_schema = structured_schema["items"]["properties"]["content"]
-    content_types = {option["properties"]["type"]["const"] for option in content_schema["items"]["oneOf"]}
-    assert content_types == {"input_text", "input_image", "input_file"}
+    assert structured_schema["items"] == {"type": "object", "additionalProperties": True}
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py
@@ -92,6 +92,62 @@ async def test_make_response_endpoint_builds_upload_client_after_lease(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_make_response_endpoint_forwards_structured_message_without_file_upload(monkeypatch) -> None:
+    """Structured message attachments should use the core message contract, not file_urls upload."""
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils import endpoint_handlers
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    structured_message = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,AAAA",
+                },
+                {"type": "input_text", "text": "Describe this image."},
+            ],
+        }
+    ]
+    seen_message = None
+
+    class _ThreadManager:
+        def get_all_messages(self):
+            return []
+
+    class _Response:
+        final_output = "ok"
+
+    class _Agency:
+        def __init__(self):
+            self.thread_manager = _ThreadManager()
+
+        async def get_response(self, **kwargs):
+            nonlocal seen_message
+            seen_message = kwargs["message"]
+            return _Response()
+
+    async def _attach_noop(_agency):
+        return None
+
+    async def _unexpected_upload(*_args, **_kwargs):
+        raise AssertionError("structured message input must not call file_urls upload")
+
+    monkeypatch.setattr(endpoint_handlers, "attach_persistent_mcp_servers", _attach_noop)
+    monkeypatch.setattr(endpoint_handlers, "upload_from_urls", _unexpected_upload)
+
+    handler = make_response_endpoint(BaseRequest, lambda **_: _Agency(), verify_token=lambda: None)
+    response = await handler(BaseRequest(message=structured_message), token=None)
+
+    assert response["response"] == "ok"
+    assert seen_message == structured_message
+    assert "file_ids_map" not in response
+
+
+@pytest.mark.asyncio
 async def test_make_response_endpoint_serializes_singleton_agency_requests(monkeypatch) -> None:
     """Concurrent requests against a cached agency should be serialized by the handler."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
@@ -337,6 +337,63 @@ async def test_codex_streaming_reinjects_missing_message_into_completed_event(mo
 
 
 @pytest.mark.asyncio
+async def test_codex_streaming_reinjects_missing_items_in_output_index_order(monkeypatch) -> None:
+    """Missing streamed items should be merged back before later completed output items."""
+    from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage, ResponseOutputText
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        content=[ResponseOutputText(annotations=[], logprobs=[], text="first", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    streamed_tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-1",
+        status="completed",
+    )
+    completed_tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-1",
+        status="completed",
+    )
+
+    observed = await _collect_codex_stream_events(
+        monkeypatch,
+        [
+            ResponseOutputItemDoneEvent(
+                item=message,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.done",
+            ),
+            ResponseOutputItemDoneEvent(
+                item=streamed_tool_call,
+                output_index=1,
+                sequence_number=2,
+                type="response.output_item.done",
+            ),
+            ResponseCompletedEvent(
+                response=_build_response([completed_tool_call]),
+                sequence_number=3,
+                type="response.completed",
+            ),
+        ],
+    )
+
+    assert observed[-1].response.output == [message, completed_tool_call]
+
+
+@pytest.mark.asyncio
 async def test_codex_streaming_passes_text_only_events_through_unchanged(monkeypatch) -> None:
     """Codex-configured streaming should leave text-only responses unchanged."""
     from openai.types.responses import ResponseOutputMessage, ResponseOutputText

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
@@ -157,6 +157,71 @@ async def test_make_stream_endpoint_background_cleanup_without_stream_consumptio
 
 
 @pytest.mark.asyncio
+async def test_make_stream_endpoint_forwards_structured_message_without_file_upload(monkeypatch) -> None:
+    """Streaming FastAPI requests should preserve structured inline attachments."""
+    pytest.importorskip("agents")
+
+    from agency_swarm.agent.execution_stream_response import StreamingRunResponse
+    from agency_swarm.integrations.fastapi_utils import endpoint_handlers
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import ActiveRunRegistry, make_stream_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    class _HttpRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    class _ThreadManager:
+        def get_all_messages(self):
+            return []
+
+    structured_message = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_file", "filename": "report.pdf", "file_data": "data:application/pdf;base64,AAAA"},
+                {"type": "input_text", "text": "Summarize this file."},
+            ],
+        }
+    ]
+    seen_message = None
+
+    class _Agency:
+        def __init__(self):
+            self.thread_manager = _ThreadManager()
+
+        def get_response_stream(self, **kwargs):
+            nonlocal seen_message
+            seen_message = kwargs["message"]
+
+            async def _stream():
+                if False:
+                    yield {}
+
+            return StreamingRunResponse(_stream())
+
+    async def _attach_noop(_agency):
+        return None
+
+    async def _unexpected_upload(*_args, **_kwargs):
+        raise AssertionError("structured message input must not call file_urls upload")
+
+    monkeypatch.setattr(endpoint_handlers, "attach_persistent_mcp_servers", _attach_noop)
+    monkeypatch.setattr(endpoint_handlers, "upload_from_urls", _unexpected_upload)
+
+    handler = make_stream_endpoint(
+        BaseRequest,
+        lambda **_: _Agency(),
+        verify_token=lambda: None,
+        run_registry=ActiveRunRegistry(),
+    )
+    response = await handler(http_request=_HttpRequest(), request=BaseRequest(message=structured_message), token=None)
+    chunks = [chunk async for chunk in response.body_iterator]
+
+    assert seen_message == structured_message
+    assert any(chunk.startswith("event: messages") for chunk in chunks)
+
+
+@pytest.mark.asyncio
 async def test_codex_streaming_reinjects_missing_tool_call_into_completed_event(monkeypatch) -> None:
     """Codex-configured streaming should surface a streamed function call in completed output."""
     from openai.types.responses import ResponseFunctionToolCall

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
@@ -302,6 +302,41 @@ async def test_codex_streaming_does_not_duplicate_tool_call_already_in_completed
 
 
 @pytest.mark.asyncio
+async def test_codex_streaming_reinjects_missing_message_into_completed_event(monkeypatch) -> None:
+    """Codex-configured streaming should surface streamed assistant text in completed output."""
+    from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    message = ResponseOutputMessage(
+        id="msg-1",
+        content=[ResponseOutputText(annotations=[], logprobs=[], text="silver compass", type="output_text")],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    observed = await _collect_codex_stream_events(
+        monkeypatch,
+        [
+            ResponseOutputItemDoneEvent(
+                item=message,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.done",
+            ),
+            ResponseCompletedEvent(
+                response=_build_response([]),
+                sequence_number=2,
+                type="response.completed",
+            ),
+        ],
+    )
+
+    assert [event.type for event in observed] == ["response.output_item.done", "response.completed"]
+    assert observed[-1].response.output == [message]
+
+
+@pytest.mark.asyncio
 async def test_codex_streaming_passes_text_only_events_through_unchanged(monkeypatch) -> None:
     """Codex-configured streaming should leave text-only responses unchanged."""
     from openai.types.responses import ResponseOutputMessage, ResponseOutputText

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py
@@ -302,6 +302,54 @@ async def test_codex_streaming_does_not_duplicate_tool_call_already_in_completed
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("completed_id", ["fc-regenerated", None])
+async def test_codex_streaming_dedupes_tool_call_by_call_id_when_completed_id_changes(
+    monkeypatch,
+    completed_id: str | None,
+) -> None:
+    """Codex may complete the same function call with a regenerated or absent item id."""
+    from openai.types.responses import ResponseFunctionToolCall
+    from openai.types.responses.response_completed_event import ResponseCompletedEvent
+    from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
+
+    streamed_tool_call = ResponseFunctionToolCall(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id="fc-streamed",
+        status="completed",
+    )
+    completed_tool_call = ResponseFunctionToolCall.model_construct(
+        arguments='{"q":"weather"}',
+        call_id="call-1",
+        name="lookup_weather",
+        type="function_call",
+        id=completed_id,
+        status="completed",
+    )
+    observed = await _collect_codex_stream_events(
+        monkeypatch,
+        [
+            ResponseOutputItemDoneEvent(
+                item=streamed_tool_call,
+                output_index=0,
+                sequence_number=1,
+                type="response.output_item.done",
+            ),
+            ResponseCompletedEvent(
+                response=_build_response([completed_tool_call]),
+                sequence_number=2,
+                type="response.completed",
+            ),
+        ],
+    )
+
+    assert [item.call_id for item in observed[-1].response.output] == ["call-1"]
+    assert observed[-1].response.output == [completed_tool_call]
+
+
+@pytest.mark.asyncio
 async def test_codex_streaming_reinjects_missing_message_into_completed_event(monkeypatch) -> None:
     """Codex-configured streaming should surface streamed assistant text in completed output."""
     from openai.types.responses import ResponseOutputMessage, ResponseOutputText


### PR DESCRIPTION
## Summary
- Exposes Agency Swarm's existing structured message attachment support through the FastAPI request model.
- Validates structured `message` payloads for Responses-compatible `input_text`, `input_image`, and `input_file` content instead of accepting arbitrary object lists.
- Documents structured message attachments and manual `chat_history` replay limits for FastAPI clients.

## Why
AgentSwarm TUI dropped images/files should not be forced through the `file_urls` upload path when the intended contract is a structured Responses message attachment. This keeps browser-auth image attachments out of the OpenAI Files upload path.

Follow-up attachment continuity comes from manual `chat_history` replay and may resend inline attachment content or references. It does not use OpenAI server-managed state, `previous_response_id`, Conversations, or `file_id` reuse.

## Verification
- `uv run --python python3.12 pytest tests/test_fastapi_utils_modules/test_openai_client_config_request_state.py tests/test_fastapi_utils_modules/test_openai_client_config_streaming.py`
- `uv run pytest tests/test_fastapi_utils_modules`
- `uv run ruff check ...`
- `uv run mypy src`
- Independent Codex review: no findings after the validation/schema fix.
