### PR TITLE
Fix xAI variant forwarding and stabilize tools-folder test

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1240,6 +1240,8 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
         if not _agent_uses_litellm(agent) or is_litellm_gemini:
             extra_args.pop("reasoning_effort", None)
             extra_args.pop("reasoning_summary", None)
+        elif litellm_model_name.startswith("openai/"):
+            extra_args.pop("reasoning_summary", None)
     elif isinstance(extra_args.get("reasoning"), dict) and not _agent_uses_litellm(agent):
         raw_reasoning = cast(dict[str, Any], extra_args.pop("reasoning"))
         effort = raw_reasoning.get("effort")
@@ -1343,7 +1345,21 @@ def _normalize_thinking_budget_tokens(extra_args: dict[str, Any]) -> None:
 def _litellm_model_name(agent: Agent) -> str:
     if not _agent_uses_litellm(agent):
         return ""
-    return str(getattr(agent.model, "model", "")).lower()
+    model = agent.model
+    if isinstance(model, str):
+        name = model
+    elif isinstance(model, OpenAIResponsesModel | OpenAIChatCompletionsModel):
+        name = model.model
+    elif _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
+        name = model.model
+    elif isinstance(model, Model):
+        name = getattr(model, "model", "")
+    else:
+        name = ""
+    if not isinstance(name, str):
+        return ""
+    normalized = name.lower()
+    return normalized[8:] if normalized.startswith("litellm/") else normalized
 
 
 def _is_codex_base_url(value: str | None) -> bool:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1302,12 +1302,7 @@ def _xai_litellm_model_supports_reasoning_effort(model_name: str) -> bool:
         model = model_name.removeprefix("xai/").lower()
         if "non-reasoning" in model:
             return False
-        return (
-            "grok-3-mini" in model
-            or "grok-4.3" in model
-            or "grok-4-3" in model
-            or ("grok" in model and "reasoning" in model)
-        )
+        return "grok-3-mini" in model or "grok-4.3" in model or "grok-4-3" in model
 
 
 def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1219,7 +1219,7 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = extra_args.get("reasoning_summary")
     elif litellm_model_name.startswith("xai/"):
-        _normalize_xai_litellm_variant_args(extra_args)
+        _normalize_xai_litellm_variant_args(extra_args, litellm_model_name)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = extra_args.get("reasoning_summary")
     elif is_litellm_gemini:
@@ -1281,13 +1281,28 @@ def _normalize_anthropic_litellm_variant_args(extra_args: dict[str, Any]) -> Non
     _normalize_thinking_budget_tokens(extra_args)
 
 
-def _normalize_xai_litellm_variant_args(extra_args: dict[str, Any]) -> None:
+def _normalize_xai_litellm_variant_args(extra_args: dict[str, Any], model_name: str) -> None:
     """Keep only xAI reasoning fields that LiteLLM forwards to Grok chat."""
     effort = extra_args.pop("effort", None)
-    if isinstance(effort, str) and "reasoning_effort" not in extra_args:
-        extra_args["reasoning_effort"] = effort
+    if _xai_litellm_model_supports_reasoning_effort(model_name):
+        if isinstance(effort, str) and "reasoning_effort" not in extra_args:
+            extra_args["reasoning_effort"] = effort
+    else:
+        extra_args.pop("reasoning_effort", None)
     extra_args.pop("reasoning_summary", None)
     extra_args.pop("include", None)
+
+
+def _xai_litellm_model_supports_reasoning_effort(model_name: str) -> bool:
+    model = model_name.removeprefix("xai/").lower()
+    if "non-reasoning" in model:
+        return False
+    return (
+        "grok-3-mini" in model
+        or "grok-4.3" in model
+        or "grok-4-3" in model
+        or ("grok" in model and "reasoning" in model)
+    )
 
 
 def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1294,15 +1294,20 @@ def _normalize_xai_litellm_variant_args(extra_args: dict[str, Any], model_name: 
 
 
 def _xai_litellm_model_supports_reasoning_effort(model_name: str) -> bool:
-    model = model_name.removeprefix("xai/").lower()
-    if "non-reasoning" in model:
-        return False
-    return (
-        "grok-3-mini" in model
-        or "grok-4.3" in model
-        or "grok-4-3" in model
-        or ("grok" in model and "reasoning" in model)
-    )
+    try:
+        import litellm
+
+        return bool(litellm.supports_reasoning(model=model_name))
+    except Exception:
+        model = model_name.removeprefix("xai/").lower()
+        if "non-reasoning" in model:
+            return False
+        return (
+            "grok-3-mini" in model
+            or "grok-4.3" in model
+            or "grok-4-3" in model
+            or ("grok" in model and "reasoning" in model)
+        )
 
 
 def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1240,7 +1240,7 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
             extra_args["reasoning_effort"] = normalized_effort
         extra_args.pop("reasoning_summary", None)
     elif normalized_effort is not None and (
-        not uses_litellm or litellm_model_name.startswith(("gemini/", "vertex_ai/"))
+        not uses_litellm or litellm_model_name.startswith(("anthropic/", "gemini/", "vertex_ai/"))
     ):
         current.reasoning = Reasoning(
             effort=normalized_effort,
@@ -1322,7 +1322,7 @@ def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:
         thinking_level = thinking_config.get("thinkingLevel")
         if isinstance(thinking_budget, int):
             extra_args["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
-            extra_args.setdefault("reasoning_effort", "high" if thinking_budget >= 16000 else "medium")
+            extra_args.pop("reasoning_effort", None)
         elif isinstance(thinking_level, str) and "reasoning_effort" not in extra_args:
             extra_args["reasoning_effort"] = thinking_level
     thinking_level = extra_args.pop("thinkingLevel", None)
@@ -1331,7 +1331,7 @@ def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:
     thinking_budget = extra_args.pop("thinkingBudget", None)
     if isinstance(thinking_budget, int):
         extra_args["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
-        extra_args.setdefault("reasoning_effort", "high" if thinking_budget >= 16000 else "medium")
+        extra_args.pop("reasoning_effort", None)
     extra_args.pop("includeThoughts", None)
     extra_args.pop("reasoning_summary", None)
     extra_args.pop("include", None)

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -184,7 +184,7 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
         return gateway_client is not None
 
     if _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
-        actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+        actual = _normalize_litellm_model_name(model_name)
         agent.model = LitellmModel(model=actual, base_url=model.base_url, api_key=model.api_key)
         return False
 
@@ -287,7 +287,7 @@ def _apply_request_litellm_model(agent: Agent, model_name: str) -> None:
             model_name,
         )
         return
-    actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+    actual = _normalize_litellm_model_name(model_name)
     agent.model = LitellmModel(model=actual, base_url=None, api_key=None)
 
 
@@ -1230,19 +1230,26 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
 
     normalized_effort = _reasoning_effort_value(reasoning_effort)
     normalized_summary = _reasoning_summary_value(reasoning_summary)
-    if normalized_effort is not None and (
-        not _agent_uses_litellm(agent) or litellm_model_name.startswith(("openai/", "google/", "gemini/", "vertex_ai/"))
+    uses_litellm = _agent_uses_litellm(agent)
+    is_litellm_openai = uses_litellm and litellm_model_name.startswith("openai/")
+    if normalized_effort is not None and is_litellm_openai:
+        current.reasoning = None
+        if normalized_summary is not None:
+            extra_args["reasoning_effort"] = {"effort": normalized_effort, "summary": normalized_summary}
+        else:
+            extra_args["reasoning_effort"] = normalized_effort
+        extra_args.pop("reasoning_summary", None)
+    elif normalized_effort is not None and (
+        not uses_litellm or litellm_model_name.startswith(("gemini/", "vertex_ai/"))
     ):
         current.reasoning = Reasoning(
             effort=normalized_effort,
             summary=normalized_summary,
         )
-        if not _agent_uses_litellm(agent) or is_litellm_gemini:
+        if not uses_litellm or is_litellm_gemini:
             extra_args.pop("reasoning_effort", None)
             extra_args.pop("reasoning_summary", None)
-        elif litellm_model_name.startswith("openai/"):
-            extra_args.pop("reasoning_summary", None)
-    elif isinstance(extra_args.get("reasoning"), dict) and not _agent_uses_litellm(agent):
+    elif isinstance(extra_args.get("reasoning"), dict) and not uses_litellm:
         raw_reasoning = cast(dict[str, Any], extra_args.pop("reasoning"))
         effort = raw_reasoning.get("effort")
         summary = raw_reasoning.get("summary")
@@ -1358,8 +1365,7 @@ def _litellm_model_name(agent: Agent) -> str:
         name = ""
     if not isinstance(name, str):
         return ""
-    normalized = name.lower()
-    return normalized[8:] if normalized.startswith("litellm/") else normalized
+    return _normalize_litellm_model_name(name).lower()
 
 
 def _is_codex_base_url(value: str | None) -> bool:
@@ -1513,6 +1519,14 @@ def _apply_codex_compatibility_model_settings(agent: Agent) -> None:
 def _is_litellm_model(model_name: str) -> bool:
     """Check if a model name is a LiteLLM model (uses litellm/ prefix)."""
     return model_name.startswith("litellm/")
+
+
+def _normalize_litellm_model_name(model_name: str) -> str:
+    actual = model_name[8:] if model_name.startswith("litellm/") else model_name
+    provider, sep, rest = actual.partition("/")
+    if sep and provider.lower() == "google":
+        return f"gemini/{rest}"
+    return actual
 
 
 def _is_openai_model_name(model_name: str) -> bool:
@@ -1759,11 +1773,10 @@ def _apply_litellm_config(agent: Agent, model_name: str, config: ClientConfig) -
         )
         return
 
-    # Strip the 'litellm/' prefix to get the actual model identifier
-    actual_model = model_name[8:] if model_name.startswith("litellm/") else model_name
+    actual_model = _normalize_litellm_model_name(model_name)
 
-    api_key = _resolve_litellm_api_key(model_name, config, existing_api_key=None)
-    base_url = _resolve_litellm_base_url(model_name, config, existing_base_url=None)
+    api_key = _resolve_litellm_api_key(actual_model, config, existing_api_key=None)
+    base_url = _resolve_litellm_base_url(actual_model, config, existing_base_url=None)
 
     agent.model = LitellmModel(
         model=actual_model,

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1224,10 +1224,6 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = requested_reasoning_summary if isinstance(requested_reasoning_summary, str) else "auto"
 
-    if litellm_model_name.startswith("xai/") and "grok" in litellm_model_name:
-        extra_args.pop("reasoning_effort", None)
-        extra_args.pop("reasoning_summary", None)
-        extra_args.pop("effort", None)
     normalized_effort = _reasoning_effort_value(reasoning_effort)
     normalized_summary = _reasoning_summary_value(reasoning_summary)
     if normalized_effort is not None and (

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1311,7 +1311,13 @@ def _xai_litellm_model_supports_reasoning_effort(model_name: str) -> bool:
         model = model_name.removeprefix("xai/").lower()
         if "non-reasoning" in model:
             return False
-        return "grok-3-mini" in model or "grok-4.3" in model or "grok-4-3" in model
+        return (
+            "grok-3-mini" in model
+            or "grok-4.3" in model
+            or "grok-4-3" in model
+            or "grok-4-1-fast" in model
+            or "grok-code-fast" in model
+        )
 
 
 def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1218,6 +1218,10 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
         _normalize_anthropic_litellm_variant_args(extra_args)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = extra_args.get("reasoning_summary")
+    elif litellm_model_name.startswith("xai/"):
+        _normalize_xai_litellm_variant_args(extra_args)
+        reasoning_effort = extra_args.get("reasoning_effort")
+        reasoning_summary = extra_args.get("reasoning_summary")
     elif is_litellm_gemini:
         requested_reasoning_summary = reasoning_summary
         _normalize_gemini_litellm_variant_args(extra_args)
@@ -1275,6 +1279,15 @@ def _normalize_anthropic_litellm_variant_args(extra_args: dict[str, Any]) -> Non
     extra_args.pop("reasoning_summary", None)
     extra_args.pop("include", None)
     _normalize_thinking_budget_tokens(extra_args)
+
+
+def _normalize_xai_litellm_variant_args(extra_args: dict[str, Any]) -> None:
+    """Keep only xAI reasoning fields that LiteLLM forwards to Grok chat."""
+    effort = extra_args.pop("effort", None)
+    if isinstance(effort, str) and "reasoning_effort" not in extra_args:
+        extra_args["reasoning_effort"] = effort
+    extra_args.pop("reasoning_summary", None)
+    extra_args.pop("include", None)
 
 
 def _normalize_gemini_litellm_variant_args(extra_args: dict[str, Any]) -> None:

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -28,6 +28,7 @@ class RequestOverridePolicy:
             or self.config.default_headers is not None
             or self.config.litellm_keys is not None
             or getattr(self.config, "model", None) is not None
+            or getattr(self.config, "model_settings_extra_args", None) is not None
         )
 
     @property

--- a/tests/deterministic_model.py
+++ b/tests/deterministic_model.py
@@ -38,6 +38,7 @@ _MESSAGE_RE = re.compile(r"message:\s*(?P<message>.+)$", re.IGNORECASE)
 _SECRET_RE = re.compile(r"secret code:\s*(?P<secret>[\w-]+)", re.IGNORECASE)
 _HANDLE_RE = re.compile(r"handle\s+(?P<task>[\w-]+)", re.IGNORECASE)
 _TASK_RE = re.compile(r"task\s+(?P<task>[\w-]+)", re.IGNORECASE)
+_ECHO_RE = re.compile(r"echo\s+['\"](?P<message>[^'\"]+)['\"]", re.IGNORECASE)
 
 
 def _extract_text_from_content(content: Any) -> str | None:
@@ -343,6 +344,11 @@ class DeterministicModel(Model):
             get_match = _GET_RE.search(user_text)
             if get_match:
                 return _build_tool_call_response("get_data", {"key": get_match.group("key")})
+
+        if "echo_tool" in tool_map:
+            echo_match = _ECHO_RE.search(user_text)
+            if echo_match:
+                return _build_tool_call_response("echo_tool", {"message": echo_match.group("message")})
 
         if "send_message" in tool_map:
             schema = tool_map["send_message"].params_json_schema

--- a/tests/integration/tools/test_tools_folder_integration.py
+++ b/tests/integration/tools/test_tools_folder_integration.py
@@ -2,11 +2,12 @@ import pytest
 from agents import ModelSettings, RunResult
 
 from agency_swarm import Agent
+from tests.deterministic_model import DeterministicModel
 
 
 @pytest.mark.asyncio
-async def test_tools_folder_with_real_agent(tmp_path):
-    """Integration test: tools_folder loads and executes tools with real OpenAI API."""
+async def test_tools_folder_executes_loaded_tool(tmp_path):
+    """Integration test: tools_folder loads and executes tools through Agent.get_response."""
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
 
@@ -26,6 +27,7 @@ def echo_tool(message: str) -> str:
         name="TestAgent",
         instructions="You are a test agent. When asked to echo something, use the echo_tool with the provided message.",
         tools_folder=str(tools_dir),
+        model=DeterministicModel(),
         model_settings=ModelSettings(temperature=0.0),
     )
 
@@ -33,7 +35,7 @@ def echo_tool(message: str) -> str:
     tool_names = [tool.name for tool in agent.tools]
     assert "echo_tool" in tool_names
 
-    # Test real execution with OpenAI API
+    # Test execution through the real Agent runner without relying on live model routing.
     result: RunResult = await agent.get_response("Use the echo tool to echo 'hello world'")
 
     # Verify the tool was actually called and executed

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -688,6 +688,38 @@ def test_xai_grok_variant_forwards_selected_reasoning_effort() -> None:
     assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
 
 
+@pytest.mark.parametrize("model_name", ["xai/grok-4", "xai/grok-4-1-fast-non-reasoning"])
+def test_xai_grok_variant_drops_unsupported_reasoning_effort(model_name: str) -> None:
+    """xAI Grok variants without configurable reasoning should not receive LiteLLM reasoning args."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model=model_name))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model=f"litellm/{model_name}",
+            model_settings_extra_args={
+                "effort": "medium",
+                "reasoning_effort": "high",
+                "reasoning_summary": "auto",
+                "include": ["reasoning.encrypted_content"],
+            },
+        ),
+    )
+
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args is None
+
+
 def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:
     """Custom non-OpenAI model names should skip OpenAI client construction entirely."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -675,7 +675,12 @@ def test_xai_grok_variant_forwards_selected_reasoning_effort() -> None:
         agency,
         ClientConfig(
             model="litellm/xai/grok-4.3",
-            model_settings_extra_args={"reasoning_effort": "high"},
+            model_settings_extra_args={
+                "effort": "medium",
+                "reasoning_effort": "high",
+                "reasoning_summary": "auto",
+                "include": ["reasoning.encrypted_content"],
+            },
         ),
     )
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -957,6 +957,39 @@ def test_xai_grok_variant_drops_unsupported_reasoning_effort(model_name: str) ->
     assert agent.model_settings.extra_args is None
 
 
+@pytest.mark.parametrize("model_name", ["xai/grok-4-1-fast", "xai/grok-code-fast"])
+def test_xai_grok_fallback_keeps_configurable_reasoning_effort(monkeypatch, model_name: str) -> None:
+    """If LiteLLM metadata is unavailable, configurable Grok variants should keep effort."""
+    pytest.importorskip("agents")
+    litellm = pytest.importorskip("litellm")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    def fail_supports_reasoning(*args, **kwargs):
+        raise RuntimeError("metadata unavailable")
+
+    monkeypatch.setattr(litellm, "supports_reasoning", fail_supports_reasoning)
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model=model_name))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model=f"litellm/{model_name}",
+            model_settings_extra_args={"reasoning_effort": "high", "reasoning_summary": "auto"},
+        ),
+    )
+
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
+
+
 def test_xai_grok_fallback_drops_fixed_reasoning_effort(monkeypatch) -> None:
     """If LiteLLM metadata is unavailable, fixed-reasoning Grok variants should stay stripped."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -657,7 +657,8 @@ def test_litellm_openai_variant_sets_reasoning_without_forcing_other_providers()
     assert agent.model_settings.extra_args == {"reasoning_effort": "high", "reasoning_summary": "auto"}
 
 
-def test_xai_grok_variant_forwards_selected_reasoning_effort() -> None:
+@pytest.mark.parametrize("model_name", ["xai/grok-4.3", "xai/grok-4-1-fast", "xai/grok-code-fast"])
+def test_xai_grok_variant_forwards_selected_reasoning_effort(model_name: str) -> None:
     """Selected xAI Grok variants should reach LiteLLM as explicit extra args."""
     pytest.importorskip("agents")
     pytest.importorskip("agents.extensions.models.litellm_model")
@@ -668,13 +669,13 @@ def test_xai_grok_variant_forwards_selected_reasoning_effort() -> None:
     from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
     from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 
-    agent = Agent(name="A", instructions="x", model=LitellmModel(model="xai/grok-4.3"))
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model=model_name))
     agency = type("Agency", (), {"agents": {"A": agent}})()
 
     apply_openai_client_config(
         agency,
         ClientConfig(
-            model="litellm/xai/grok-4.3",
+            model=f"litellm/{model_name}",
             model_settings_extra_args={
                 "effort": "medium",
                 "reasoning_effort": "high",

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -721,6 +721,38 @@ def test_xai_grok_variant_drops_unsupported_reasoning_effort(model_name: str) ->
     assert agent.model_settings.extra_args is None
 
 
+def test_xai_grok_fallback_drops_fixed_reasoning_effort(monkeypatch) -> None:
+    """If LiteLLM metadata is unavailable, fixed-reasoning Grok variants should stay stripped."""
+    pytest.importorskip("agents")
+    litellm = pytest.importorskip("litellm")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    def fail_supports_reasoning(*args, **kwargs):
+        raise RuntimeError("metadata unavailable")
+
+    monkeypatch.setattr(litellm, "supports_reasoning", fail_supports_reasoning)
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="xai/grok-4-fast-reasoning"))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="litellm/xai/grok-4-fast-reasoning",
+            model_settings_extra_args={"reasoning_effort": "high", "reasoning_summary": "auto"},
+        ),
+    )
+
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args is None
+
+
 def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:
     """Custom non-OpenAI model names should skip OpenAI client construction entirely."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -657,8 +657,8 @@ def test_litellm_openai_variant_sets_reasoning_without_forcing_other_providers()
     assert agent.model_settings.extra_args == {"reasoning_effort": "high", "reasoning_summary": "auto"}
 
 
