### PR TITLE
fix: preserve stateless Responses reasoning replay

### DIFF
--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -18,6 +18,7 @@ from agents.models.default_models import get_default_model_settings as get_sdk_d
 from agency_swarm.agent.attachment_manager import AttachmentManager
 from agency_swarm.agent.constants import FRAMEWORK_DEFAULT_MODEL
 from agency_swarm.agent.file_manager import AgentFileManager
+from agency_swarm.messages.response_input_sanitizer import ensure_store_false_reasoning_encrypted_content
 from agency_swarm.tools import BaseTool, ToolFactory
 from agency_swarm.utils.model_utils import get_default_settings_model_name
 
@@ -135,6 +136,7 @@ def apply_framework_defaults(kwargs: dict[str, Any]) -> None:
     existing_settings = kwargs.get("model_settings")
     if existing_settings is None:
         kwargs["model_settings"] = base_defaults
+        ensure_store_false_reasoning_encrypted_content(kwargs["model_settings"])
         return
 
     if isinstance(existing_settings, dict):
@@ -145,6 +147,7 @@ def apply_framework_defaults(kwargs: dict[str, Any]) -> None:
 
     # User-specified values override defaults; unset fields inherit framework+SDK defaults
     kwargs["model_settings"] = base_defaults.resolve(existing_settings)
+    ensure_store_false_reasoning_encrypted_content(kwargs["model_settings"])
 
 
 def separate_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -58,6 +58,11 @@ from agency_swarm.integrations.fastapi_utils.override_policy import (
 )
 from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 from agency_swarm.messages import MessageFilter, MessageFormatter
+from agency_swarm.messages.response_input_sanitizer import (
+    REASONING_ENCRYPTED_CONTENT_INCLUDE,
+    ensure_store_false_reasoning_encrypted_content,
+    sanitize_store_false_responses_input,
+)
 from agency_swarm.streaming.id_normalizer import StreamIdNormalizer
 from agency_swarm.tools.mcp_manager import attach_persistent_mcp_servers
 from agency_swarm.ui.core.agui_adapter import AguiAdapter
@@ -1039,15 +1044,20 @@ Rules:
             codex_input = [cast(TResponseInputItem, {"role": "user", "content": formatted_messages})]
         else:
             codex_input = cast(list[TResponseInputItem], stripped_messages)
+            codex_input = cast(list[TResponseInputItem], sanitize_store_false_responses_input(codex_input))
 
         retry_suffix = ""
         for _attempt in range(4):
