### PR TITLE
fix(fastapi): replay Codex preservation messages as developer

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/codex_replay.py
+++ b/src/agency_swarm/integrations/fastapi_utils/codex_replay.py
@@ -63,15 +63,16 @@ def _uses_codex_backend(
     recipient_agent: str | None = None,
 ) -> bool:
     """Return True when the resolved request backend is Codex browser auth."""
-    if config is not None and config.base_url is not None:
-        return _is_codex_base_url(config.base_url)
-
     if agency is not None:
         selected_agent = _get_upload_client_agent(agency, recipient_agent=recipient_agent)
         if selected_agent is not None:
             agent_uses_codex = _agent_codex_backend_state(selected_agent)
             if agent_uses_codex is not None:
                 return agent_uses_codex
+            return False
+
+    if config is not None and config.base_url is not None:
+        return _is_codex_base_url(config.base_url)
 
     return _client_uses_codex_backend(get_default_openai_client())
 
@@ -80,9 +81,6 @@ def _agent_codex_backend_state(agent: Agent) -> bool | None:
     client = _get_openai_client_from_agent(agent)
     if client is not None:
         return _client_uses_codex_backend(client)
-    cached_client = getattr(agent, "_openai_client", None)
-    if isinstance(cached_client, AsyncOpenAI):
-        return _client_uses_codex_backend(cached_client)
     return None
 
 

