### PR TITLE
test: assert tool folder run items

### DIFF
--- a/tests/integration/tools/test_tools_folder_integration.py
+++ b/tests/integration/tools/test_tools_folder_integration.py
@@ -1,5 +1,7 @@
 import pytest
 from agents import ModelSettings, RunResult
+from agents.items import ToolCallItem, ToolCallOutputItem
+from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 
 from agency_swarm import Agent
 
@@ -36,9 +38,14 @@ def echo_tool(message: str) -> str:
     # Test real execution with OpenAI API
     result: RunResult = await agent.get_response("Use the echo tool to echo 'hello world'")
 
-    # Verify the tool was actually called and executed
-    # Check that both the tool output is present and 'hello world' is echoed
-    final_output_str = str(result.final_output)
-    assert "Tool executed: hello world" in final_output_str or (
-        "hello world" in final_output_str and "echo" in final_output_str.lower()
-    ), f"Expected tool execution or echo response not found in: {final_output_str}"
+    tool_call_names = [
+        item.raw_item.name
+        for item in result.new_items
+        if isinstance(item, ToolCallItem) and isinstance(item.raw_item, ResponseFunctionToolCall)
+    ]
+    assert "echo_tool" in tool_call_names, f"Expected echo_tool call in new_items, got: {tool_call_names}"
+
+    tool_outputs = [str(item.output) for item in result.new_items if isinstance(item, ToolCallOutputItem)]
+    assert any("Tool executed: hello world" in output for output in tool_outputs), (
+        f"Expected echo_tool output in new_items, got: {tool_outputs}"
+    )


### PR DESCRIPTION
## Summary
- assert the tools-folder integration test against RunResult.new_items tool-call evidence
- stop relying on final model prose, which can be a terse `hello world` even when the tool ran

## Checks
- uv run --python 3.13 ruff check tests/integration/tools/test_tools_folder_integration.py tests/test_agent_modules/test_agent_file_manager.py
- uv run --python 3.13 pytest tests/test_agent_modules/test_agent_file_manager.py -q
- UV_PYTHON=3.13 make check
- git diff --check origin/main...HEAD

## Note
The live tools-folder test needs OPENAI_API_KEY; the GitHub Actions test job is the credentialed proof path.