-            response = await client.responses.create(
-                model="gpt-5.4-mini",
-                instructions=title_instructions + retry_suffix,
-                input=codex_input,
-                store=False,
-                stream=True,
+            response = cast(
+                Any,
+                await client.responses.create(
+                    model="gpt-5.4-mini",
+                    instructions=title_instructions + retry_suffix,
+                    input=codex_input,
+                    include=[REASONING_ENCRYPTED_CONTENT_INCLUDE],
+                    store=False,
+                    stream=True,
+                ),
             )
             text_parts: list[str] = []
             async for event in response:
@@ -1305,6 +1315,7 @@ def _apply_codex_compatibility_model_settings(agent: Agent) -> None:
     current: ModelSettings = getattr(agent, "model_settings", None) or ModelSettings()
     current.store = False
     current.truncation = None
+    ensure_store_false_reasoning_encrypted_content(current)
     agent.model_settings = current
 
     model = agent.model

--- a/src/agency_swarm/integrations/openclaw.py
+++ b/src/agency_swarm/integrations/openclaw.py
@@ -43,6 +43,7 @@ _OPENRESPONSES_ALLOWED_KEYS: tuple[str, ...] = (
     "top_p",
     "metadata",
     "store",
+    "include",
     "previous_response_id",
     "reasoning",
     "truncation",

--- a/src/agency_swarm/integrations/openclaw.py
+++ b/src/agency_swarm/integrations/openclaw.py
@@ -49,6 +49,16 @@ _OPENRESPONSES_ALLOWED_KEYS: tuple[str, ...] = (
     "truncation",
 )
 _ALLOWED_TOOL_CHOICE_VALUES = {"auto", "none", "required"}
+_OPENRESPONSES_ALLOWED_INCLUDE_VALUES = {
+    "file_search_call.results",
+    "web_search_call.results",
+    "web_search_call.action.sources",
+    "message.input_image.image_url",
+    "computer_call_output.output.image_url",
+    "code_interpreter_call.outputs",
+    "reasoning.encrypted_content",
+    "message.output_text.logprobs",
+}
 _PROVIDER_ENV_KEYS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
 _RESPONSE_HEADER_BLOCKLIST = {"content-length", "transfer-encoding", "connection"}
 _RESPONSE_HEADER_BLOCKLIST_DECODED = _RESPONSE_HEADER_BLOCKLIST | {"content-encoding"}
@@ -780,6 +790,13 @@ def _normalize_metadata(metadata: Any) -> dict[str, str] | None:
     return normalized
 
 
+def _normalize_response_include(include: Any) -> list[str] | None:
+    if not isinstance(include, list):
+        return None
+    normalized = [item for item in include if isinstance(item, str) and item in _OPENRESPONSES_ALLOWED_INCLUDE_VALUES]
+    return normalized or None
+
+
 def normalize_openclaw_responses_request(raw_payload: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize Open Responses requests to OpenClaw-compatible shape."""
     payload = dict(raw_payload)
@@ -804,7 +821,7 @@ def normalize_openclaw_responses_request(raw_payload: Mapping[str, Any]) -> dict
     }
 
     for key in _OPENRESPONSES_ALLOWED_KEYS:
-        if key in {"model", "input", "tools", "tool_choice", "metadata"}:
+        if key in {"model", "input", "tools", "tool_choice", "metadata", "include"}:
             continue
         if key in payload:
             normalized[key] = payload[key]
@@ -823,6 +840,11 @@ def normalize_openclaw_responses_request(raw_payload: Mapping[str, Any]) -> dict
         normalized_metadata = _normalize_metadata(payload.get("metadata"))
         if normalized_metadata is not None:
             normalized["metadata"] = normalized_metadata
+
+    if "include" in payload:
+        normalized_include = _normalize_response_include(payload.get("include"))
+        if normalized_include is not None:
+            normalized["include"] = normalized_include
 
     return normalized
 

--- a/src/agency_swarm/messages/message_formatter.py
+++ b/src/agency_swarm/messages/message_formatter.py
@@ -21,6 +21,11 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_file_search_tool_call import Result as ResponseFileSearchResult
 
+from agency_swarm.messages.response_input_sanitizer import (
+    ensure_store_false_reasoning_encrypted_content,
+    sanitize_store_false_responses_input,
+)
+
 if TYPE_CHECKING:
     from agency_swarm.agent.core import AgencyContext, Agent
 
@@ -297,6 +302,9 @@ class MessageFormatter:
         # Strip agency metadata before sending to OpenAI
         history_for_runner = MessageFormatter.strip_agency_metadata(history_for_runner)
         history_for_runner = MessageFormatter.sanitize_replayed_tool_item_ids(history_for_runner)
+        if MessageFormatter._model_settings_store_false(agent):
+            ensure_store_false_reasoning_encrypted_content(agent.model_settings)
+            history_for_runner = sanitize_store_false_responses_input(history_for_runner)
         return history_for_runner  # type: ignore[return-value]
 
     @staticmethod
@@ -396,6 +404,11 @@ class MessageFormatter:
                 continue
             sanitized.append(msg)
         return sanitized
+
+    @staticmethod
+    def _model_settings_store_false(agent: "Agent") -> bool:
+        model_settings = getattr(agent, "model_settings", None)
+        return getattr(model_settings, "store", None) is False
 
     @staticmethod
     def add_citations_to_message(

--- a/src/agency_swarm/messages/response_input_sanitizer.py
+++ b/src/agency_swarm/messages/response_input_sanitizer.py
@@ -23,17 +23,18 @@ def sanitize_store_false_responses_input(history: list[Any]) -> list[dict[str, A
     """Drop reasoning items that cannot be replayed without server-side state."""
     sanitized: list[dict[str, Any]] = []
     dropped_item_ids: set[str] = set()
-    skip_next = False
+    previous_reasoning_dropped = False
     for msg in history:
-        if skip_next:
+        if previous_reasoning_dropped and _is_reasoning_dependent_response_item(msg):
             if isinstance(msg, dict) and isinstance(msg.get("id"), str):
                 dropped_item_ids.add(msg["id"])
-            skip_next = False
+            previous_reasoning_dropped = False
             continue
+        previous_reasoning_dropped = False
         if isinstance(msg, dict) and msg.get("type") == "reasoning" and not msg.get("encrypted_content"):
             if isinstance(msg.get("id"), str):
                 dropped_item_ids.add(msg["id"])
-            skip_next = True
+            previous_reasoning_dropped = True
             continue
         if (
             isinstance(msg, dict)
@@ -47,6 +48,21 @@ def sanitize_store_false_responses_input(history: list[Any]) -> list[dict[str, A
             sanitized.append(cleaned)
     cleaned = MessageFilter.remove_orphaned_messages(cast(list[TResponseInputItem], sanitized))
     return cast(list[dict[str, Any]], cleaned)
+
+
+def _is_reasoning_dependent_response_item(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+
+    msg_type = value.get("type")
+    if msg_type == "message":
+        return value.get("role") == "assistant"
+    return msg_type in (
+        MessageFilter.CALL_ID_CALL_TYPES
+        | MessageFilter.CALL_ID_OUTPUT_TYPES
+        | MessageFilter.MCP_APPROVAL_REQUEST_TYPES
+        | MessageFilter.MCP_APPROVAL_RESPONSE_TYPES
+    )
 
 
 def _sanitize_store_false_responses_value(value: Any) -> Any | None:

--- a/src/agency_swarm/messages/response_input_sanitizer.py
+++ b/src/agency_swarm/messages/response_input_sanitizer.py
@@ -1,6 +1,10 @@
 """Responses input helpers for manual replay paths."""
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
+
+from agents import TResponseInputItem
+
+from agency_swarm.messages.message_filter import MessageFilter
 
 REASONING_ENCRYPTED_CONTENT_INCLUDE: Literal["reasoning.encrypted_content"] = "reasoning.encrypted_content"
 
@@ -18,11 +22,31 @@ def ensure_store_false_reasoning_encrypted_content(model_settings: Any) -> None:
 def sanitize_store_false_responses_input(history: list[Any]) -> list[dict[str, Any]]:
     """Drop reasoning items that cannot be replayed without server-side state."""
     sanitized: list[dict[str, Any]] = []
+    dropped_item_ids: set[str] = set()
+    skip_next = False
     for msg in history:
+        if skip_next:
+            if isinstance(msg, dict) and isinstance(msg.get("id"), str):
+                dropped_item_ids.add(msg["id"])
+            skip_next = False
+            continue
+        if isinstance(msg, dict) and msg.get("type") == "reasoning" and not msg.get("encrypted_content"):
+            if isinstance(msg.get("id"), str):
+                dropped_item_ids.add(msg["id"])
+            skip_next = True
+            continue
+        if (
+            isinstance(msg, dict)
+            and msg.get("type") == "item_reference"
+            and isinstance(msg.get("id"), str)
+            and msg["id"] in dropped_item_ids
+        ):
+            continue
         cleaned = _sanitize_store_false_responses_value(msg)
         if isinstance(cleaned, dict):
             sanitized.append(cleaned)
-    return sanitized
+    cleaned = MessageFilter.remove_orphaned_messages(cast(list[TResponseInputItem], sanitized))
+    return cast(list[dict[str, Any]], cleaned)
 
 
 def _sanitize_store_false_responses_value(value: Any) -> Any | None:

--- a/src/agency_swarm/messages/response_input_sanitizer.py
+++ b/src/agency_swarm/messages/response_input_sanitizer.py
@@ -1,0 +1,48 @@
+"""Responses input helpers for manual replay paths."""
+
+from typing import Any, Literal
+
+REASONING_ENCRYPTED_CONTENT_INCLUDE: Literal["reasoning.encrypted_content"] = "reasoning.encrypted_content"
+
+
+def ensure_store_false_reasoning_encrypted_content(model_settings: Any) -> None:
+    """Request encrypted reasoning when Responses history will not be stored server-side."""
+    if getattr(model_settings, "store", None) is not False:
+        return
+
+    existing = list(getattr(model_settings, "response_include", None) or [])
+    if REASONING_ENCRYPTED_CONTENT_INCLUDE not in existing:
+        model_settings.response_include = [*existing, REASONING_ENCRYPTED_CONTENT_INCLUDE]
+
+
+def sanitize_store_false_responses_input(history: list[Any]) -> list[dict[str, Any]]:
+    """Drop reasoning items that cannot be replayed without server-side state."""
+    sanitized: list[dict[str, Any]] = []
+    for msg in history:
+        cleaned = _sanitize_store_false_responses_value(msg)
+        if isinstance(cleaned, dict):
+            sanitized.append(cleaned)
+    return sanitized
+
+
+def _sanitize_store_false_responses_value(value: Any) -> Any | None:
+    if isinstance(value, list):
+        cleaned_items: list[Any] = []
+        for item in value:
+            cleaned = _sanitize_store_false_responses_value(item)
+            if cleaned is not None:
+                cleaned_items.append(cleaned)
+        return cleaned_items
+
+    if not isinstance(value, dict):
+        return value
+
+    if value.get("type") == "reasoning" and not value.get("encrypted_content"):
+        return None
+
+    cleaned_dict: dict[str, Any] = {}
+    for key, item in value.items():
+        cleaned = _sanitize_store_false_responses_value(item)
+        if cleaned is not None:
+            cleaned_dict[key] = cleaned
+    return cleaned_dict

--- a/tests/integration/fastapi/test_openclaw_proxy_requests.py
+++ b/tests/integration/fastapi/test_openclaw_proxy_requests.py
@@ -186,12 +186,11 @@ def test_openclaw_proxy_filters_request_keys_and_normalizes_payload(
         "top_p",
         "metadata",
         "store",
-        "include",
         "previous_response_id",
         "reasoning",
         "truncation",
     }
-    assert forwarded["include"] == ["response.output_text"]
+    assert "include" not in forwarded
     assert "parallel_tool_calls" not in forwarded
     assert forwarded["model"] == "openai/gpt-5.4-mini"
     assert forwarded["input"] == [
@@ -246,7 +245,7 @@ def test_openclaw_proxy_forwards_encrypted_reasoning_include(
         json={
             "model": "openclaw:main",
             "input": "hello",
-            "include": ["reasoning.encrypted_content"],
+            "include": ["response.output_text", "reasoning.encrypted_content"],
             "store": False,
         },
     )

--- a/tests/integration/fastapi/test_openclaw_proxy_requests.py
+++ b/tests/integration/fastapi/test_openclaw_proxy_requests.py
@@ -186,11 +186,12 @@ def test_openclaw_proxy_filters_request_keys_and_normalizes_payload(
         "top_p",
         "metadata",
         "store",
+        "include",
         "previous_response_id",
         "reasoning",
         "truncation",
     }
-    assert "include" not in forwarded
+    assert forwarded["include"] == ["response.output_text"]
     assert "parallel_tool_calls" not in forwarded
     assert forwarded["model"] == "openai/gpt-5.4-mini"
     assert forwarded["input"] == [
@@ -212,6 +213,47 @@ def test_openclaw_proxy_filters_request_keys_and_normalizes_payload(
     assert forwarded["metadata"] == {"attempt": "1", "scope": '{"a": 1}', "label": "ok"}
     assert captured["headers"]["Authorization"] == "Bearer gateway-token"
     assert captured["url"] == "http://127.0.0.1:18789/v1/responses"
+
+
+def test_openclaw_proxy_forwards_encrypted_reasoning_include(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def __aenter__(self) -> _FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> httpx.Response:
+            captured["json"] = json
+            return httpx.Response(status_code=200, json={"ok": True})
+
+    monkeypatch.setattr("agency_swarm.integrations.openclaw.httpx.AsyncClient", _FakeAsyncClient)
+
+    app = FastAPI()
+    attach_openclaw_to_fastapi(app, _build_openclaw_config(tmp_path))
+    client = TestClient(app)
+
+    response = client.post(
+        "/openclaw/v1/responses",
+        json={
+            "model": "openclaw:main",
+            "input": "hello",
+            "include": ["reasoning.encrypted_content"],
+            "store": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["json"]["include"] == ["reasoning.encrypted_content"]
+    assert captured["json"]["store"] is False
 
 
 def test_openclaw_proxy_preserves_full_history_without_synthesizing_session_fields(

--- a/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
+++ b/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
@@ -355,6 +355,18 @@ def _history_with_unencrypted_reasoning_before_tool_pair() -> list[dict[str, Any
     ]
 
 
+def _history_with_unencrypted_reasoning_before_current_user_message() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "reasoning",
+            "id": "rs_reasoning_123",
+            "summary": [{"type": "summary_text", "text": "looked up the answer"}],
+            "status": "completed",
+        },
+        {"role": "user", "content": "again"},
+    ]
+
+
 def _assert_store_false_input_preserves_stateless_reasoning(model_input: str | list[TResponseInputItem]) -> None:
     assert isinstance(model_input, list)
     reasoning = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "reasoning")
@@ -470,6 +482,12 @@ async def test_stream_endpoint_store_false_drops_only_unencrypted_reasoning() ->
 
 def test_store_false_sanitizer_drops_dependent_followers_after_unencrypted_reasoning() -> None:
     sanitized = sanitize_store_false_responses_input(_history_with_unencrypted_reasoning_before_tool_pair())
+
+    assert sanitized == [{"role": "user", "content": "again"}]
+
+
+def test_store_false_sanitizer_preserves_current_user_after_unencrypted_reasoning() -> None:
+    sanitized = sanitize_store_false_responses_input(_history_with_unencrypted_reasoning_before_current_user_message())
 
     assert sanitized == [{"role": "user", "content": "again"}]
 

--- a/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
+++ b/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
@@ -32,10 +32,12 @@ from openai.types.responses.response_usage import InputTokensDetails, OutputToke
 from agency_swarm import Agency, Agent
 from agency_swarm.integrations.fastapi_utils.endpoint_handlers import (
     ActiveRunRegistry,
+    generate_chat_name,
     make_response_endpoint,
     make_stream_endpoint,
 )
 from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+from agency_swarm.messages.response_input_sanitizer import REASONING_ENCRYPTED_CONTENT_INCLUDE
 
 
 class _TrackingResponsesModel(Model):
@@ -44,6 +46,7 @@ class _TrackingResponsesModel(Model):
         self.issued_response_ids: list[str] = []
         self.seen_previous_response_ids: list[str | None] = []
         self.seen_inputs: list[str | list[TResponseInputItem]] = []
+        self.seen_model_settings: list[ModelSettings] = []
 
     async def get_response(
         self,
@@ -60,6 +63,7 @@ class _TrackingResponsesModel(Model):
         prompt: ResponsePromptParam | None,
     ) -> ModelResponse:
         self.seen_inputs.append(copy.deepcopy(input) if isinstance(input, list) else input)
+        self.seen_model_settings.append(copy.deepcopy(model_settings))
         self.seen_previous_response_ids.append(previous_response_id)
         response_id = self._issue_response_id()
         return _build_model_response(text="OK", response_id=response_id)
@@ -79,6 +83,7 @@ class _TrackingResponsesModel(Model):
         prompt: ResponsePromptParam | None,
     ) -> AsyncIterator[TResponseStreamEvent]:
         self.seen_inputs.append(copy.deepcopy(input) if isinstance(input, list) else input)
+        self.seen_model_settings.append(copy.deepcopy(model_settings))
         self.seen_previous_response_ids.append(previous_response_id)
         response_id = self._issue_response_id()
         return _stream_text_events(text="OK", model_name=self.model, response_id=response_id)
@@ -246,6 +251,111 @@ def _build_agency_factory(model: _TrackingResponsesModel):
     return create_agency
 
 
+def _build_store_false_agency_factory(model: _TrackingResponsesModel):
+    def create_agency(load_threads_callback=None, save_threads_callback=None):
+        agent = Agent(
+            name="TestAgent",
+            instructions="Base instructions",
+            model=model,
+            model_settings=ModelSettings(store=False, temperature=0.0),
+        )
+        return Agency(
+            agent,
+            load_threads_callback=load_threads_callback,
+            save_threads_callback=save_threads_callback,
+        )
+
+    return create_agency
+
+
+def _history_with_encrypted_reasoning() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "reasoning",
+            "id": "rs_reasoning_123",
+            "summary": [{"type": "summary_text", "text": "looked up the answer", "id": "rs_summary_123"}],
+            "content": [{"type": "reasoning_text", "text": "private", "id": "rs_content_123"}],
+            "encrypted_content": "encrypted_reasoning",
+            "previous_response_id": "resp_previous_123",
+            "status": "completed",
+            "agent": "TestAgent",
+            "callerAgent": None,
+            "timestamp": 1,
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "id": "msg_answer_123",
+            "content": [{"type": "output_text", "text": "The answer is 42.", "annotations": [], "id": "msg_text_123"}],
+            "conversation_id": "conv_previous_123",
+            "status": "completed",
+            "agent": "TestAgent",
+            "callerAgent": None,
+            "timestamp": 2,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_lookup_123",
+            "call_id": "call_lookup_123",
+            "name": "lookup",
+            "arguments": "{}",
+            "status": "completed",
+            "agent": "TestAgent",
+            "callerAgent": None,
+            "timestamp": 3,
+        },
+        {
+            "type": "function_call_output",
+            "id": "fc_output_123",
+            "call_id": "call_lookup_123",
+            "output": "42",
+            "status": "completed",
+            "agent": "TestAgent",
+            "callerAgent": None,
+            "timestamp": 4,
+        },
+        {"type": "item_reference", "id": "msg_answer_123", "agent": "TestAgent", "callerAgent": None, "timestamp": 5},
+    ]
+
+
+def _history_with_unencrypted_reasoning() -> list[dict[str, Any]]:
+    history = _history_with_encrypted_reasoning()
+    reasoning = next(item for item in history if item.get("type") == "reasoning")
+    reasoning.pop("encrypted_content")
+    return history
+
+
+def _assert_store_false_input_preserves_stateless_reasoning(model_input: str | list[TResponseInputItem]) -> None:
+    assert isinstance(model_input, list)
+    reasoning = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "reasoning")
+    assert reasoning["id"] == "rs_reasoning_123"
+    assert reasoning["encrypted_content"] == "encrypted_reasoning"
+
+    function_call = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call")
+    tool_output = next(
+        item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call_output"
+    )
+    assert function_call["call_id"] == "call_lookup_123"
+    assert tool_output["call_id"] == "call_lookup_123"
+
+
+def _assert_unencrypted_reasoning_is_dropped(model_input: str | list[TResponseInputItem]) -> None:
+    assert isinstance(model_input, list)
+    assert all(not (isinstance(item, dict) and item.get("type") == "reasoning") for item in model_input)
+    function_call = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call")
+    tool_output = next(
+        item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call_output"
+    )
+    assert function_call["call_id"] == "call_lookup_123"
+    assert tool_output["call_id"] == "call_lookup_123"
+
+
+def _assert_store_false_requests_encrypted_reasoning(model_settings: ModelSettings) -> None:
+    assert model_settings.store is False
+    assert model_settings.response_include is not None
+    assert REASONING_ENCRYPTED_CONTENT_INCLUDE in model_settings.response_include
+
+
 def _assert_history_input_has_no_response_ids(model_input: str | list[TResponseInputItem]) -> None:
     assert isinstance(model_input, list)
     leaked_response_ids = [item for item in model_input if isinstance(item, dict) and "response_id" in item]
@@ -293,6 +403,69 @@ async def test_stream_endpoint_replays_returned_history_without_hidden_response_
 
     assert model.seen_previous_response_ids == [None, None]
     _assert_history_input_has_no_response_ids(model.seen_inputs[1])
+
+
+@pytest.mark.asyncio
+async def test_response_endpoint_store_false_requests_and_preserves_encrypted_reasoning() -> None:
+    model = _TrackingResponsesModel()
+    handler = make_response_endpoint(BaseRequest, _build_store_false_agency_factory(model), lambda: None)
+
+    await handler(BaseRequest(message="again", chat_history=_history_with_encrypted_reasoning()), token=None)
+
+    _assert_store_false_requests_encrypted_reasoning(model.seen_model_settings[0])
+    _assert_store_false_input_preserves_stateless_reasoning(model.seen_inputs[0])
+
+
+@pytest.mark.asyncio
+async def test_stream_endpoint_store_false_drops_only_unencrypted_reasoning() -> None:
+    model = _TrackingResponsesModel()
+    handler = make_stream_endpoint(
+        BaseRequest,
+        _build_store_false_agency_factory(model),
+        lambda: None,
+        ActiveRunRegistry(),
+    )
+
+    response = await handler(
+        http_request=_StubRequest(),
+        request=BaseRequest(message="again", chat_history=_history_with_unencrypted_reasoning()),
+        token=None,
+    )
+    _chunks = [chunk async for chunk in response.body_iterator]
+
+    _assert_store_false_requests_encrypted_reasoning(model.seen_model_settings[0])
+    _assert_unencrypted_reasoning_is_dropped(model.seen_inputs[0])
+
+
+@pytest.mark.asyncio
+async def test_codex_chat_name_store_false_uses_encrypted_reasoning_include() -> None:
+    captured_inputs: list[list[TResponseInputItem]] = []
+    captured_includes: list[list[str]] = []
+
+    class _TitleStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class _Responses:
+        async def create(self, **kwargs: Any) -> _TitleStream:
+            captured_inputs.append(copy.deepcopy(kwargs["input"]))
+            captured_includes.append(copy.deepcopy(kwargs["include"]))
+            return _TitleStream()
+
+    class _Client:
+        base_url = "https://chatgpt.com/backend-api/codex"
+        responses = _Responses()
+
+    with pytest.raises(ValueError, match="Generated chat name"):
+        await generate_chat_name(_history_with_encrypted_reasoning(), openai_client=_Client())  # type: ignore[arg-type]
+
+    assert captured_inputs
+    assert captured_includes
+    assert all(include == [REASONING_ENCRYPTED_CONTENT_INCLUDE] for include in captured_includes)
+    _assert_store_false_input_preserves_stateless_reasoning(captured_inputs[0])
 
 
 @pytest.mark.asyncio

--- a/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
+++ b/tests/integration/fastapi/test_openclaw_response_history_sanitization.py
@@ -37,7 +37,10 @@ from agency_swarm.integrations.fastapi_utils.endpoint_handlers import (
     make_stream_endpoint,
 )
 from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
-from agency_swarm.messages.response_input_sanitizer import REASONING_ENCRYPTED_CONTENT_INCLUDE
+from agency_swarm.messages.response_input_sanitizer import (
+    REASONING_ENCRYPTED_CONTENT_INCLUDE,
+    sanitize_store_false_responses_input,
+)
 
 
 class _TrackingResponsesModel(Model):
@@ -325,6 +328,33 @@ def _history_with_unencrypted_reasoning() -> list[dict[str, Any]]:
     return history
 
 
+def _history_with_unencrypted_reasoning_before_tool_pair() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "reasoning",
+            "id": "rs_reasoning_123",
+            "summary": [{"type": "summary_text", "text": "looked up the answer"}],
+            "status": "completed",
+        },
+        {
+            "type": "function_call",
+            "id": "fc_lookup_123",
+            "call_id": "call_lookup_123",
+            "name": "lookup",
+            "arguments": "{}",
+            "status": "completed",
+        },
+        {
+            "type": "function_call_output",
+            "id": "fc_output_123",
+            "call_id": "call_lookup_123",
+            "output": "42",
+            "status": "completed",
+        },
+        {"role": "user", "content": "again"},
+    ]
+
+
 def _assert_store_false_input_preserves_stateless_reasoning(model_input: str | list[TResponseInputItem]) -> None:
     assert isinstance(model_input, list)
     reasoning = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "reasoning")
@@ -342,6 +372,7 @@ def _assert_store_false_input_preserves_stateless_reasoning(model_input: str | l
 def _assert_unencrypted_reasoning_is_dropped(model_input: str | list[TResponseInputItem]) -> None:
     assert isinstance(model_input, list)
     assert all(not (isinstance(item, dict) and item.get("type") == "reasoning") for item in model_input)
+    assert all(not (isinstance(item, dict) and item.get("id") == "msg_answer_123") for item in model_input)
     function_call = next(item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call")
     tool_output = next(
         item for item in model_input if isinstance(item, dict) and item.get("type") == "function_call_output"
@@ -435,6 +466,12 @@ async def test_stream_endpoint_store_false_drops_only_unencrypted_reasoning() ->
 
     _assert_store_false_requests_encrypted_reasoning(model.seen_model_settings[0])
     _assert_unencrypted_reasoning_is_dropped(model.seen_inputs[0])
+
+
+def test_store_false_sanitizer_drops_dependent_followers_after_unencrypted_reasoning() -> None:
+    sanitized = sanitize_store_false_responses_input(_history_with_unencrypted_reasoning_before_tool_pair())
+
+    assert sanitized == [{"role": "user", "content": "again"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -280,6 +280,7 @@ def test_openai_client_override_applies_codex_compatibility_model_settings() -> 
     assert agent.model_settings is not None
     assert agent.model_settings.store is False
     assert agent.model_settings.truncation is None
+    assert "reasoning.encrypted_content" in (agent.model_settings.response_include or [])
 
 
 def test_snapshot_restore_preserves_model_settings_headers() -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py
@@ -44,6 +44,7 @@ async def test_generate_chat_name_uses_codex_direct_client_stream() -> None:
     assert captured["model"] == "gpt-5.4-mini"
     assert captured["store"] is False
     assert captured["stream"] is True
+    assert captured["include"] == ["reasoning.encrypted_content"]
     assert captured["input"] == [{"role": "user", "content": "hello"}]
     assert "generates a human-friendly title" in str(captured["instructions"])
 


### PR DESCRIPTION
## Summary
- request `reasoning.encrypted_content` whenever Agency Swarm sends OpenAI Responses calls with `store=False`
- preserve encrypted reasoning items for stateless replay and drop only legacy unencrypted reasoning items that cannot be replayed without persisted server state
- keep PR #612 Codex browser-auth compatibility by retaining the direct Codex title path, Codex-safe `store=False` settings, and function/tool `call_id` linkage

## Provider scope
- OpenAI Responses path can persist/replay `rs_...` reasoning items; this is the failing path when `store=False` omits encrypted reasoning.
- Codex browser-auth uses the same Responses-shaped replay hazard through PR #612's direct Responses request shape.
- LiteLLM and OpenAI Chat Completions convert replay history to chat messages; they do not replay OpenAI `rs_...` item ids unless a provider is routed through an OpenAI Responses-compatible path.
 