-def test_xai_grok_variant_does_not_forward_unsupported_reasoning_effort() -> None:
-    """Grok reasoning models reason by model choice and reject reasoning_effort parameters."""
+def test_xai_grok_variant_forwards_selected_reasoning_effort() -> None:
+    """Selected xAI Grok variants should reach LiteLLM as explicit extra args."""
     pytest.importorskip("agents")
     pytest.importorskip("agents.extensions.models.litellm_model")
 
@@ -668,19 +668,19 @@ def test_xai_grok_variant_does_not_forward_unsupported_reasoning_effort() -> Non
     from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
     from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 
-    agent = Agent(name="A", instructions="x", model=LitellmModel(model="xai/grok-4.20-0309-reasoning"))
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="xai/grok-4.3"))
     agency = type("Agency", (), {"agents": {"A": agent}})()
 
     apply_openai_client_config(
         agency,
         ClientConfig(
-            model="litellm/xai/grok-4.20-0309-reasoning",
-            model_settings_extra_args={"reasoning_effort": "high", "reasoning_summary": "auto"},
+            model="litellm/xai/grok-4.3",
+            model_settings_extra_args={"reasoning_effort": "high"},
         ),
     )
 
     assert agent.model_settings.reasoning is None
-    assert agent.model_settings.extra_args is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
 
 
 def test_non_openai_custom_model_skips_openai_client_build(monkeypatch) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -654,7 +654,53 @@ def test_litellm_openai_variant_sets_reasoning_without_forcing_other_providers()
     assert isinstance(agent.model, LitellmModel)
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
-    assert agent.model_settings.extra_args == {"reasoning_effort": "high", "reasoning_summary": "auto"}
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
+
+
+def test_litellm_prefixed_string_model_normalizes_variant_extra_args_without_model_override() -> None:
+    """Existing LiteLLM-prefixed string models should still get provider-specific variant mapping."""
+    pytest.importorskip("agents")
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model="litellm/anthropic/claude-sonnet-4-6")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(model_settings_extra_args={"effort": "high", "reasoning_summary": "auto"}),
+    )
+
+    assert agent.model == "litellm/anthropic/claude-sonnet-4-6"
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
+
+
+def test_litellm_prefixed_wrapper_model_normalizes_variant_extra_args_without_model_override() -> None:
+    """Existing LiteLLM wrappers with a prefixed model should still get provider-specific variant mapping."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="litellm/anthropic/claude-sonnet-4-6"))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(model_settings_extra_args={"effort": "high", "reasoning_summary": "auto"}),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "litellm/anthropic/claude-sonnet-4-6"
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
 
 
 @pytest.mark.parametrize("model_name", ["xai/grok-4.3", "xai/grok-4-1-fast", "xai/grok-code-fast"])

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -471,7 +471,8 @@ def test_litellm_model_override_applies_explicit_variant_extra_args() -> None:
 
     assert isinstance(agent.model, LitellmModel)
     assert agent.model.model == "anthropic/claude-sonnet-4-20250514"
-    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.extra_args == {
         "thinking": {"type": "enabled", "budget_tokens": 16000},
         "reasoning_effort": "high",
@@ -504,7 +505,8 @@ def test_litellm_anthropic_variant_maps_effort_without_leaking_provider_field() 
         ),
     )
 
-    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.extra_args == {
         "thinking": {"type": "adaptive"},
         "reasoning_effort": "high",
@@ -537,12 +539,146 @@ def test_litellm_gemini_variant_maps_thinking_config() -> None:
 
     assert isinstance(agent.model, LitellmModel)
     assert agent.model.model == "gemini/gemini-2.5-pro"
-    assert agent.model_settings.reasoning is not None
-    assert agent.model_settings.reasoning.effort == "high"
-    assert agent.model_settings.reasoning.summary == "auto"
+    assert agent.model_settings.reasoning is None
     assert agent.model_settings.extra_args == {
         "thinking": {"type": "enabled", "budget_tokens": 16000},
     }
+
+
+async def test_litellm_gemini_budget_forwards_only_thinking_payload(monkeypatch) -> None:
+    """Budget-based Gemini variants should not also send LiteLLM reasoning_effort."""
+    pytest.importorskip("agents")
+    litellm = pytest.importorskip("litellm")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+    from agents.models.interface import ModelTracing
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="google/gemini-2.5-pro"))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    seen: dict[str, object] = {}
+
+    async def capture(**kwargs):
+        seen.update(kwargs)
+        msg = litellm.types.utils.Message(content="ok", role="assistant")
+        choice = litellm.types.utils.Choices(finish_reason="stop", index=0, message=msg)
+        return litellm.types.utils.ModelResponse(choices=[choice], model=kwargs["model"])
+
+    monkeypatch.setattr(litellm, "acompletion", capture)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="litellm/google/gemini-2.5-pro",
+            model_settings_extra_args={
+                "thinkingConfig": {"includeThoughts": True, "thinkingBudget": 16000},
+                "reasoning_effort": "high",
+            },
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"thinking": {"type": "enabled", "budget_tokens": 16000}}
+
+    await agent.model._fetch_response(
+        None,
+        "hi",
+        agent.model_settings,
+        [],
+        None,
+        [],
+        None,
+        ModelTracing.DISABLED,
+        stream=False,
+    )
+
+    assert seen["thinking"] == {"type": "enabled", "budget_tokens": 16000}
+    assert seen["reasoning_effort"] is None
+
+
+async def test_litellm_anthropic_variant_preserves_reasoning_for_tool_replay(monkeypatch) -> None:
+    """Anthropic thinking variants should replay signed thinking blocks across tool calls."""
+    pytest.importorskip("agents")
+    litellm = pytest.importorskip("litellm")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+    from agents.models.interface import ModelTracing
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="anthropic/claude-sonnet-4-6"))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    seen: dict[str, object] = {}
+
+    async def capture(**kwargs):
+        seen.update(kwargs)
+        msg = litellm.types.utils.Message(content="ok", role="assistant")
+        choice = litellm.types.utils.Choices(finish_reason="stop", index=0, message=msg)
+        return litellm.types.utils.ModelResponse(choices=[choice], model=kwargs["model"])
+
+    monkeypatch.setattr(litellm, "acompletion", capture)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="litellm/anthropic/claude-sonnet-4-6",
+            model_settings_extra_args={
+                "thinking": {"type": "adaptive"},
+                "effort": "high",
+            },
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
+
+    await agent.model._fetch_response(
+        None,
+        [
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "content": [{"type": "reasoning_text", "text": "private chain"}],
+                "encrypted_content": "signed-thinking",
+                "provider_data": {"model": "anthropic/claude-sonnet-4-6"},
+            },
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+                "provider_data": {"model": "anthropic/claude-sonnet-4-6"},
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "tool result"},
+        ],
+        agent.model_settings,
+        [],
+        None,
+        [],
+        None,
+        ModelTracing.DISABLED,
+        stream=False,
+    )
+
+    assert seen["reasoning_effort"] == "high"
+    assert seen["thinking"] == {"type": "adaptive"}
+    messages = seen["messages"]
+    assert isinstance(messages, list)
+    assistant = messages[0]
+    assert isinstance(assistant, dict)
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == [{"type": "thinking", "thinking": "private chain", "signature": "signed-thinking"}]
+    assert assistant["tool_calls"][0]["id"] == "call_1"
 
 
 def test_litellm_gemini_variant_maps_top_level_thinking_level() -> None:
@@ -726,7 +862,8 @@ def test_litellm_prefixed_string_model_normalizes_variant_extra_args_without_mod
     )
 
     assert agent.model == "litellm/anthropic/claude-sonnet-4-6"
-    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
 
 
@@ -751,7 +888,8 @@ def test_litellm_prefixed_wrapper_model_normalizes_variant_extra_args_without_mo
 
     assert isinstance(agent.model, LitellmModel)
     assert agent.model.model == "litellm/anthropic/claude-sonnet-4-6"
-    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -535,6 +535,8 @@ def test_litellm_gemini_variant_maps_thinking_config() -> None:
         ),
     )
 
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "gemini/gemini-2.5-pro"
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.reasoning.summary == "auto"
@@ -568,6 +570,8 @@ def test_litellm_gemini_variant_maps_top_level_thinking_level() -> None:
         ),
     )
 
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "gemini/gemini-3.5-flash"
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.reasoning.summary == "auto"
@@ -652,9 +656,57 @@ def test_litellm_openai_variant_sets_reasoning_without_forcing_other_providers()
     )
 
     assert isinstance(agent.model, LitellmModel)
-    assert agent.model_settings.reasoning is not None
-    assert agent.model_settings.reasoning.effort == "high"
-    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": {"effort": "high", "summary": "auto"}}
+
+
+async def test_litellm_openai_variant_forwards_reasoning_summary_to_litellm(monkeypatch) -> None:
+    """OpenAI LiteLLM summaries must reach the SDK chat-completions call payload."""
+    pytest.importorskip("agents")
+    litellm = pytest.importorskip("litellm")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+    from agents.models.interface import ModelTracing
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model=LitellmModel(model="openai/gpt-4o-mini"))
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+    seen: dict[str, object] = {}
+
+    async def capture(**kwargs):
+        seen.update(kwargs)
+        msg = litellm.types.utils.Message(content="ok", role="assistant")
+        choice = litellm.types.utils.Choices(finish_reason="stop", index=0, message=msg)
+        return litellm.types.utils.ModelResponse(choices=[choice], model=kwargs["model"])
+
+    monkeypatch.setattr(litellm, "acompletion", capture)
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="litellm/openai/gpt-5.4",
+            model_settings_extra_args={"reasoning_effort": "high", "reasoning_summary": "auto"},
+        ),
+    )
+
+    assert isinstance(agent.model, LitellmModel)
+    await agent.model._fetch_response(
+        None,
+        "hi",
+        agent.model_settings,
+        [],
+        None,
+        [],
+        None,
+        ModelTracing.DISABLED,
+        stream=False,
+    )
+
+    assert seen["reasoning_effort"] == {"effort": "high", "summary": "auto"}
 
 
 def test_litellm_prefixed_string_model_normalizes_variant_extra_args_without_model_override() -> None:

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -24,6 +24,10 @@ def test_request_override_policy_flags() -> None:
     assert model_only.has_client_overrides is True
     assert model_only.has_openai_overrides is False
 
+    extra_args_only = RequestOverridePolicy(ClientConfig(model_settings_extra_args={"reasoning_effort": "high"}))
+    assert extra_args_only.has_client_overrides is True
+    assert extra_args_only.has_openai_overrides is False
+
     litellm_cfg = cast(
         ClientConfig,
         SimpleNamespace(


### PR DESCRIPTION
## Summary

- Keep selected xAI Grok reasoning effort in LiteLLM `extra_args` instead of stripping it from request-scoped model settings.
- Make the tools-folder execution test deterministic by using the existing deterministic test model to force the loaded `echo_tool` call.

## Checks

Local focused tests passed for xAI Grok reasoning forwarding and tools-folder execution on Python 3.12. Ruff passed on the touched files.

## Related

Polishes https://github.com/VRSEN/agency-swarm/pull/654.