--- a/src/agency_swarm/integrations/fastapi_utils/codex_replay.py
+++ b/src/agency_swarm/integrations/fastapi_utils/codex_replay.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+from agents.models._openai_shared import get_default_openai_client
+from openai import AsyncOpenAI
+
+from agency_swarm import Agency, Agent
+from agency_swarm.integrations.fastapi_utils.override_policy import (
+    _get_openai_client_from_agent,
+    _get_upload_client_agent,
+)
+from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+_CODEX_DEVELOPER_ROLE_PRESERVATION_ORIGINS = {
+    "file_search_preservation",
+    "web_search_preservation",
+}
+
+
+def prepare_chat_history_for_client_config(
+    chat_history: list[dict[str, Any]],
+    config: ClientConfig | None,
+    agency: Agency | None = None,
+    recipient_agent: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return request chat history adjusted for the active backend compatibility boundary."""
+    if not _uses_codex_backend(config, agency, recipient_agent=recipient_agent):
+        return chat_history
+
+    prepared_history: list[dict[str, Any]] = []
+    for item in chat_history:
+        if item.get("role") == "system" and item.get("message_origin") in _CODEX_DEVELOPER_ROLE_PRESERVATION_ORIGINS:
+            item = {**item, "role": "developer"}
+        prepared_history.append(item)
+    return prepared_history
+
+
+def prepare_loaded_chat_history_for_active_client(
+    agency: Agency,
+    chat_history: list[dict[str, Any]] | None,
+    config: ClientConfig | None,
+    recipient_agent: str | None = None,
+) -> None:
+    """Update loaded request chat history after agency/request clients have been resolved."""
+    if chat_history is None:
+        return
+    thread_manager = getattr(agency, "thread_manager", None)
+    replace_messages = getattr(thread_manager, "replace_messages", None)
+    if not callable(replace_messages):
+        return
+    replace_messages(
+        prepare_chat_history_for_client_config(
+            chat_history,
+            config,
+            agency=agency,
+            recipient_agent=recipient_agent,
+        )
+    )
+
+
+def _uses_codex_backend(
+    config: ClientConfig | None,
+    agency: Agency | None = None,
+    recipient_agent: str | None = None,
+) -> bool:
+    """Return True when the resolved request backend is Codex browser auth."""
+    if config is not None and config.base_url is not None:
+        return _is_codex_base_url(config.base_url)
+
+    if agency is not None:
+        selected_agent = _get_upload_client_agent(agency, recipient_agent=recipient_agent)
+        if selected_agent is not None:
+            agent_uses_codex = _agent_codex_backend_state(selected_agent)
+            if agent_uses_codex is not None:
+                return agent_uses_codex
+
+    return _client_uses_codex_backend(get_default_openai_client())
+
+
+def _agent_codex_backend_state(agent: Agent) -> bool | None:
+    client = _get_openai_client_from_agent(agent)
+    if client is not None:
+        return _client_uses_codex_backend(client)
+    cached_client = getattr(agent, "_openai_client", None)
+    if isinstance(cached_client, AsyncOpenAI):
+        return _client_uses_codex_backend(cached_client)
+    return None
+
+
+def _client_uses_codex_backend(client: AsyncOpenAI | None) -> bool:
+    if client is None:
+        return False
+    return _is_codex_base_url(str(client.base_url))
+
+
+def _is_codex_base_url(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.rstrip("/") == "https://chatgpt.com/backend-api/codex"

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -49,6 +49,10 @@ from agency_swarm import (
 )
 from agency_swarm.agent.execution_stream_response import StreamingRunResponse
 from agency_swarm.agent.initialization import apply_framework_defaults
+from agency_swarm.integrations.fastapi_utils.codex_replay import (
+    prepare_chat_history_for_client_config,
+    prepare_loaded_chat_history_for_active_client,
+)
 from agency_swarm.integrations.fastapi_utils.file_handler import upload_from_urls
 from agency_swarm.integrations.fastapi_utils.logging_middleware import get_logs_endpoint_impl
 from agency_swarm.integrations.fastapi_utils.override_policy import (
@@ -448,7 +452,11 @@ def make_response_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return request.chat_history
+                return prepare_chat_history_for_client_config(
+                    request.chat_history,
+                    request.client_config,
+                    recipient_agent=request.recipient_agent,
+                )
         else:
 
             def load_callback() -> list:
@@ -464,6 +472,12 @@ def make_response_endpoint(
 
         try:
             await override_session.acquire()
+            prepare_loaded_chat_history_for_active_client(
+                agency_instance,
+                request.chat_history,
+                request.client_config,
+                recipient_agent=request.recipient_agent,
+            )
 
             request_upload_client = _build_file_upload_client(
                 agency_instance,
@@ -543,7 +557,11 @@ def make_stream_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return request.chat_history
+                return prepare_chat_history_for_client_config(
+                    request.chat_history,
+                    request.client_config,
+                    recipient_agent=request.recipient_agent,
+                )
         else:
 
             def load_callback() -> list:
@@ -562,6 +580,12 @@ def make_stream_endpoint(
 
         try:
             await override_session.acquire()
+            prepare_loaded_chat_history_for_active_client(
+                agency_instance,
+                request.chat_history,
+                request.client_config,
+                recipient_agent=request.recipient_agent,
+            )
 
             request_upload_client = _build_file_upload_client(
                 agency_instance,
@@ -796,7 +820,7 @@ def make_agui_chat_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return request.chat_history
+                return prepare_chat_history_for_client_config(request.chat_history, request.client_config)
 
         elif request.messages is not None:
             # Pull the default agent from the agency
@@ -832,6 +856,7 @@ def make_agui_chat_endpoint(
 
         try:
             await override_session.acquire()
+            prepare_loaded_chat_history_for_active_client(agency, request.chat_history, request.client_config)
 
             request_upload_client = _build_file_upload_client(agency, request.client_config, recipient_agent=None)
             if getattr(request, "file_urls", None):

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -50,7 +50,6 @@ from agency_swarm import (
 from agency_swarm.agent.execution_stream_response import StreamingRunResponse
 from agency_swarm.agent.initialization import apply_framework_defaults
 from agency_swarm.integrations.fastapi_utils.codex_replay import (
-    prepare_chat_history_for_client_config,
     prepare_loaded_chat_history_for_active_client,
 )
 from agency_swarm.integrations.fastapi_utils.file_handler import upload_from_urls
@@ -452,11 +451,7 @@ def make_response_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return prepare_chat_history_for_client_config(
-                    request.chat_history,
-                    request.client_config,
-                    recipient_agent=request.recipient_agent,
-                )
+                return list(request.chat_history)
         else:
 
             def load_callback() -> list:
@@ -557,11 +552,7 @@ def make_stream_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return prepare_chat_history_for_client_config(
-                    request.chat_history,
-                    request.client_config,
-                    recipient_agent=request.recipient_agent,
-                )
+                return list(request.chat_history)
         else:
 
             def load_callback() -> list:
@@ -820,7 +811,7 @@ def make_agui_chat_endpoint(
         if request.chat_history is not None:
             # Chat history is now a flat list
             def load_callback() -> list:
-                return prepare_chat_history_for_client_config(request.chat_history, request.client_config)
+                return list(request.chat_history)
 
         elif request.messages is not None:
             # Pull the default agent from the agency

--- a/tests/test_fastapi_utils_modules/test_codex_replay_preservation.py
+++ b/tests/test_fastapi_utils_modules/test_codex_replay_preservation.py
@@ -1,0 +1,378 @@
+from typing import Any
+
+import pytest
+
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+
+
+def _preserved_message(origin: str, agent: str = "A") -> dict[str, Any]:
+    return {
+        "role": "system",
+        "content": f"[{origin}] result",
+        "message_origin": origin,
+        "agent": agent,
+        "callerAgent": None,
+    }
+
+
+def _regular_system_message(agent: str = "A") -> dict[str, Any]:
+    return {
+        "role": "system",
+        "content": "regular system message",
+        "message_origin": "other",
+        "agent": agent,
+        "callerAgent": None,
+    }
+
+
+def _roles(history: list[dict[str, Any]]) -> list[str]:
+    return [item["role"] for item in history]
+
+
+class _ThreadManager:
+    def __init__(self, messages: list[dict[str, Any]] | None = None):
+        self._messages = list(messages or [])
+
+    def get_all_messages(self) -> list[dict[str, Any]]:
+        return list(self._messages)
+
+    def replace_messages(self, messages: list[dict[str, Any]]) -> None:
+        self._messages = list(messages)
+
+
+class _Response:
+    final_output = "ok"
+
+
+class _ResponseAgency:
+    def __init__(
+        self,
+        messages: list[dict[str, Any]],
+        loaded_history: list[dict[str, Any]],
+        agents: dict[str, Any] | None = None,
+        entry_points: list[Any] | None = None,
+    ):
+        self.agents = agents or {}
+        if entry_points is not None:
+            self.entry_points = entry_points
+        self.thread_manager = _ThreadManager(messages)
+        self._loaded_history = loaded_history
+
+    async def get_response(self, **_kwargs) -> _Response:
+        self._loaded_history[:] = self.thread_manager.get_all_messages()
+        return _Response()
+
+
+class _Model:
+    model = "gpt-5.4-mini"
+
+    def __init__(self, base_url: str):
+        from openai import AsyncOpenAI
+
+        self.openai_client = AsyncOpenAI(api_key="sk-agent", base_url=base_url)
+
+
+class _AgentState:
+    def __init__(self, name: str, base_url: str):
+        self.name = name
+        self.model = _Model(base_url)
+        self.model_settings = None
+        self._openai_client = None
+
+
+async def _attach_noop(_agency) -> None:
+    return None
+
+
+def _patch_endpoint_setup(monkeypatch):
+    from agency_swarm.integrations.fastapi_utils import endpoint_handlers
+
+    monkeypatch.setattr(endpoint_handlers, "attach_persistent_mcp_servers", _attach_noop)
+    return endpoint_handlers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("base_url", "expected_roles"),
+    [
+        (CODEX_BASE_URL, ["developer", "developer", "system"]),
+        (OPENAI_BASE_URL, ["system", "system", "system"]),
+    ],
+)
+async def test_response_endpoint_replays_preservation_roles_for_explicit_base_url(
+    monkeypatch,
+    base_url: str,
+    expected_roles: list[str],
+) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
+
+    _patch_endpoint_setup(monkeypatch)
+    replayed_history = [
+        _preserved_message("web_search_preservation"),
+        _preserved_message("file_search_preservation"),
+        _regular_system_message(),
+    ]
+    loaded_history: list[dict[str, Any]] = []
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(kwargs["load_threads_callback"](), loaded_history)
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(
+        BaseRequest(
+            message="next",
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key", base_url=base_url),
+        ),
+        token=None,
+    )
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == expected_roles
+    assert _roles(replayed_history) == ["system", "system", "system"]
+
+
+@pytest.mark.asyncio
+async def test_response_endpoint_rewrites_replay_for_inherited_default_codex_client(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from openai import AsyncOpenAI
+
+    from agency_swarm.integrations.fastapi_utils import codex_replay
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    _patch_endpoint_setup(monkeypatch)
+    monkeypatch.setattr(
+        codex_replay,
+        "get_default_openai_client",
+        lambda: AsyncOpenAI(api_key="sk-default", base_url=CODEX_BASE_URL),
+    )
+    replayed_history = [_preserved_message("web_search_preservation"), _regular_system_message()]
+    loaded_history: list[dict[str, Any]] = []
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(kwargs["load_threads_callback"](), loaded_history)
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(BaseRequest(message="next", chat_history=replayed_history), token=None)
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == ["developer", "system"]
+    assert _roles(replayed_history) == ["system", "system"]
+
+
+@pytest.mark.asyncio
+async def test_response_endpoint_keeps_agent_non_codex_replay_when_default_is_codex(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from openai import AsyncOpenAI
+
+    from agency_swarm.integrations.fastapi_utils import codex_replay
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest
+
+    _patch_endpoint_setup(monkeypatch)
+    monkeypatch.setattr(
+        codex_replay,
+        "get_default_openai_client",
+        lambda: AsyncOpenAI(api_key="sk-default", base_url=CODEX_BASE_URL),
+    )
+    replayed_history = [_preserved_message("web_search_preservation")]
+    loaded_history: list[dict[str, Any]] = []
+    agents = {"A": _AgentState("A", OPENAI_BASE_URL)}
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(kwargs["load_threads_callback"](), loaded_history, agents=agents)
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(BaseRequest(message="next", chat_history=replayed_history), token=None)
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == ["system"]
+
+
+@pytest.mark.asyncio
+async def test_response_endpoint_rewrites_replay_for_agent_codex_client(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils import codex_replay
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
+
+    _patch_endpoint_setup(monkeypatch)
+    monkeypatch.setattr(codex_replay, "get_default_openai_client", lambda: None)
+    replayed_history = [_preserved_message("file_search_preservation"), _regular_system_message()]
+    loaded_history: list[dict[str, Any]] = []
+    agents = {"A": _AgentState("A", CODEX_BASE_URL)}
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(kwargs["load_threads_callback"](), loaded_history, agents=agents)
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(
+        BaseRequest(
+            message="next",
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key"),
+        ),
+        token=None,
+    )
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == ["developer", "system"]
+    assert _roles(replayed_history) == ["system", "system"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("recipient_agent", "expected_roles"),
+    [
+        ("OpenAI", ["system"]),
+        (None, ["developer"]),
+    ],
+)
+async def test_response_endpoint_uses_selected_or_default_agent_backend_in_mixed_agency(
+    monkeypatch,
+    recipient_agent: str | None,
+    expected_roles: list[str],
+) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils import codex_replay
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
+
+    _patch_endpoint_setup(monkeypatch)
+    monkeypatch.setattr(codex_replay, "get_default_openai_client", lambda: None)
+    openai_agent = _AgentState("OpenAI", OPENAI_BASE_URL)
+    codex_agent = _AgentState("Codex", CODEX_BASE_URL)
+    agents = {"OpenAI": openai_agent, "Codex": codex_agent}
+    replayed_history = [
+        _preserved_message("web_search_preservation", agent=recipient_agent or "Codex"),
+    ]
+    loaded_history: list[dict[str, Any]] = []
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(
+            kwargs["load_threads_callback"](),
+            loaded_history,
+            agents=agents,
+            entry_points=[codex_agent],
+        )
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(
+        BaseRequest(
+            message="next",
+            recipient_agent=recipient_agent,
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key"),
+        ),
+        token=None,
+    )
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == expected_roles
+    assert _roles(replayed_history) == ["system"]
+
+
+@pytest.mark.asyncio
+async def test_stream_endpoint_rewrites_codex_preservation_replay_without_mutating_input(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import ActiveRunRegistry, make_stream_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
+
+    _patch_endpoint_setup(monkeypatch)
+    replayed_history = [
+        _preserved_message("web_search_preservation"),
+        _preserved_message("file_search_preservation"),
+        _regular_system_message(),
+    ]
+    loaded_history: list[dict[str, Any]] = []
+
+    class _HttpRequest:
+        async def is_disconnected(self) -> bool:
+            return False
+
+    class _StreamAgency:
+        def __init__(self, messages: list[dict[str, Any]]):
+            self.agents = {}
+            self.thread_manager = _ThreadManager(messages)
+
+    def _agency_factory(**kwargs):
+        loaded_history[:] = kwargs["load_threads_callback"]()
+        return _StreamAgency(loaded_history)
+
+    handler = make_stream_endpoint(
+        BaseRequest,
+        _agency_factory,
+        verify_token=lambda: None,
+        run_registry=ActiveRunRegistry(),
+    )
+    response = await handler(
+        http_request=_HttpRequest(),
+        request=BaseRequest(
+            message="next",
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key", base_url=CODEX_BASE_URL),
+        ),
+        token=None,
+    )
+
+    assert response.media_type == "text/event-stream"
+    assert _roles(loaded_history) == ["developer", "developer", "system"]
+    assert _roles(replayed_history) == ["system", "system", "system"]
+    if response.background is not None:
+        await response.background()
+
+
+@pytest.mark.asyncio
+async def test_agui_chat_endpoint_rewrites_codex_preservation_replay_without_mutating_input(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_agui_chat_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig, RunAgentInputCustom
+
+    _patch_endpoint_setup(monkeypatch)
+    replayed_history = [
+        _preserved_message("web_search_preservation"),
+        _preserved_message("file_search_preservation"),
+        _regular_system_message(),
+    ]
+    loaded_history: list[dict[str, Any]] = []
+
+    class _AguiAgency:
+        def __init__(self):
+            self.agents = {}
+
+    def _agency_factory(**kwargs):
+        loaded_history[:] = kwargs["load_threads_callback"]()
+        return _AguiAgency()
+
+    handler = make_agui_chat_endpoint(RunAgentInputCustom, _agency_factory, verify_token=lambda: None)
+    response = await handler(
+        RunAgentInputCustom(
+            thread_id="thread-1",
+            run_id="run-1",
+            state=None,
+            messages=[],
+            tools=[],
+            context=[],
+            forwarded_props=None,
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key", base_url=CODEX_BASE_URL),
+        ),
+        token=None,
+    )
+
+    assert response.media_type == "text/event-stream"
+    assert _roles(loaded_history) == ["developer", "developer", "system"]
+    assert _roles(replayed_history) == ["system", "system", "system"]
+    if response.background is not None:
+        await response.background()

--- a/tests/test_fastapi_utils_modules/test_codex_replay_preservation.py
+++ b/tests/test_fastapi_utils_modules/test_codex_replay_preservation.py
@@ -81,6 +81,14 @@ class _AgentState:
         self._openai_client = None
 
 
+class _CustomModelAgentState:
+    def __init__(self, name: str):
+        self.name = name
+        self.model = "custom-provider/custom-model"
+        self.model_settings = None
+        self._openai_client = None
+
+
 async def _attach_noop(_agency) -> None:
     return None
 
@@ -282,6 +290,44 @@ async def test_response_endpoint_uses_selected_or_default_agent_backend_in_mixed
 
 
 @pytest.mark.asyncio
+async def test_response_endpoint_keeps_non_openai_agent_replay_despite_codex_config(monkeypatch) -> None:
+    pytest.importorskip("agents")
+
+    from agency_swarm.integrations.fastapi_utils import codex_replay
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import make_response_endpoint
+    from agency_swarm.integrations.fastapi_utils.request_models import BaseRequest, ClientConfig
+
+    _patch_endpoint_setup(monkeypatch)
+    monkeypatch.setattr(codex_replay, "get_default_openai_client", lambda: None)
+    replayed_history = [_preserved_message("web_search_preservation", agent="Custom")]
+    loaded_history: list[dict[str, Any]] = []
+    custom_agent = _CustomModelAgentState("Custom")
+    agents = {"Custom": custom_agent}
+
+    def _agency_factory(**kwargs):
+        return _ResponseAgency(
+            kwargs["load_threads_callback"](),
+            loaded_history,
+            agents=agents,
+            entry_points=[custom_agent],
+        )
+
+    handler = make_response_endpoint(BaseRequest, _agency_factory, verify_token=lambda: None)
+    response = await handler(
+        BaseRequest(
+            message="next",
+            chat_history=replayed_history,
+            client_config=ClientConfig(api_key="sk-request-key", base_url=CODEX_BASE_URL),
+        ),
+        token=None,
+    )
+
+    assert response["response"] == "ok"
+    assert _roles(loaded_history) == ["system"]
+    assert _roles(replayed_history) == ["system"]
+
+
+@pytest.mark.asyncio
 async def test_stream_endpoint_rewrites_codex_preservation_replay_without_mutating_input(monkeypatch) -> None:
     pytest.importorskip("agents")
 
@@ -305,9 +351,13 @@ async def test_stream_endpoint_rewrites_codex_preservation_replay_without_mutati
             self.agents = {}
             self.thread_manager = _ThreadManager(messages)
 
+    stream_agency: _StreamAgency | None = None
+
     def _agency_factory(**kwargs):
+        nonlocal stream_agency
         loaded_history[:] = kwargs["load_threads_callback"]()
-        return _StreamAgency(loaded_history)
+        stream_agency = _StreamAgency(loaded_history)
+        return stream_agency
 
     handler = make_stream_endpoint(
         BaseRequest,
@@ -326,7 +376,8 @@ async def test_stream_endpoint_rewrites_codex_preservation_replay_without_mutati
     )
 
     assert response.media_type == "text/event-stream"
-    assert _roles(loaded_history) == ["developer", "developer", "system"]
+    assert stream_agency is not None
+    assert _roles(stream_agency.thread_manager.get_all_messages()) == ["developer", "developer", "system"]
     assert _roles(replayed_history) == ["system", "system", "system"]
     if response.background is not None:
         await response.background()
@@ -350,10 +401,15 @@ async def test_agui_chat_endpoint_rewrites_codex_preservation_replay_without_mut
     class _AguiAgency:
         def __init__(self):
             self.agents = {}
+            self.thread_manager = _ThreadManager(loaded_history)
+
+    agui_agency: _AguiAgency | None = None
 
     def _agency_factory(**kwargs):
+        nonlocal agui_agency
         loaded_history[:] = kwargs["load_threads_callback"]()
-        return _AguiAgency()
+        agui_agency = _AguiAgency()
+        return agui_agency
 
     handler = make_agui_chat_endpoint(RunAgentInputCustom, _agency_factory, verify_token=lambda: None)
     response = await handler(
@@ -372,7 +428,8 @@ async def test_agui_chat_endpoint_rewrites_codex_preservation_replay_without_mut
     )
 
     assert response.media_type == "text/event-stream"
-    assert _roles(loaded_history) == ["developer", "developer", "system"]
+    assert agui_agency is not None
+    assert _roles(agui_agency.thread_manager.get_all_messages()) == ["developer", "developer", "system"]
     assert _roles(replayed_history) == ["system", "system", "system"]
     if response.background is not None:
         await response.background()


### PR DESCRIPTION
### Summary

Fixes Codex/browser-auth replay of hosted-tool preservation history. Agency Swarm can persist `web_search_preservation` and `file_search_preservation` messages as `role: "system"`; Codex rejects replayed `system` messages with `System messages are not allowed`. This keeps the preservation context but rewrites only those preservation messages to `developer` when the resolved backend is the Codex browser-auth endpoint.

### Test plan

- `PYTHONPATH=src uv run --python /opt/homebrew/bin/python3.13 pytest -q tests/test_fastapi_utils_modules/test_codex_replay_preservation.py tests/test_fastapi_utils_modules/test_openai_client_config_response_overrides.py`
- `UV_PYTHON=/opt/homebrew/bin/python3.13 uv run --python /opt/homebrew/bin/python3.13 make check`
- `UV_PYTHON=/opt/homebrew/bin/python3.13 uv run --python /opt/homebrew/bin/python3.13 make format`
- Fresh Codex review before latest scope narrowing: no actionable regressions.

### Issue number

N/A - reported from live Agent Swarm TUI QA as `Error code: 400 - {'detail': 'System messages are not allowed'}` after web-search preservation replay.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass