### PR TITLE
ci: route dependabot PRs around secret-backed tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,14 +64,14 @@ jobs:
         run: make sync
 
       - name: Run tests with coverage
-        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+        if: github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: make coverage
 
-      - name: Run unit tests for fork PRs
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+      - name: Run unit tests for PRs without secrets
+        if: github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.fork)
         run: uv run pytest tests/test_*_modules
 
   tests_py312:


### PR DESCRIPTION
## Summary
- route Dependabot PRs to the existing no-secret unit-test path used by fork PRs
- keep full `make coverage` for normal same-repo PRs and `main`

## Why
The current dependency PR CI runs fail before dependency-specific tests execute. The `tests` job is triggered with `Secret source: Dependabot`, but `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are blank, then `tests/integration/conftest.py` fails collection with `OPENAI_API_KEY not found in environment`.

Affected dependency PRs: #665, #666, #667, #668, #669.

## Verification
- Checked failed Dependabot CI logs for the shared missing-secret failure.
- Local shell execution is currently unavailable in this Codex environment, so local tests were not run.
