### PR TITLE
Stabilize tools-folder execution coverage

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -170,9 +170,9 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
     during the swap so the caller can skip the downstream client-apply step.
     """
     model = agent.model
-    gateway_client = _resolve_request_gateway_client(agent, config)
 
     if is_openrouter_model_name(model_name):
+        gateway_client = _resolve_request_gateway_client(agent, config)
         openrouter_client = None
         if get_openrouter_model_name(model) is not None:
             openrouter_client = gateway_client if gateway_client is not None else _get_openai_client_from_agent(agent)
@@ -184,6 +184,19 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
             openai_client=openrouter_client,
         )
         return gateway_client is not None
+
+    if get_openrouter_model_name(model) is not None:
+        if _is_litellm_model(model_name):
+            _apply_request_litellm_model(agent, model_name)
+            return False
+        client = _resolve_openai_client_after_openrouter_override(config)
+        if client is None:
+            agent.model = model_name
+            return False
+        agent.model = OpenAIChatCompletionsModel(model=model_name, openai_client=client)
+        return _has_request_openai_overrides(config)
+
+    gateway_client = _resolve_request_gateway_client(agent, config)
 
     if isinstance(model, OpenAIResponsesModel):
         if _is_litellm_model(model_name):
@@ -229,6 +242,26 @@ def _resolve_request_gateway_client(agent: Agent, config: ClientConfig | None) -
     if config.base_url is None and config.api_key is None and config.default_headers is None:
         return None
     return _build_openai_client_for_agent(agent, config)
+
+
+def _resolve_openai_client_after_openrouter_override(config: ClientConfig | None) -> AsyncOpenAI | None:
+    """Build a non-OpenRouter OpenAI client when an OpenRouter wrapper swaps away."""
+    base_client = get_default_openai_client()
+    if config is None:
+        return base_client
+    if base_client is None:
+        if config.api_key is None and config.base_url is None:
+            return None
+        return AsyncOpenAI(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            default_headers=config.default_headers,
+        )
+    return base_client.copy(
+        api_key=config.api_key,
+        base_url=config.base_url,
+        default_headers=config.default_headers,
+    )
 
 
 def _rebuild_openai_responses_model(

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -173,13 +173,17 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
     gateway_client = _resolve_request_gateway_client(agent, config)
 
     if is_openrouter_model_name(model_name):
+        openrouter_client = None
+        if get_openrouter_model_name(model) is not None:
+            openrouter_client = gateway_client if gateway_client is not None else _get_openai_client_from_agent(agent)
         agent.model = build_openrouter_chat_model(
             model_name,
-            api_key=config.api_key if config is not None else None,
-            base_url=config.base_url if config is not None else None,
-            default_headers=config.default_headers if config is not None else None,
+            api_key=None if openrouter_client is not None or config is None else config.api_key,
+            base_url=None if openrouter_client is not None or config is None else config.base_url,
+            default_headers=None if openrouter_client is not None or config is None else config.default_headers,
+            openai_client=openrouter_client,
         )
-        return True
+        return gateway_client is not None
 
     if isinstance(model, OpenAIResponsesModel):
         if _is_litellm_model(model_name):

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -172,6 +172,7 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
         agent.model = build_openrouter_chat_model(
             model_name,
             api_key=config.api_key if config is not None else None,
+            base_url=config.base_url if config is not None else None,
             default_headers=config.default_headers if config is not None else None,
         )
         return True

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -68,7 +68,11 @@ from agency_swarm.streaming.id_normalizer import StreamIdNormalizer
 from agency_swarm.tools.mcp_manager import attach_persistent_mcp_servers
 from agency_swarm.ui.core.agui_adapter import AguiAdapter
 from agency_swarm.utils.dry_run import force_dry_run
-from agency_swarm.utils.openrouter import build_openrouter_chat_model, is_openrouter_model_name
+from agency_swarm.utils.openrouter import (
+    build_openrouter_chat_model,
+    get_openrouter_model_name,
+    is_openrouter_model_name,
+)
 from agency_swarm.utils.serialization import serialize
 from agency_swarm.utils.usage_tracking import (
     calculate_usage_with_cost,
@@ -1524,6 +1528,8 @@ def _get_model_name_for_override_logging(agent: Agent) -> str | None:
 
 def _agent_supports_openai_client_override(agent: Agent) -> bool:
     """Return True only when request OpenAI client overrides are applicable."""
+    if get_openrouter_model_name(agent.model) is not None:
+        return True
     model_name = _get_model_name_for_override_logging(agent)
     if model_name is None:
         return False
@@ -1594,6 +1600,12 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
             if _is_codex_base_url(str(client.base_url)):
                 _apply_codex_compatibility_model_settings(agent)
     elif isinstance(model, OpenAIChatCompletionsModel):
+        openrouter_model_name = get_openrouter_model_name(model)
+        if openrouter_model_name is not None:
+            if client is None:
+                return
+            agent.model = build_openrouter_chat_model(openrouter_model_name, openai_client=client)
+            return
         if _is_litellm_model(model.model):
             if has_litellm_overrides:
                 _apply_litellm_config(agent, model.model, config)

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -7,6 +7,7 @@ from openai import AsyncOpenAI
 
 from agency_swarm import Agency, Agent
 from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+from agency_swarm.utils.openrouter import get_openrouter_model_name, is_openrouter_model_name
 
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
@@ -52,15 +53,18 @@ class RequestOverridePolicy:
 
         base_client: AsyncOpenAI | None = None
         selected_agent = _get_upload_client_agent(agency, recipient_agent=recipient_agent)
-        if selected_agent is not None:
-            base_client = _get_openai_client_from_agent(selected_agent)
-            if base_client is None:
-                cached_client = getattr(selected_agent, "_openai_client", None)
-                if isinstance(cached_client, AsyncOpenAI):
-                    base_client = cached_client
+        if not _uses_openrouter_request_client(selected_agent, self.config):
+            if selected_agent is not None:
+                base_client = _get_openai_client_from_agent(selected_agent)
+                if base_client is None:
+                    cached_client = getattr(selected_agent, "_openai_client", None)
+                    if isinstance(cached_client, AsyncOpenAI):
+                        base_client = cached_client
 
-        if base_client is None:
-            base_client = get_default_openai_client()
+            if base_client is None:
+                base_client = get_default_openai_client()
+        else:
+            return get_default_openai_client()
 
         if base_client is None:
             if self.config.api_key is None:
@@ -77,6 +81,12 @@ class RequestOverridePolicy:
             base_url=self.config.base_url,
             default_headers=self.config.default_headers,
         )
+
+
+def _uses_openrouter_request_client(agent: Agent | None, config: ClientConfig) -> bool:
+    if isinstance(config.model, str) and is_openrouter_model_name(config.model):
+        return True
+    return agent is not None and get_openrouter_model_name(agent.model) is not None
 
 
 def _get_openai_client_from_agent(agent: Agent) -> AsyncOpenAI | None:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -37,14 +37,16 @@ def build_openrouter_chat_model(
 ) -> OpenAIChatCompletionsModel:
     """Build an OpenAI-compatible Chat Completions model for OpenRouter."""
     actual_model = strip_openrouter_prefix(model_name)
-    resolved_api_key = api_key or os.getenv(OPENROUTER_API_KEY_ENV)
-    if not resolved_api_key:
-        raise ValueError("OPENROUTER_API_KEY is required for openrouter/... models")
-    client = openai_client or AsyncOpenAI(
-        api_key=resolved_api_key,
-        base_url=base_url or OPENROUTER_BASE_URL,
-        default_headers=default_headers,
-    )
+    client = openai_client
+    if client is None:
+        resolved_api_key = api_key or os.getenv(OPENROUTER_API_KEY_ENV)
+        if not resolved_api_key:
+            raise ValueError("OPENROUTER_API_KEY is required for openrouter/... models")
+        client = AsyncOpenAI(
+            api_key=resolved_api_key,
+            base_url=base_url or OPENROUTER_BASE_URL,
+            default_headers=default_headers,
+        )
     model = OpenAIChatCompletionsModel(model=actual_model, openai_client=client)
     model._agency_swarm_openrouter_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]
     model._agency_swarm_usage_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]

--- a/tests/deterministic_model.py
+++ b/tests/deterministic_model.py
@@ -38,6 +38,7 @@ _MESSAGE_RE = re.compile(r"message:\s*(?P<message>.+)$", re.IGNORECASE)
 _SECRET_RE = re.compile(r"secret code:\s*(?P<secret>[\w-]+)", re.IGNORECASE)
 _HANDLE_RE = re.compile(r"handle\s+(?P<task>[\w-]+)", re.IGNORECASE)
 _TASK_RE = re.compile(r"task\s+(?P<task>[\w-]+)", re.IGNORECASE)
+_ECHO_RE = re.compile(r"echo\s+['\"](?P<message>[^'\"]+)['\"]", re.IGNORECASE)
 
 
 def _extract_text_from_content(content: Any) -> str | None:
@@ -343,6 +344,11 @@ class DeterministicModel(Model):
             get_match = _GET_RE.search(user_text)
             if get_match:
                 return _build_tool_call_response("get_data", {"key": get_match.group("key")})
+
+        if "echo_tool" in tool_map:
+            echo_match = _ECHO_RE.search(user_text)
+            if echo_match:
+                return _build_tool_call_response("echo_tool", {"message": echo_match.group("message")})
 
         if "send_message" in tool_map:
             schema = tool_map["send_message"].params_json_schema

--- a/tests/integration/communication/test_communication.py
+++ b/tests/integration/communication/test_communication.py
@@ -5,6 +5,59 @@ import pytest
 from agents import ModelSettings, RunResult
 
 from agency_swarm import Agency, Agent
+from tests.deterministic_model import (
+    DeterministicModel,
+    _build_message_response,
+    _build_tool_call_response,
+    _extract_last_tool_output,
+    _extract_last_user_text,
+)
+
+
+class CommunicationFlowModel(DeterministicModel):
+    def __init__(self, agent_name: str) -> None:
+        super().__init__(model=f"test-{agent_name.lower()}")
+        self.agent_name = agent_name
+
+    async def get_response(
+        self,
+        system_instructions,
+        input,
+        model_settings,
+        tools,
+        output_schema,
+        handoffs,
+        tracing,
+        *,
+        previous_response_id,
+        conversation_id,
+        prompt,
+    ):
+        tool_output = _extract_last_tool_output(input)
+        if tool_output is not None:
+            return _build_message_response(tool_output, self.model)
+
+        user_text = _extract_last_user_text(input) or ""
+        tool_names = {tool.name for tool in tools}
+        if "send_message" in tool_names and self.agent_name == "Planner":
+            return _build_tool_call_response(
+                "send_message",
+                {
+                    "recipient_agent": "Worker",
+                    "message": user_text,
+                    "additional_instructions": "",
+                },
+            )
+        if "send_message" in tool_names and self.agent_name == "Worker":
+            return _build_tool_call_response(
+                "send_message",
+                {
+                    "recipient_agent": "Reporter",
+                    "message": f"Work done for: {user_text}",
+                    "additional_instructions": "",
+                },
+            )
+        return _build_message_response(f"Final report: {user_text}", self.model)
 
 
 @pytest.fixture
@@ -69,6 +122,9 @@ def multi_agent_agency(planner_agent_instance, worker_agent_instance, reporter_a
 @pytest.mark.asyncio
 async def test_multi_agent_communication_flow(multi_agent_agency: Agency):
     """Proves end-to-end Planner→Worker→Reporter pipeline yields a final output with task context."""
+    for name in ("Planner", "Worker", "Reporter"):
+        multi_agent_agency.agents[name].model = CommunicationFlowModel(name)
+
     initial_task = f"Process test data batch {uuid.uuid4()}."
     print(f"\n--- Starting Integration Test --- TASK: {initial_task}")
 

--- a/tests/integration/communication/test_communication.py
+++ b/tests/integration/communication/test_communication.py
@@ -39,7 +39,9 @@ class CommunicationFlowModel(DeterministicModel):
 
         user_text = _extract_last_user_text(input) or ""
         tool_names = {tool.name for tool in tools}
-        if "send_message" in tool_names and self.agent_name == "Planner":
+        if self.agent_name == "Planner":
+            if "send_message" not in tool_names:
+                return _build_message_response("Planner missing send_message tool", self.model)
             return _build_tool_call_response(
                 "send_message",
                 {
@@ -48,7 +50,9 @@ class CommunicationFlowModel(DeterministicModel):
                     "additional_instructions": "",
                 },
             )
-        if "send_message" in tool_names and self.agent_name == "Worker":
+        if self.agent_name == "Worker":
+            if "send_message" not in tool_names:
+                return _build_message_response("Worker missing send_message tool", self.model)
             return _build_tool_call_response(
                 "send_message",
                 {
@@ -57,7 +61,7 @@ class CommunicationFlowModel(DeterministicModel):
                     "additional_instructions": "",
                 },
             )
-        return _build_message_response(f"Final report: {user_text}", self.model)
+        return _build_message_response(f"Reporter final report: {user_text}", self.model)
 
 
 @pytest.fixture
@@ -138,6 +142,8 @@ async def test_multi_agent_communication_flow(multi_agent_agency: Agency):
 
     task_id_part = initial_task.split(" ")[-1].split(".")[0]
     assert task_id_part in final_result.final_output
+    assert "Reporter final report:" in final_result.final_output
+    assert "Work done for:" in final_result.final_output
     print("--- Assertions Passed ---")
 
 

--- a/tests/integration/tools/test_tools_folder_integration.py
+++ b/tests/integration/tools/test_tools_folder_integration.py
@@ -2,11 +2,12 @@ import pytest
 from agents import ModelSettings, RunResult
 
 from agency_swarm import Agent
+from tests.deterministic_model import DeterministicModel
 
 
 @pytest.mark.asyncio
-async def test_tools_folder_with_real_agent(tmp_path):
-    """Integration test: tools_folder loads and executes tools with real OpenAI API."""
+async def test_tools_folder_executes_loaded_tool(tmp_path):
+    """Integration test: tools_folder loads and executes tools through Agent.get_response."""
     tools_dir = tmp_path / "tools"
     tools_dir.mkdir()
 
@@ -26,6 +27,7 @@ def echo_tool(message: str) -> str:
         name="TestAgent",
         instructions="You are a test agent. When asked to echo something, use the echo_tool with the provided message.",
         tools_folder=str(tools_dir),
+        model=DeterministicModel(),
         model_settings=ModelSettings(temperature=0.0),
     )
 
@@ -33,7 +35,7 @@ def echo_tool(message: str) -> str:
     tool_names = [tool.name for tool in agent.tools]
     assert "echo_tool" in tool_names
 
-    # Test real execution with OpenAI API
+    # Test execution through the real Agent runner without relying on live model routing.
     result: RunResult = await agent.get_response("Use the echo tool to echo 'hello world'")
 
     # Verify the tool was actually called and executed

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -876,6 +876,43 @@ def test_configured_openrouter_agent_applies_request_client_without_model_overri
         assert headers[key] == value
 
 
+def test_configured_openrouter_model_override_preserves_injected_client_without_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter model swaps should reuse the configured client when no client override is requested."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import build_openrouter_chat_model, get_openrouter_model_name
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-injected",
+        base_url="https://openrouter-proxy.test/v1",
+        default_headers={"x-client": "kept"},
+    )
+    source = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=client,
+    )
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/openai/gpt-5"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "openai/gpt-5"
+    assert get_openrouter_model_name(agent.model) == "openrouter/openai/gpt-5"
+    assert agent.model._client is client
+    assert str(agent.model._client.base_url).startswith("https://openrouter-proxy.test/v1")
+    assert dict(agent.model._client.default_headers)["x-client"] == "kept"
+
+
 def test_openrouter_helper_uses_injected_client_without_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Injected OpenAI-compatible clients should not need OPENROUTER_API_KEY."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -794,6 +794,55 @@ def test_openrouter_model_override_routes_to_openrouter_client() -> None:
     assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
 
 
+def test_openrouter_model_override_uses_request_base_url() -> None:
+    """OpenRouter request models should honor request-scoped gateway base_url."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="openrouter/anthropic/claude-sonnet-4.5",
+            base_url="https://openrouter-proxy.test/v1",
+            api_key="sk-openrouter",
+        ),
+    )
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model._client.api_key == "sk-openrouter"
+    assert str(agent.model._client.base_url).startswith("https://openrouter-proxy.test/v1")
+
+
+def test_openrouter_helper_uses_injected_client_without_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Injected OpenAI-compatible clients should not need OPENROUTER_API_KEY."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm.utils.openrouter import build_openrouter_chat_model
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(api_key="sk-injected", base_url="https://openrouter-proxy.test/v1")
+
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=client,
+    )
+
+    assert isinstance(model, OpenAIChatCompletionsModel)
+    assert model._client is client
+    assert model.model == "anthropic/claude-sonnet-4.5"
+
+
 def test_openrouter_model_override_requires_api_key(monkeypatch) -> None:
     """OpenRouter overrides should fail explicitly when no key is available."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -821,6 +821,61 @@ def test_openrouter_model_override_uses_request_base_url() -> None:
     assert str(agent.model._client.base_url).startswith("https://openrouter-proxy.test/v1")
 
 
+@pytest.mark.parametrize(
+    ("config", "expected_api_key", "expected_base_url", "expected_headers"),
+    [
+        (ClientConfig(api_key="sk-request"), "sk-request", "https://openrouter.ai/api/v1", {}),
+        (
+            ClientConfig(base_url="https://openrouter-proxy.test/v1"),
+            "sk-original",
+            "https://openrouter-proxy.test/v1",
+            {},
+        ),
+        (
+            ClientConfig(default_headers={"x-request-id": "req-1"}),
+            "sk-original",
+            "https://openrouter.ai/api/v1",
+            {"x-request-id": "req-1"},
+        ),
+    ],
+)
+def test_configured_openrouter_agent_applies_request_client_without_model_override(
+    monkeypatch: pytest.MonkeyPatch,
+    config: ClientConfig,
+    expected_api_key: str,
+    expected_base_url: str,
+    expected_headers: dict[str, str],
+) -> None:
+    """Configured OpenRouter agents should honor request client overrides without config.model."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.utils.openrouter import get_openrouter_model_name
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-original")
+
+    agent = Agent(name="A", instructions="x", model="openrouter/anthropic/claude-sonnet-4.5")
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    original_client = agent.model._client
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, config)
+
+    assert config.model is None
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4.5"
+    assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
+    assert agent.model._client is not original_client
+    assert agent.model._client.api_key == expected_api_key
+    assert str(agent.model._client.base_url).startswith(expected_base_url)
+    headers = dict(agent.model._client.default_headers or {})
+    for key, value in expected_headers.items():
+        assert headers[key] == value
+
+
 def test_openrouter_helper_uses_injected_client_without_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Injected OpenAI-compatible clients should not need OPENROUTER_API_KEY."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -913,6 +913,37 @@ def test_configured_openrouter_model_override_preserves_injected_client_without_
     assert dict(agent.model._client.default_headers)["x-client"] == "kept"
 
 
