### PR TITLE
feat: allow handoff and send message for the same agent pair

### DIFF
--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -37,6 +37,7 @@ CommunicationFlowEntry = (
     tuple[Agent, Agent]  # Basic (sender, receiver) pair
     | tuple[AgentFlow, type]  # Agent flow with tool class
     | tuple[Agent, Agent, type]  # Individual (sender, receiver, tool_class)
+    | tuple[Agent, Agent, list[type] | tuple[type, ...]]  # Individual pair with multiple tool classes
     | AgentFlow  # Standalone agent flow (uses default tool)
 )
 
@@ -75,7 +76,8 @@ class Agency:
     _agent_runtime_state: dict[str, "AgentRuntimeState"]
 
     # Communication tool class mappings for agent-to-agent specific tools
-    _communication_tool_classes: dict[tuple[str, str], type]  # (sender_name, receiver_name) -> tool_class
+    _communication_tool_classes: dict[tuple[str, str], list[type]]  # (sender_name, receiver_name) -> tool_classes
+    _default_communication_tool_pairs: set[tuple[str, str]]  # pairs that requested the default send_message tool
 
     def __init__(
         self,
@@ -133,15 +135,18 @@ class Agency:
 
         _derived_entry_points: list[Agent] = []
         _derived_communication_flows: list[tuple[Agent, Agent]] = []
-        _communication_tool_classes: dict[tuple[str, str], type] = {}  # (sender_name, receiver_name) -> tool_class
+        _communication_tool_classes: dict[tuple[str, str], list[type]] = {}
+        _default_communication_tool_pairs: set[tuple[str, str]] = set()
 
         if entry_point_agents or communication_flows is not None:
             _derived_entry_points = list(entry_point_agents)
             if not all(isinstance(ep, Agent) for ep in _derived_entry_points):
                 raise TypeError("All positional arguments (entry points) must be Agent instances.")
-            _derived_communication_flows, _communication_tool_classes = parse_agent_flows(
-                self, communication_flows or []
-            )
+            (
+                _derived_communication_flows,
+                _communication_tool_classes,
+                _default_communication_tool_pairs,
+            ) = parse_agent_flows(self, communication_flows or [])
         else:
             raise ValueError(
                 "Agency structure not defined. Provide entry point agents as positional arguments and/or "
@@ -188,6 +193,7 @@ class Agency:
         logger.info(f"Designated entry points: {[ep.name for ep in self.entry_points]}")
         self._derived_communication_flows = _derived_communication_flows
         self._communication_tool_classes = _communication_tool_classes
+        self._default_communication_tool_pairs = _default_communication_tool_pairs
         configure_agents(self, _derived_communication_flows)
         apply_shared_resources(self)
         for agent_name, agent_instance in self.agents.items():

--- a/src/agency_swarm/agency/helpers.py
+++ b/src/agency_swarm/agency/helpers.py
@@ -79,8 +79,14 @@ def build_fastapi_agencies(agency: "Agency") -> dict[str, Callable[..., "Agency"
     def agency_factory(*, load_threads_callback=None, save_threads_callback=None, **_: Any) -> "Agency":
         flows: list[Any] = []
         for sender, receiver in agency._derived_communication_flows:
-            tool_cls = agency._communication_tool_classes.get((sender.name, receiver.name))
-            flows.append((sender, receiver, tool_cls) if tool_cls else (sender, receiver))
+            pair_key = (sender.name, receiver.name)
+            tool_cls = agency._communication_tool_classes.get(pair_key)
+            if pair_key in agency._default_communication_tool_pairs:
+                flows.append((sender, receiver))
+            if tool_cls:
+                flows.append((sender, receiver, tool_cls))
+            elif pair_key not in agency._default_communication_tool_pairs:
+                flows.append((sender, receiver))
 
         return agency_cls(
             *agency.entry_points,

--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -24,6 +24,14 @@ logger = logging.getLogger(__name__)
 _warned_deprecated_send_message_handoff = False
 
 
+def _validate_communication_tool_class(tool_class: type) -> None:
+    if not issubclass(tool_class, SendMessage | Handoff):
+        raise TypeError(
+            f"Invalid communication tool class: {tool_class.__name__}. "
+            "Expected a SendMessage or Handoff subclass."
+        )
+
+
 def _add_tool_class_for_pair(
     mapping: dict[tuple[str, str], list[type]],
     default_tool_pairs: set[tuple[str, str]],
@@ -32,6 +40,7 @@ def _add_tool_class_for_pair(
 ) -> None:
     if tool_class is None:
         return
+    _validate_communication_tool_class(tool_class)
     if pair_key in default_tool_pairs and issubclass(tool_class, SendMessage):
         raise ValueError(
             f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "

--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -164,6 +164,8 @@ def parse_agent_flows(
             # The agency factory reconstructs flows from _communication_tool_classes,
             # which stores lists of types per pair. Accept both a single class and a list.
             tool_classes = raw_tool_class if isinstance(raw_tool_class, (list, tuple)) else [raw_tool_class]
+            if not tool_classes:
+                raise ValueError("Communication flow tool class list cannot be empty.")
             for tc in tool_classes:
                 if not isinstance(tc, type):
                     raise TypeError(f"Invalid tool class in communication flow: {tc}. Expected a class type.")

--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -38,6 +38,13 @@ def _add_tool_class_for_pair(
             f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
         )
     classes = mapping.setdefault(pair_key, [])
+    if issubclass(tool_class, SendMessage):
+        for existing_tool_class in classes:
+            if issubclass(existing_tool_class, SendMessage):
+                raise ValueError(
+                    f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+                    f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+                )
     if tool_class in classes:
         raise ValueError(
             f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "

--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -279,8 +279,8 @@ def configure_agents(agency: "Agency", defined_communication_flows: list[tuple[A
                 if not tool_classes:
                     tool_classes.append(agency.send_message_tool_class or SendMessage)
 
-                try:
-                    for effective_tool_class in tool_classes:
+                for effective_tool_class in tool_classes:
+                    try:
                         if isinstance(effective_tool_class, Handoff) or (
                             isinstance(effective_tool_class, type) and issubclass(effective_tool_class, Handoff)
                         ):
@@ -298,6 +298,7 @@ def configure_agents(agency: "Agency", defined_communication_flows: list[tuple[A
                                 _warned_deprecated_send_message_handoff = True
 
                             handoff_instance = effective_tool_class().create_handoff(recipient_agent=recipient_agent)
+                            handoff_instance._agency_swarm_tool_class = effective_tool_class
                             runtime_state.handoffs.append(handoff_instance)
                             logger.debug(f"Added Handoff for {agent_name} -> {recipient_name}")
                         else:
@@ -313,11 +314,11 @@ def configure_agents(agency: "Agency", defined_communication_flows: list[tuple[A
                                 runtime_state=runtime_state,
                             )
 
-                except Exception as e:
-                    logger.error(
-                        f"Error registering subagent '{recipient_name}' for sender '{agent_name}': {e}",
-                        exc_info=True,
-                    )
+                    except Exception as e:
+                        logger.error(
+                            f"Error registering subagent '{recipient_name}' for sender '{agent_name}': {e}",
+                            exc_info=True,
+                        )
         else:
             logger.debug(f"Agent '{agent_name}' has no explicitly defined outgoing communication paths.")
     logger.info("Agent configuration complete.")

--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -24,19 +24,62 @@ logger = logging.getLogger(__name__)
 _warned_deprecated_send_message_handoff = False
 
 
+def _add_tool_class_for_pair(
+    mapping: dict[tuple[str, str], list[type]],
+    default_tool_pairs: set[tuple[str, str]],
+    pair_key: tuple[str, str],
+    tool_class: type | None,
+) -> None:
+    if tool_class is None:
+        return
+    if pair_key in default_tool_pairs and issubclass(tool_class, SendMessage):
+        raise ValueError(
+            f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+            f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+        )
+    classes = mapping.setdefault(pair_key, [])
+    if tool_class in classes:
+        raise ValueError(
+            f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+            f"{tool_class.__name__}. Each tool class for a pair can only be defined once."
+        )
+    classes.append(tool_class)
+
+
+def _add_default_tool_pair(
+    custom_mapping: dict[tuple[str, str], list[type]],
+    default_tool_pairs: set[tuple[str, str]],
+    pair_key: tuple[str, str],
+) -> None:
+    if pair_key in default_tool_pairs:
+        raise ValueError(
+            f"Duplicate communication flow detected: {pair_key[0]} -> {pair_key[1]}. "
+            "Each default agent-to-agent communication can only be defined once."
+        )
+    for tool_class in custom_mapping.get(pair_key, []):
+        if issubclass(tool_class, SendMessage):
+            raise ValueError(
+                f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+                f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+            )
+    default_tool_pairs.add(pair_key)
+
+
 def parse_agent_flows(
     agency: "Agency", communication_flows: list["CommunicationFlowEntry"]
-) -> tuple[list[tuple[Agent, Agent]], dict[tuple[str, str], type]]:
+) -> tuple[list[tuple[Agent, Agent]], dict[tuple[str, str], list[type]], set[tuple[str, str]]]:
     """
     Parse communication flows supporting AgentFlow chains and custom tool classes.
 
     Returns:
         tuple: (basic_flows, tool_class_mapping)
             - basic_flows: List of (sender, receiver) agent pairs
-            - tool_class_mapping: Dict mapping (sender_name, receiver_name) to tool class
+            - tool_class_mapping: Dict mapping (sender_name, receiver_name) to tool classes
+            - default_tool_pairs: Set of pairs that requested the default SendMessage tool
     """
     basic_flows: list[tuple[Agent, Agent]] = []
-    tool_class_mapping: dict[tuple[str, str], type] = {}
+    tool_class_mapping: dict[tuple[str, str], list[type]] = {}
+    default_tool_pairs: set[tuple[str, str]] = set()
     seen_flows: set[tuple[str, str]] = set()  # Track already defined flows
 
     # Capture chain flows ONCE at the start (from any evaluation during flow creation)
@@ -56,13 +99,10 @@ def parse_agent_flows(
             if isinstance(first, Agent) and isinstance(second, Agent):
                 # Basic (sender, receiver) pair
                 flow_key = (first.name, second.name)
-                if flow_key in seen_flows:
-                    raise ValueError(
-                        f"Duplicate communication flow detected: {first.name} -> {second.name}. "
-                        "Each agent-to-agent communication can only be defined once."
-                    )
-                seen_flows.add(flow_key)
-                basic_flows.append((first, second))
+                if flow_key not in seen_flows:
+                    seen_flows.add(flow_key)
+                    basic_flows.append((first, second))
+                _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key)
 
             elif isinstance(first, AgentFlow) and (isinstance(second, type) or second is None):
                 # (AgentFlow, tool_class) or standalone AgentFlow - use all flows from the complete chain
@@ -81,15 +121,16 @@ def parse_agent_flows(
                 # Create communication flows with the tool class (if specified)
                 for sender, receiver in all_flows:
                     flow_key = (sender.name, receiver.name)
-                    if flow_key in seen_flows:
-                        raise ValueError(
-                            f"Duplicate communication flow detected: {sender.name} -> {receiver.name}. "
-                            "Each agent-to-agent communication can only be defined once."
-                        )
-                    seen_flows.add(flow_key)
-                    basic_flows.append((sender, receiver))
-                    if tool_class is not None:
-                        tool_class_mapping[(sender.name, receiver.name)] = tool_class
+                    if flow_key not in seen_flows:
+                        seen_flows.add(flow_key)
+                        basic_flows.append((sender, receiver))
+                    elif tool_class is None:
+                        _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key)
+                        continue
+                    if tool_class is None:
+                        _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key)
+                    else:
+                        _add_tool_class_for_pair(tool_class_mapping, default_tool_pairs, flow_key, tool_class)
 
             else:
                 raise TypeError(
@@ -99,28 +140,30 @@ def parse_agent_flows(
 
         elif isinstance(flow_entry, tuple | list) and len(flow_entry) == 3:
             # (Agent, Agent, tool_class) format
-            sender, receiver, tool_class = flow_entry
+            sender, receiver, raw_tool_class = flow_entry
 
             if not isinstance(sender, Agent) or not isinstance(receiver, Agent):
                 raise TypeError(f"Invalid communication flow entry: {flow_entry}. Expected (Agent, Agent, tool_class).")
 
-            if not isinstance(tool_class, type):
-                raise TypeError(f"Invalid tool class in communication flow: {tool_class}. Expected a class type.")
+            # The agency factory reconstructs flows from _communication_tool_classes,
+            # which stores lists of types per pair. Accept both a single class and a list.
+            tool_classes = raw_tool_class if isinstance(raw_tool_class, (list, tuple)) else [raw_tool_class]
+            for tc in tool_classes:
+                if not isinstance(tc, type):
+                    raise TypeError(f"Invalid tool class in communication flow: {tc}. Expected a class type.")
 
             flow_key = (sender.name, receiver.name)
-            if flow_key in seen_flows:
-                raise ValueError(
-                    f"Duplicate communication flow detected: {sender.name} -> {receiver.name}. "
-                    "Each agent-to-agent communication can only be defined once."
-                )
-            seen_flows.add(flow_key)
-            basic_flows.append((sender, receiver))
-            tool_class_mapping[(sender.name, receiver.name)] = tool_class
+            if flow_key not in seen_flows:
+                seen_flows.add(flow_key)
+                basic_flows.append((sender, receiver))
+
+            for tc in tool_classes:
+                _add_tool_class_for_pair(tool_class_mapping, default_tool_pairs, flow_key, tc)
 
         else:
             raise ValueError(f"Invalid communication flow entry: {flow_entry}. Expected 2 or 3 elements.")
 
-    return basic_flows, tool_class_mapping
+    return basic_flows, tool_class_mapping, default_tool_pairs
 
 
 def register_all_agents_and_set_entry_points(
@@ -210,47 +253,47 @@ def configure_agents(agency: "Agency", defined_communication_flows: list[tuple[A
 
                 # Check if there's a custom tool class for this specific pair
                 pair_key = (agent_name, recipient_name)
-                custom_tool_class = agency._communication_tool_classes.get(pair_key)
-
-                # Determine which tool class to use
-                effective_tool_class = custom_tool_class or agency.send_message_tool_class
+                configured = agency._communication_tool_classes.get(pair_key, [])
+                tool_classes: list[type] = []
+                if pair_key in agency._default_communication_tool_pairs:
+                    tool_classes.append(agency.send_message_tool_class or SendMessage)
+                tool_classes.extend(configured)
+                if not tool_classes:
+                    tool_classes.append(agency.send_message_tool_class or SendMessage)
 
                 try:
-                    if isinstance(effective_tool_class, Handoff) or (
-                        isinstance(effective_tool_class, type) and issubclass(effective_tool_class, Handoff)
-                    ):
-                        global _warned_deprecated_send_message_handoff
-                        if (
-                            not _warned_deprecated_send_message_handoff
-                            and isinstance(effective_tool_class, type)
-                            and issubclass(effective_tool_class, SendMessageHandoff)
+                    for effective_tool_class in tool_classes:
+                        if isinstance(effective_tool_class, Handoff) or (
+                            isinstance(effective_tool_class, type) and issubclass(effective_tool_class, Handoff)
                         ):
-                            warnings.warn(
-                                "SendMessageHandoff is deprecated; use Handoff instead.",
-                                DeprecationWarning,
-                                stacklevel=3,
-                            )
-                            _warned_deprecated_send_message_handoff = True
-                        handoff_instance = effective_tool_class().create_handoff(recipient_agent=recipient_agent)
-                        runtime_state.handoffs.append(handoff_instance)
-                        logger.debug(f"Added Handoff for {agent_name} -> {recipient_name}")
-                    else:
-                        # Register subagent with optional custom tool class
-                        if custom_tool_class:
-                            logger.debug(
-                                f"Using custom tool class {custom_tool_class.__name__} "
-                                f"for {agent_name} -> {recipient_name}"
-                            )
+                            global _warned_deprecated_send_message_handoff
+                            if (
+                                not _warned_deprecated_send_message_handoff
+                                and isinstance(effective_tool_class, type)
+                                and issubclass(effective_tool_class, SendMessageHandoff)
+                            ):
+                                warnings.warn(
+                                    "SendMessageHandoff is deprecated; use Handoff instead.",
+                                    DeprecationWarning,
+                                    stacklevel=3,
+                                )
+                                _warned_deprecated_send_message_handoff = True
 
-                        chosen_tool_class = effective_tool_class or SendMessage
-                        if not isinstance(chosen_tool_class, type) or not issubclass(chosen_tool_class, SendMessage):
-                            chosen_tool_class = SendMessage
+                            handoff_instance = effective_tool_class().create_handoff(recipient_agent=recipient_agent)
+                            runtime_state.handoffs.append(handoff_instance)
+                            logger.debug(f"Added Handoff for {agent_name} -> {recipient_name}")
+                        else:
+                            chosen_tool_class = effective_tool_class or SendMessage
+                            if not isinstance(chosen_tool_class, type) or not issubclass(
+                                chosen_tool_class, SendMessage
+                            ):
+                                chosen_tool_class = SendMessage
 
-                        agent_instance.register_subagent(
-                            recipient_agent,
-                            send_message_tool_class=chosen_tool_class,
-                            runtime_state=runtime_state,
-                        )
+                            agent_instance.register_subagent(
+                                recipient_agent,
+                                send_message_tool_class=chosen_tool_class,
+                                runtime_state=runtime_state,
+                            )
 
                 except Exception as e:
                     logger.error(

--- a/src/agency_swarm/agent/conversation_starters_cache.py
+++ b/src/agency_swarm/agent/conversation_starters_cache.py
@@ -519,11 +519,15 @@ def _runtime_tool_signatures(runtime_state: AgentRuntimeState | None) -> list[di
 def _handoff_signature(handoff: SDKHandoff) -> dict[str, Any]:
     schema = handoff.input_json_schema
     serialized_schema = _sanitize_mapping(schema) if isinstance(schema, dict) else _serialize_value(schema)
-    return {
+    signature = {
         "tool_name": handoff.tool_name,
         "agent_name": handoff.agent_name,
         "input_json_schema": serialized_schema,
     }
+    tool_class = getattr(handoff, "_agency_swarm_tool_class", None)
+    if tool_class is not None:
+        signature["tool_class"] = _serialize_value(tool_class)
+    return signature
 
 
 def _handoff_signatures(agent: Agent, runtime_state: AgentRuntimeState | None) -> list[dict[str, Any]]:

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -44,8 +44,12 @@ Streaming helpers moved to execution_streaming.py.
 TRACE_REGEX = re.compile(r"^trace_[a-f0-9]{32}$")
 
 
-def _handoff_identity(handoff: Any) -> tuple[Any, Any]:
-    return (getattr(handoff, "agent_name", None), getattr(handoff, "tool_name", None))
+def _handoff_identity(handoff: Any) -> tuple[Any, Any, Any]:
+    return (
+        getattr(handoff, "agent_name", None),
+        getattr(handoff, "tool_name", None),
+        getattr(handoff, "_agency_swarm_tool_class", None),
+    )
 
 
 async def perform_single_run(

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -44,6 +44,10 @@ Streaming helpers moved to execution_streaming.py.
 TRACE_REGEX = re.compile(r"^trace_[a-f0-9]{32}$")
 
 
+def _handoff_identity(handoff: Any) -> tuple[Any, Any]:
+    return (getattr(handoff, "agent_name", None), getattr(handoff, "tool_name", None))
+
+
 async def perform_single_run(
     *,
     agent: "Agent",
@@ -381,8 +385,8 @@ def setup_execution(
         agent._handoffs_restore = original_handoffs  # type: ignore[attr-defined]
 
     if runtime_state and getattr(runtime_state, "handoffs", None):
-        existing = {getattr(h, "agent_name", None) for h in original_handoffs}
-        additional = [h for h in runtime_state.handoffs if getattr(h, "agent_name", None) not in existing]
+        existing = {_handoff_identity(h) for h in original_handoffs}
+        additional = [h for h in runtime_state.handoffs if _handoff_identity(h) not in existing]
         agent.handoffs = original_handoffs + additional
 
     # Log the conversation context

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -26,6 +26,7 @@ from agency_swarm.agent.context_types import AgentRuntimeState
 from agency_swarm.context import MasterContext
 from agency_swarm.messages import MessageFormatter
 from agency_swarm.tools.mcp_manager import default_mcp_manager
+from agency_swarm.tools.send_message import Handoff
 
 from .execution_guardrails import append_guardrail_feedback, extract_guardrail_texts
 
@@ -48,7 +49,7 @@ def _handoff_identity(handoff: Any) -> tuple[Any, Any, Any]:
     return (
         getattr(handoff, "agent_name", None),
         getattr(handoff, "tool_name", None),
-        getattr(handoff, "_agency_swarm_tool_class", None),
+        getattr(handoff, "_agency_swarm_tool_class", Handoff),
     )
 
 

--- a/src/agency_swarm/agent/subagents.py
+++ b/src/agency_swarm/agent/subagents.py
@@ -76,14 +76,9 @@ def register_subagent(
     if runtime_state is not None:
         recipient_key = recipient_name.lower()
 
-        if recipient_key in runtime_state.subagents:
-            logger.warning(
-                f"Agent '{recipient_name}' is already registered as a subagent for '{agent.name}'. Skipping."
-            )
-            return
-
-        runtime_state.subagents[recipient_key] = recipient_agent
-        logger.info(f"Agent '{agent.name}' registered subagent: '{recipient_name}'")
+        if recipient_key not in runtime_state.subagents:
+            runtime_state.subagents[recipient_key] = recipient_agent
+            logger.info(f"Agent '{agent.name}' registered subagent: '{recipient_name}'")
 
         send_message_cls = _resolve_send_message_class(agent, send_message_tool_class)
         tool_key = send_message_cls.__name__

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -10,7 +10,7 @@ recipient details.
 import asyncio
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Literal, get_type_hints
+from typing import TYPE_CHECKING, Any, Literal, cast, get_type_hints
 
 from agents import (
     FunctionTool,
@@ -588,7 +588,7 @@ class Handoff:
 
         schema = strict_schema.ensure_strict_json_schema(InputArgs.model_json_schema())
         handoff_object.input_json_schema = schema
-        handoff_object._agency_swarm_tool_class = type(self)
+        cast(Any, handoff_object)._agency_swarm_tool_class = type(self)
 
         # Conditionally modify invoke function to include system message into context
         if self.add_reminder:

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -588,6 +588,7 @@ class Handoff:
 
         schema = strict_schema.ensure_strict_json_schema(InputArgs.model_json_schema())
         handoff_object.input_json_schema = schema
+        handoff_object._agency_swarm_tool_class = type(self)
 
         # Conditionally modify invoke function to include system message into context
         if self.add_reminder:

--- a/tests/test_agency_modules/test_agency_helpers.py
+++ b/tests/test_agency_modules/test_agency_helpers.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import agency_swarm
 from agency_swarm import Agency, Agent
 from agency_swarm.agency.helpers import run_fastapi as helpers_run_fastapi
-from agency_swarm.tools import SendMessage
+from agency_swarm.tools import Handoff, SendMessage
 
 
 class _BlockOptionalDepsFinder(importlib.abc.MetaPathFinder):
@@ -96,9 +96,34 @@ def test_run_fastapi_preserves_custom_tool_mappings(mocker):
     new_agency = factory()
 
     pair = ("A", "B")
-    assert new_agency._communication_tool_classes.get(pair) is CustomSendMessage, (
+    assert new_agency._communication_tool_classes.get(pair) == [CustomSendMessage], (
         "Custom tool mapping was not preserved"
     )
+
+
+def test_run_fastapi_preserves_default_and_custom_tool_mappings(mocker):
+    sender = Agent(name="A", instructions="test", model="gpt-5.4-mini")
+    recipient = Agent(name="B", instructions="test", model="gpt-5.4-mini")
+    agency = Agency(sender, recipient, communication_flows=[(sender, recipient), (sender, recipient, Handoff)])
+
+    captured = {}
+
+    def fake_run_fastapi(*, agencies=None, **kwargs):
+        captured["factory"] = agencies["agency"]
+        return None
+
+    mocker.patch("agency_swarm.integrations.fastapi.run_fastapi", side_effect=fake_run_fastapi)
+
+    helpers_run_fastapi(agency)
+    factory = captured["factory"]
+    new_agency = factory()
+
+    pair = ("A", "B")
+    runtime_state = new_agency.get_agent_runtime_state("A")
+    assert pair in new_agency._default_communication_tool_pairs
+    assert new_agency._communication_tool_classes.get(pair) == [Handoff]
+    assert "SendMessage" in runtime_state.send_message_tools
+    assert "transfer_to_B" in [handoff.tool_name for handoff in runtime_state.handoffs]
 
 
 def test_run_fastapi_normalizes_relative_shared_folders_for_factory_calls(mocker, tmp_path: Path):

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -40,6 +40,26 @@ class CustomHandoff(Handoff):
         return handoff
 
 
+class DefaultNamedCustomHandoff(Handoff):
+    """Handoff variant that keeps the default tool name."""
+
+    pass
+
+
+class OtherDefaultNamedCustomHandoff(Handoff):
+    """Second handoff variant that keeps the default tool name."""
+
+    pass
+
+
+class BrokenHandoff(Handoff):
+    """Handoff variant that fails while wiring."""
+
+    def create_handoff(self, recipient_agent: Agent) -> Any:
+        _ = recipient_agent
+        raise RuntimeError("broken handoff")
+
+
 # --- Agency Integration Tests ---
 
 
@@ -135,6 +155,47 @@ def test_runtime_handoff_variant_is_preserved_with_static_handoff() -> None:
         assert handoff_names == ["transfer_to_Agent2", "custom_transfer_to_Agent2"]
     finally:
         cleanup_execution(agent1, original_instructions, None, context, master_context)
+
+
+def test_same_name_handoff_variants_are_preserved_with_static_handoff() -> None:
+    """Test distinct handoff classes are preserved even when they share one tool name."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+    agent1.handoffs.append(Handoff().create_handoff(recipient_agent=agent2))
+
+    agency = Agency(
+        agent1,
+        communication_flows=[
+            (agent1, agent2, [DefaultNamedCustomHandoff, OtherDefaultNamedCustomHandoff]),
+        ],
+    )
+
+    context = agency.get_agent_context("Agent1")
+    master_context = prepare_master_context(agent1, None, context)
+    original_instructions = setup_execution(agent1, None, context, None)
+
+    try:
+        handoff_names = [handoff.tool_name for handoff in agent1.handoffs]
+        assert handoff_names == ["transfer_to_Agent2", "transfer_to_Agent2", "transfer_to_Agent2"]
+    finally:
+        cleanup_execution(agent1, original_instructions, None, context, master_context)
+
+
+def test_later_communication_tool_is_wired_after_handoff_failure() -> None:
+    """Test one broken tool class does not prevent later configured tools from wiring."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    agency = Agency(
+        agent1,
+        communication_flows=[
+            (agent1, agent2, [BrokenHandoff, CustomHandoff]),
+        ],
+    )
+
+    runtime_state = agency.get_agent_runtime_state("Agent1")
+    handoff_names = [handoff.tool_name for handoff in runtime_state.handoffs]
+    assert handoff_names == ["custom_transfer_to_Agent2"]
 
 
 def test_duplicate_communication_tool_class_is_rejected():

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -4,9 +4,12 @@ Unit tests for AgentFlow integration with Agency class.
 Tests the parsing and handling of AgentFlow objects in communication_flows.
 """
 
+from typing import Any
+
 import pytest
 
 from agency_swarm import Agency, Agent
+from agency_swarm.agent.execution_helpers import cleanup_execution, prepare_master_context, setup_execution
 from agency_swarm.tools.send_message import Handoff, SendMessage, SendMessageHandoff
 
 
@@ -26,6 +29,15 @@ class UnsupportedCommunicationTool:
     """Tool class outside the supported communication families."""
 
     pass
+
+
+class CustomHandoff(Handoff):
+    """Handoff variant with a distinct tool name."""
+
+    def create_handoff(self, recipient_agent: Agent) -> Any:
+        handoff = super().create_handoff(recipient_agent)
+        handoff.tool_name = f"custom_transfer_to_{recipient_agent.name.replace(' ', '_')}"
+        return handoff
 
 
 # --- Agency Integration Tests ---
@@ -99,6 +111,30 @@ def test_agent_pair_can_use_send_message_and_handoff():
 
     handoff_names = [handoff.tool_name for handoff in runtime_state.handoffs]
     assert "transfer_to_Agent2" in handoff_names
+
+
+def test_runtime_handoff_variant_is_preserved_with_static_handoff() -> None:
+    """Test runtime handoff variants are not dropped when a static handoff targets the same agent."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+    agent1.handoffs.append(Handoff().create_handoff(recipient_agent=agent2))
+
+    agency = Agency(
+        agent1,
+        communication_flows=[
+            (agent1, agent2, CustomHandoff),
+        ],
+    )
+
+    context = agency.get_agent_context("Agent1")
+    master_context = prepare_master_context(agent1, None, context)
+    original_instructions = setup_execution(agent1, None, context, None)
+
+    try:
+        handoff_names = [handoff.tool_name for handoff in agent1.handoffs]
+        assert handoff_names == ["transfer_to_Agent2", "custom_transfer_to_Agent2"]
+    finally:
+        cleanup_execution(agent1, original_instructions, None, context, master_context)
 
 
 def test_duplicate_communication_tool_class_is_rejected():

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -22,6 +22,12 @@ class OtherCustomSendMessage(SendMessage):
     pass
 
 
+class UnsupportedCommunicationTool:
+    """Tool class outside the supported communication families."""
+
+    pass
+
+
 # --- Agency Integration Tests ---
 
 
@@ -115,6 +121,20 @@ def test_duplicate_communication_tool_class_is_rejected():
             communication_flows=[
                 (agent1, agent2, CustomSendMessage),
                 (agent1, agent2, OtherCustomSendMessage),
+            ],
+        )
+
+
+def test_unsupported_communication_tool_class_is_rejected():
+    """Test that communication flows only accept supported tool families."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    with pytest.raises(TypeError, match="Expected a SendMessage or Handoff subclass"):
+        Agency(
+            agent1,
+            communication_flows=[
+                (agent1, agent2, [UnsupportedCommunicationTool, CustomSendMessage]),
             ],
         )
 

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -16,6 +16,12 @@ class CustomSendMessage(SendMessage):
     pass
 
 
+class OtherCustomSendMessage(SendMessage):
+    """Second custom send message tool for duplicate-family testing."""
+
+    pass
+
+
 # --- Agency Integration Tests ---
 
 
@@ -90,7 +96,7 @@ def test_agent_pair_can_use_send_message_and_handoff():
 
 
 def test_duplicate_communication_tool_class_is_rejected():
-    """Test that duplicate tool classes for the same pair are rejected."""
+    """Test that multiple SendMessage tools for the same pair are rejected."""
     agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
     agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
 
@@ -100,6 +106,15 @@ def test_duplicate_communication_tool_class_is_rejected():
             communication_flows=[
                 (agent1, agent2, SendMessage),
                 (agent1, agent2, SendMessage),
+            ],
+        )
+
+    with pytest.raises(ValueError, match="Each SendMessage tool for a pair can only be defined once"):
+        Agency(
+            agent1,
+            communication_flows=[
+                (agent1, agent2, CustomSendMessage),
+                (agent1, agent2, OtherCustomSendMessage),
             ],
         )
 

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -39,9 +39,9 @@ def test_agency_with_mixed_communication_flows():
 
     # Check tool mappings
     tool_mappings = agency._communication_tool_classes
-    assert tool_mappings[("Agent1", "Agent2")] == CustomSendMessage
-    assert tool_mappings[("Agent2", "Agent3")] == CustomSendMessage
-    assert tool_mappings[("Agent2", "Agent4")] == Handoff
+    assert tool_mappings[("Agent1", "Agent2")] == [CustomSendMessage]
+    assert tool_mappings[("Agent2", "Agent3")] == [CustomSendMessage]
+    assert tool_mappings[("Agent2", "Agent4")] == [Handoff]
 
 
 def test_agency_with_mixed_communication_flows_reverse():
@@ -61,8 +61,47 @@ def test_agency_with_mixed_communication_flows_reverse():
 
     # Check tool mappings
     tool_mappings = agency._communication_tool_classes
-    assert tool_mappings[("Agent1", "Agent2")] == CustomSendMessage
-    assert tool_mappings[("Agent2", "Agent3")] == CustomSendMessage
+    assert tool_mappings[("Agent1", "Agent2")] == [CustomSendMessage]
+    assert tool_mappings[("Agent2", "Agent3")] == [CustomSendMessage]
+
+
+def test_agent_pair_can_use_send_message_and_handoff():
+    """Test that one agent pair can expose both SendMessage and Handoff."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    agency = Agency(
+        agent1,
+        communication_flows=[
+            (agent1, agent2),
+            (agent1 > agent2, Handoff),
+        ],
+    )
+
+    assert agency._communication_tool_classes[("Agent1", "Agent2")] == [Handoff]
+    assert ("Agent1", "Agent2") in agency._default_communication_tool_pairs
+
+    runtime_state = agency.get_agent_runtime_state("Agent1")
+    assert "agent2" in runtime_state.subagents
+    assert "SendMessage" in runtime_state.send_message_tools
+
+    handoff_names = [handoff.tool_name for handoff in runtime_state.handoffs]
+    assert "transfer_to_Agent2" in handoff_names
+
+
+def test_duplicate_communication_tool_class_is_rejected():
+    """Test that duplicate tool classes for the same pair are rejected."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    with pytest.raises(ValueError, match="Duplicate communication tool class detected"):
+        Agency(
+            agent1,
+            communication_flows=[
+                (agent1, agent2, SendMessage),
+                (agent1, agent2, SendMessage),
+            ],
+        )
 
 
 def test_duplicate_flow_detection_with_chains():
@@ -71,7 +110,7 @@ def test_duplicate_flow_detection_with_chains():
     agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
     agent3 = Agent(name="Agent3", instructions="Test agent 3", model="gpt-5.4-mini")
 
-    with pytest.raises(ValueError, match="Duplicate communication flow detected"):
+    with pytest.raises(ValueError, match="Duplicate communication tool class detected"):
         Agency(
             agent1,
             communication_flows=[

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -139,6 +139,15 @@ def test_unsupported_communication_tool_class_is_rejected():
         )
 
 
+def test_empty_communication_tool_class_list_is_rejected():
+    """Test that an explicit empty tool class list is not treated as a default flow."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    with pytest.raises(ValueError, match="tool class list cannot be empty"):
+        Agency(agent1, communication_flows=[(agent1, agent2, [])])
+
+
 def test_duplicate_flow_detection_with_chains():
     """Test that duplicate flows are detected with AgentFlow chains."""
     agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -181,6 +181,30 @@ def test_same_name_handoff_variants_are_preserved_with_static_handoff() -> None:
         cleanup_execution(agent1, original_instructions, None, context, master_context)
 
 
+def test_same_base_handoff_is_deduplicated_with_static_handoff() -> None:
+    """Test the same base handoff is not duplicated when static and runtime sources overlap."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+    agent1.handoffs.append(Handoff().create_handoff(recipient_agent=agent2))
+
+    agency = Agency(
+        agent1,
+        communication_flows=[
+            (agent1, agent2, Handoff),
+        ],
+    )
+
+    context = agency.get_agent_context("Agent1")
+    master_context = prepare_master_context(agent1, None, context)
+    original_instructions = setup_execution(agent1, None, context, None)
+
+    try:
+        handoff_names = [handoff.tool_name for handoff in agent1.handoffs]
+        assert handoff_names == ["transfer_to_Agent2"]
+    finally:
+        cleanup_execution(agent1, original_instructions, None, context, master_context)
+
+
 def test_later_communication_tool_is_wired_after_handoff_failure() -> None:
     """Test one broken tool class does not prevent later configured tools from wiring."""
     agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from agency_swarm import Agency, Agent
+from agency_swarm.agent.context_types import AgentRuntimeState
 from agency_swarm.agent.execution_helpers import cleanup_execution, prepare_master_context, setup_execution
 from agency_swarm.tools.send_message import Handoff, SendMessage, SendMessageHandoff
 
@@ -131,6 +132,21 @@ def test_agent_pair_can_use_send_message_and_handoff():
 
     handoff_names = [handoff.tool_name for handoff in runtime_state.handoffs]
     assert "transfer_to_Agent2" in handoff_names
+
+
+def test_runtime_registration_keeps_multiple_send_message_tool_classes() -> None:
+    """Test runtime registration creates each requested SendMessage class for one recipient."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+    runtime_state = AgentRuntimeState()
+
+    agent1.register_subagent(agent2, send_message_tool_class=CustomSendMessage, runtime_state=runtime_state)
+    agent1.register_subagent(agent2, send_message_tool_class=OtherCustomSendMessage, runtime_state=runtime_state)
+
+    assert runtime_state.subagents == {"agent2": agent2}
+    assert set(runtime_state.send_message_tools) == {"CustomSendMessage", "OtherCustomSendMessage"}
+    assert isinstance(runtime_state.send_message_tools["CustomSendMessage"], CustomSendMessage)
+    assert isinstance(runtime_state.send_message_tools["OtherCustomSendMessage"], OtherCustomSendMessage)
 
 
 def test_runtime_handoff_variant_is_preserved_with_static_handoff() -> None:

--- a/tests/test_agent_modules/test_conversation_starters_cache.py
+++ b/tests/test_agent_modules/test_conversation_starters_cache.py
@@ -420,6 +420,30 @@ def test_starter_cache_fingerprint_changes_for_guardrails_runtime_tools_and_hand
     assert handoff_before != handoff_after
 
 
+def test_starter_cache_fingerprint_preserves_same_name_handoff_classes() -> None:
+    class FirstDefaultNamedHandoff(Handoff):
+        pass
+
+    class SecondDefaultNamedHandoff(Handoff):
+        pass
+
+    sender = Agent(name="HandoffSender", instructions="You are helpful.", model="gpt-5.4-mini")
+    recipient = Agent(name="HandoffRecipient", instructions="You are helpful.", model="gpt-5.4-mini")
+    runtime_state = AgentRuntimeState()
+
+    runtime_state.handoffs.append(FirstDefaultNamedHandoff().create_handoff(recipient))
+    first_fingerprint = compute_starter_cache_fingerprint(sender, runtime_state=runtime_state)
+
+    runtime_state.handoffs.append(SecondDefaultNamedHandoff().create_handoff(recipient))
+    second_fingerprint = compute_starter_cache_fingerprint(sender, runtime_state=runtime_state)
+
+    runtime_state.handoffs.append(FirstDefaultNamedHandoff().create_handoff(recipient))
+    duplicate_fingerprint = compute_starter_cache_fingerprint(sender, runtime_state=runtime_state)
+
+    assert first_fingerprint != second_fingerprint
+    assert second_fingerprint == duplicate_fingerprint
+
+
 class _StructuredOutput(BaseModel):
     answer: str
 


### PR DESCRIPTION
### Summary

Allow the same agent pair to expose both normal send-message communication and handoff communication. The parser now tracks default send-message pairs separately from custom handoff tools, rejects duplicate `SendMessage`-family tools for one pair, rejects unsupported communication tool classes, rejects empty explicit tool lists, preserves runtime handoff variants when a static handoff already targets the same recipient, deduplicates identical base handoffs, keeps multiple runtime send-message tool classes wired when registered, preserves handoff class identity in starter-cache signatures, and isolates per-tool setup failures so later valid tools still wire.

### Test plan

GitHub CI on head `7ef963b3`:

- `lint`: passed
- `typecheck`: passed
- `tests`: passed

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [x] I've made sure tests pass