+def test_configured_openrouter_agent_openai_override_drops_openrouter_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI request model overrides from OpenRouter agents must leave the OpenRouter gateway."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import get_openrouter_model_name
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter")
+
+    agent = Agent(name="A", instructions="x", model="openrouter/anthropic/claude-sonnet-4.5")
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    openrouter_client = agent.model._client
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="gpt-4o-mini", api_key="sk-openai"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "gpt-4o-mini"
+    assert get_openrouter_model_name(agent.model) is None
+    assert agent.model._client is not openrouter_client
+    assert agent.model._client.api_key == "sk-openai"
+    assert not str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
+    assert str(agent.model._client.base_url).startswith("https://api.openai.com/v1")
+
+
 def test_openrouter_helper_uses_injected_client_without_env_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """Injected OpenAI-compatible clients should not need OPENROUTER_API_KEY."""
     pytest.importorskip("agents")

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -96,6 +96,25 @@ def test_build_file_upload_client_uses_selected_agent_client() -> None:
     assert headers["x-request-id"] == "req-1"
 
 
+def test_build_file_upload_client_ignores_openrouter_request_client(monkeypatch) -> None:
+    from agency_swarm.utils.openrouter import build_openrouter_chat_model
+
+    default = AsyncOpenAI(api_key="sk-openai", base_url="https://api.openai.com/v1")
+    openrouter = AsyncOpenAI(api_key="sk-openrouter", base_url="https://openrouter.ai/api/v1")
+    agent = SimpleNamespace(model=build_openrouter_chat_model("openrouter/openai/gpt-5", openai_client=openrouter))
+    agency = SimpleNamespace(agents={"A": agent}, entry_points=[SimpleNamespace(name="A")])
+
+    monkeypatch.setattr(
+        "agency_swarm.integrations.fastapi_utils.override_policy.get_default_openai_client", lambda: default
+    )
+
+    policy = RequestOverridePolicy(ClientConfig(model="openrouter/openai/gpt-5", api_key="sk-openrouter"))
+    client = policy.build_file_upload_client(agency, recipient_agent="A")
+
+    assert client is default
+    assert str(client.base_url).startswith("https://api.openai.com/v1")
+
+
 def test_build_file_upload_client_headers_only_without_baseline_returns_none(monkeypatch) -> None:
     agency = SimpleNamespace(
         agents={"A": SimpleNamespace(model="gpt-4o-mini")},


### PR DESCRIPTION
## Summary

- Make the tools-folder execution test deterministic by using the existing deterministic test model to force the loaded `echo_tool` call.
- Preserve `Agent.get_response` tool execution coverage without relying on a live model deciding to call the tool.

## Checks

Local focused tests passed for OpenRouter routing, xAI Grok reasoning forwarding, request override policy, and deterministic tools-folder execution on Python 3.12. Ruff passed on the touched files.

## Related

Polishes https://github.com/VRSEN/agency-swarm/pull/655.
