### PR TITLE
Polish provider-specific settings handling

### DIFF
--- a/src/agency_swarm/__init__.py
+++ b/src/agency_swarm/__init__.py
@@ -48,23 +48,15 @@ from agents import (  # noqa: E402
     trace,
 )
 
-# Optional: LitellmModel requires the litellm extra
-try:
-    from agents.extensions.models.litellm_model import LitellmModel  # noqa: E402, F401
-
-    _LITELLM_AVAILABLE = True
-except ImportError:
-    _LITELLM_AVAILABLE = False
-
-from .streaming.litellm_reasoning import patch_litellm_thinking_blocks  # noqa: E402
-
-patch_litellm_thinking_blocks()
-
 _JUPYTER_AVAILABLE = importlib.util.find_spec("jupyter_client") is not None
 _OPENCLAW_DEPS_AVAILABLE = (
     importlib.util.find_spec("fastapi") is not None and importlib.util.find_spec("httpx") is not None
 )
 _OPENCLAW_AGENT_DEPS_AVAILABLE = importlib.util.find_spec("httpx") is not None
+_LITELLM_EXPORT_AVAILABLE = (
+    importlib.util.find_spec("litellm") is not None
+    and importlib.util.find_spec("agents.extensions.models.litellm_model") is not None
+)
 
 from agents.model_settings import Headers, MCPToolChoice, ToolChoice  # noqa: E402
 from openai._types import Body, Query  # noqa: E402
@@ -219,9 +211,7 @@ if _OPENCLAW_DEPS_AVAILABLE:
     __all__.extend(sorted(_OPENCLAW_EXPORTS))
 if _OPENCLAW_AGENT_DEPS_AVAILABLE:
     __all__.append("OpenClawAgent")
-
-# Conditionally add LitellmModel if available
-if _LITELLM_AVAILABLE:
+if _LITELLM_EXPORT_AVAILABLE:
     __all__.append("LitellmModel")
 
 # Conditionally add IPythonInterpreter if available
@@ -231,12 +221,20 @@ if _JUPYTER_AVAILABLE:
 
 def __getattr__(name: str):
     """Provide helpful error messages for optional dependencies."""
-    if name == "LitellmModel" and not _LITELLM_AVAILABLE:
-        raise ImportError(
-            "`litellm` is required to use the LitellmModel. "
-            "You can install it via the optional dependency group: "
-            "`pip install 'openai-agents[litellm]'`."
-        )
+    if name == "LitellmModel":
+        try:
+            from agents.extensions.models.litellm_model import LitellmModel
+        except ImportError as exc:
+            raise ImportError(
+                "`litellm` is required to use the LitellmModel. "
+                "You can install it via the optional dependency group: "
+                "`pip install 'agency-swarm[litellm]'`."
+            ) from exc
+        from .streaming.litellm_reasoning import patch_litellm_thinking_blocks
+
+        patch_litellm_thinking_blocks()
+        globals()[name] = LitellmModel
+        return LitellmModel
     if name == "IPythonInterpreter":
         from .tools import IPythonInterpreter
 

--- a/src/agency_swarm/agent/initialization.py
+++ b/src/agency_swarm/agent/initialization.py
@@ -35,6 +35,23 @@ _INPUT_GUARDRAIL_WRAPPED_ATTR = "_agency_swarm_input_guardrail_wrapped"
 _FRAMEWORK_DEFAULT_MODEL_SETTINGS = ModelSettings(truncation="auto", include_usage=True)
 
 
+def _patch_litellm_thinking_blocks_for_model(model: Any) -> None:
+    if not _is_litellm_model(model):
+        return
+    from agency_swarm.streaming.litellm_reasoning import patch_litellm_thinking_blocks
+
+    patch_litellm_thinking_blocks()
+
+
+def _is_litellm_model(model: Any) -> bool:
+    if isinstance(model, str):
+        return model.startswith("litellm/")
+    return any(
+        cls.__module__ == "agents.extensions.models.litellm_model" and cls.__name__ == "LitellmModel"
+        for cls in type(model).__mro__
+    )
+
+
 def _get_framework_default_model_settings(model: str | None = None) -> ModelSettings:
     """Get SDK defaults for a model and layer Agency Swarm defaults on top."""
     base = get_sdk_default_model_settings(model)
@@ -133,6 +150,7 @@ def apply_framework_defaults(kwargs: dict[str, Any]) -> None:
         kwargs: The initialization keyword arguments (modified in place)
     """
     model_arg = kwargs.get("model")
+    _patch_litellm_thinking_blocks_for_model(model_arg)
     model_name = get_default_settings_model_name(model_arg)
     base_defaults = _get_framework_default_model_settings(model_name)
 

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1212,17 +1212,22 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
 
     reasoning_effort = extra_args.get("reasoning_effort")
     reasoning_summary = extra_args.get("reasoning_summary")
-    litellm_model_name = _litellm_model_name(agent)
-    is_litellm_gemini = litellm_model_name.startswith(("google/", "gemini/", "vertex_ai/"))
-    if litellm_model_name.startswith("anthropic/"):
+    uses_litellm = _agent_uses_litellm(agent)
+    model_name = _request_model_name(agent)
+    litellm_model_name = _normalize_litellm_model_name(model_name).lower() if uses_litellm else ""
+    variant_model_name = litellm_model_name or model_name.lower()
+    has_anthropic_thinking_budget = False
+    is_gemini = variant_model_name.startswith(("google/", "gemini/", "vertex_ai/"))
+    if variant_model_name.startswith("anthropic/"):
         _normalize_anthropic_litellm_variant_args(extra_args)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = extra_args.get("reasoning_summary")
-    elif litellm_model_name.startswith("xai/"):
-        _normalize_xai_litellm_variant_args(extra_args, litellm_model_name)
+        has_anthropic_thinking_budget = _has_enabled_thinking_budget(extra_args)
+    elif variant_model_name.startswith("xai/"):
+        _normalize_xai_litellm_variant_args(extra_args, variant_model_name)
         reasoning_effort = extra_args.get("reasoning_effort")
         reasoning_summary = extra_args.get("reasoning_summary")
-    elif is_litellm_gemini:
+    elif is_gemini:
         requested_reasoning_summary = reasoning_summary
         _normalize_gemini_litellm_variant_args(extra_args)
         reasoning_effort = extra_args.get("reasoning_effort")
@@ -1230,8 +1235,9 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
 
     normalized_effort = _reasoning_effort_value(reasoning_effort)
     normalized_summary = _reasoning_summary_value(reasoning_summary)
-    uses_litellm = _agent_uses_litellm(agent)
     is_litellm_openai = uses_litellm and _is_openai_model_name(litellm_model_name)
+    if normalized_effort is None and reasoning_effort is None and has_anthropic_thinking_budget:
+        normalized_effort = "high"
     if normalized_effort is not None and is_litellm_openai:
         current.reasoning = None
         if normalized_summary is not None:
@@ -1244,11 +1250,19 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
     ):
         current.reasoning = Reasoning(
             effort=normalized_effort,
-            summary=normalized_summary,
+            summary=None if uses_litellm else normalized_summary,
         )
-        if not uses_litellm or is_litellm_gemini:
+        if not uses_litellm or is_gemini:
             extra_args.pop("reasoning_effort", None)
             extra_args.pop("reasoning_summary", None)
+    elif normalized_effort is not None and uses_litellm:
+        current.reasoning = None
+    elif normalized_summary is not None and not uses_litellm:
+        current.reasoning = Reasoning(
+            effort=current.reasoning.effort if current.reasoning is not None else None,
+            summary=normalized_summary,
+        )
+        extra_args.pop("reasoning_summary", None)
     elif isinstance(extra_args.get("reasoning"), dict) and not uses_litellm:
         raw_reasoning = cast(dict[str, Any], extra_args.pop("reasoning"))
         effort = raw_reasoning.get("effort")
@@ -1260,12 +1274,66 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
                 effort=normalized_effort,
                 summary=normalized_summary,
             )
-    elif isinstance(reasoning_summary, str) and isinstance(reasoning_effort, dict):
+    elif isinstance(reasoning_summary, str) and isinstance(reasoning_effort, dict) and not uses_litellm:
         reasoning_effort.setdefault("summary", reasoning_summary)
         extra_args.pop("reasoning_summary", None)
+    elif uses_litellm:
+        extra_args.pop("reasoning_summary", None)
+
+    if _is_gateway_provider_variant(uses_litellm, variant_model_name):
+        _move_gateway_variant_extra_args(extra_args)
+
+    extra_body = extra_args.pop("extra_body", None)
+    if isinstance(extra_body, dict):
+        current_body = current.extra_body if isinstance(current.extra_body, dict) else {}
+        current.extra_body = {
+            **current_body,
+            **extra_body,
+        }
 
     current.extra_args = extra_args or None
     agent.model_settings = current
+
+
+def _request_model_name(agent: Agent) -> str:
+    model = agent.model
+    if isinstance(model, str):
+        name = model
+    elif isinstance(model, OpenAIResponsesModel | OpenAIChatCompletionsModel):
+        name = model.model
+    elif _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
+        name = model.model
+    elif isinstance(model, Model):
+        name = getattr(model, "model", "")
+    else:
+        name = ""
+    return name if isinstance(name, str) else ""
+
+
+def _is_gateway_provider_variant(uses_litellm: bool, model_name: str) -> bool:
+    if uses_litellm or "/" not in model_name:
+        return False
+    return not model_name.startswith(("openai/", "azure/", "azure_ai/"))
+
+
+def _move_gateway_variant_extra_args(extra_args: dict[str, Any]) -> None:
+    provider_keys = {
+        "effort",
+        "includeThoughts",
+        "reasoning_effort",
+        "reasoning_summary",
+        "thinking",
+        "thinkingBudget",
+        "thinkingConfig",
+        "thinkingLevel",
+    }
+    body = extra_args.pop("extra_body", None)
+    extra_body = dict(body) if isinstance(body, dict) else {}
+    for key in provider_keys:
+        if key in extra_args:
+            extra_body[key] = extra_args.pop(key)
+    if extra_body:
+        extra_args["extra_body"] = extra_body
 
 
 def _reasoning_effort_value(value: Any) -> ReasoningEffortValue | None:
@@ -1353,6 +1421,13 @@ def _normalize_thinking_budget_tokens(extra_args: dict[str, Any]) -> None:
         normalized["budget_tokens"] = budget_tokens
         normalized.pop("budgetTokens", None)
         extra_args["thinking"] = normalized
+
+
+def _has_enabled_thinking_budget(extra_args: dict[str, Any]) -> bool:
+    thinking = extra_args.get("thinking")
+    if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+        return False
+    return isinstance(thinking.get("budget_tokens"), int)
 
 
 def _litellm_model_name(agent: Agent) -> str:
@@ -1655,8 +1730,9 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
     elif _LITELLM_AVAILABLE and LitellmModel is not None and isinstance(model, LitellmModel):
         if has_litellm_overrides:
             # Preserve existing settings unless explicitly overridden.
-            base_url = _resolve_litellm_base_url(model.model, config, existing_base_url=model.base_url)
-            api_key = _resolve_litellm_api_key(model.model, config, existing_api_key=model.api_key)
+            resolved_model = _normalize_litellm_model_name(model.model)
+            base_url = _resolve_litellm_base_url(resolved_model, config, existing_base_url=model.base_url)
+            api_key = _resolve_litellm_api_key(resolved_model, config, existing_api_key=model.api_key)
             agent.model = LitellmModel(model=model.model, base_url=base_url, api_key=api_key)
     elif isinstance(model, Model):
         # For other Model types, try to extract and wrap with OpenAIResponsesModel

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -1203,19 +1203,21 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
     extra_args = dict(current.extra_args or {})
     extra_args.update(config.model_settings_extra_args)
 
-    include = extra_args.pop("include", None)
-    if isinstance(include, list) and not _agent_uses_litellm(agent):
-        existing_include = list(current.response_include or [])
-        current.response_include = [*existing_include, *include]
-    elif include is not None:
-        extra_args["include"] = include
-
-    reasoning_effort = extra_args.get("reasoning_effort")
-    reasoning_summary = extra_args.get("reasoning_summary")
     uses_litellm = _agent_uses_litellm(agent)
     model_name = _request_model_name(agent)
     litellm_model_name = _normalize_litellm_model_name(model_name).lower() if uses_litellm else ""
     variant_model_name = litellm_model_name or model_name.lower()
+    is_gateway_provider_variant = _is_gateway_provider_variant(uses_litellm, variant_model_name)
+
+    include = extra_args.pop("include", None)
+    if isinstance(include, list) and not uses_litellm and not is_gateway_provider_variant:
+        existing_include = list(current.response_include or [])
+        current.response_include = [*existing_include, *include]
+    elif include is not None and not is_gateway_provider_variant:
+        extra_args["include"] = include
+
+    reasoning_effort = extra_args.get("reasoning_effort")
+    reasoning_summary = extra_args.get("reasoning_summary")
     has_anthropic_thinking_budget = False
     is_gemini = variant_model_name.startswith(("google/", "gemini/", "vertex_ai/"))
     if variant_model_name.startswith("anthropic/"):
@@ -1280,7 +1282,7 @@ def _apply_request_model_settings_extra_args(agent: Agent, config: ClientConfig)
     elif uses_litellm:
         extra_args.pop("reasoning_summary", None)
 
-    if _is_gateway_provider_variant(uses_litellm, variant_model_name):
+    if is_gateway_provider_variant:
         _move_gateway_variant_extra_args(extra_args)
 
     extra_body = extra_args.pop("extra_body", None)

--- a/src/agency_swarm/streaming/litellm_reasoning.py
+++ b/src/agency_swarm/streaming/litellm_reasoning.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from inspect import signature
 from typing import Any
 
 
@@ -16,16 +17,22 @@ def patch_litellm_thinking_blocks() -> None:
         return
 
     original = handler_cls.handle_stream.__func__
+    forwards_strict_feature_validation = "strict_feature_validation" in signature(original).parameters
 
     async def handle_stream(
-        cls, response: Any, stream: AsyncIterator[Any], model: str | None = None
+        cls,
+        response: Any,
+        stream: AsyncIterator[Any],
+        model: str | None = None,
+        strict_feature_validation: bool = False,
     ) -> AsyncIterator[Any]:
         async def normalized_stream() -> AsyncIterator[Any]:
             async for chunk in stream:
                 _copy_thinking_blocks_to_reasoning_content(chunk)
                 yield chunk
 
-        async for event in original(cls, response, normalized_stream(), model):
+        kwargs = {"strict_feature_validation": strict_feature_validation} if forwards_strict_feature_validation else {}
+        async for event in original(cls, response, normalized_stream(), model, **kwargs):
             yield event
 
     handler_cls.handle_stream = classmethod(handle_stream)
@@ -41,7 +48,7 @@ def _copy_thinking_blocks_to_reasoning_content(chunk: Any) -> None:
         delta = getattr(choice, "delta", None)
         if delta is None:
             continue
-        if getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None):
+        if getattr(delta, "reasoning_content", None):
             continue
 
         text = (

--- a/tests/test_agency_modules/test_package_init_lazy_litellm.py
+++ b/tests/test_agency_modules/test_package_init_lazy_litellm.py
@@ -1,0 +1,113 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run_inline(code: str) -> str:
+    repo_src = Path(__file__).resolve().parents[2] / "src"
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{repo_src}{os.pathsep}{existing}" if existing else str(repo_src)
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result.stdout.strip()
+
+
+def _result_lines(output: str) -> list[str]:
+    return [line.removeprefix("RESULT ") for line in output.splitlines() if line.startswith("RESULT ")]
+
+
+def test_import_agency_swarm_does_not_eager_import_litellm_when_installed() -> None:
+    output = _run_inline(
+        "import importlib.util, sys; "
+        "print('RESULT', importlib.util.find_spec('litellm') is not None); "
+        "import agency_swarm; "
+        "print('RESULT', 'litellm' in sys.modules); "
+        "print('RESULT', 'agents.extensions.models.litellm_model' in sys.modules); "
+        "print('RESULT', 'agency_swarm.streaming.litellm_reasoning' in sys.modules); "
+        "print('RESULT', 'LitellmModel' in agency_swarm.__all__)"
+    )
+    lines = _result_lines(output)
+    if lines[0] == "False":
+        pytest.skip("litellm is not installed")
+    assert lines == ["True", "False", "False", "False", "True"]
+
+
+def test_litellm_model_export_loads_and_patches_lazily() -> None:
+    output = _run_inline(
+        """
+import importlib.util
+import sys
+
+available = importlib.util.find_spec("litellm") is not None
+print("RESULT", available)
+import agency_swarm
+
+print("RESULT", "agents.extensions.models.litellm_model" in sys.modules)
+if available:
+    model = agency_swarm.LitellmModel
+    from agents.extensions.models.litellm_model import ChatCmplStreamHandler, LitellmModel
+
+    print("RESULT", model is LitellmModel)
+    print("RESULT", getattr(ChatCmplStreamHandler, "_agency_swarm_thinking_patch", False))
+"""
+    )
+    lines = _result_lines(output)
+    if lines[0] == "False":
+        pytest.skip("litellm is not installed")
+    assert lines == ["True", "False", "True", "True"]
+
+
+def test_package_star_import_includes_litellm_model_when_installed() -> None:
+    output = _run_inline(
+        """
+import importlib.util
+
+available = importlib.util.find_spec("litellm") is not None
+print("RESULT", available)
+if available:
+    exported = {}
+    exec("from agency_swarm import *", exported)
+    from agents.extensions.models.litellm_model import ChatCmplStreamHandler, LitellmModel
+
+    print("RESULT", exported["LitellmModel"] is LitellmModel)
+    print("RESULT", getattr(ChatCmplStreamHandler, "_agency_swarm_thinking_patch", False))
+"""
+    )
+    lines = _result_lines(output)
+    if lines[0] == "False":
+        pytest.skip("litellm is not installed")
+    assert lines == ["True", "True", "True"]
+
+
+def test_agent_with_sdk_litellm_model_patches_when_model_is_used() -> None:
+    output = _run_inline(
+        """
+import importlib.util
+import sys
+
+available = importlib.util.find_spec("litellm") is not None
+print("RESULT", available)
+import agency_swarm
+
+print("RESULT", "agents.extensions.models.litellm_model" in sys.modules)
+if available:
+    from agents.extensions.models.litellm_model import ChatCmplStreamHandler, LitellmModel
+
+    print("RESULT", getattr(ChatCmplStreamHandler, "_agency_swarm_thinking_patch", False))
+    agency_swarm.Agent(name="A", instructions="x", model=LitellmModel(model="openai/gpt-4o-mini"))
+    print("RESULT", getattr(ChatCmplStreamHandler, "_agency_swarm_thinking_patch", False))
+"""
+    )
+    lines = _result_lines(output)
+    if lines[0] == "False":
+        pytest.skip("litellm is not installed")
+    assert lines == ["True", "False", "False", "True"]

--- a/tests/test_agent_modules/test_litellm_reasoning_patch.py
+++ b/tests/test_agent_modules/test_litellm_reasoning_patch.py
@@ -9,7 +9,8 @@ async def test_litellm_thinking_blocks_emit_reasoning_events() -> None:
     """LiteLLM thinking_blocks should be visible as reasoning stream deltas."""
     pytest.importorskip("agents.extensions.models.litellm_model")
 
-    importlib.import_module("agency_swarm")
+    patch = importlib.import_module("agency_swarm.streaming.litellm_reasoning")
+    patch.patch_litellm_thinking_blocks()
     from agents.extensions.models.litellm_model import ChatCmplStreamHandler
     from openai.types.responses import Response
 
@@ -62,7 +63,8 @@ async def test_litellm_model_extra_reasoning_content_emits_reasoning_events() ->
     """Gemini can expose reasoning fields through provider/model extras instead of attributes."""
     pytest.importorskip("agents.extensions.models.litellm_model")
 
-    importlib.import_module("agency_swarm")
+    patch = importlib.import_module("agency_swarm.streaming.litellm_reasoning")
+    patch.patch_litellm_thinking_blocks()
     from agents.extensions.models.litellm_model import ChatCmplStreamHandler
     from openai.types.responses import Response
 
@@ -108,3 +110,104 @@ async def test_litellm_model_extra_reasoning_content_emits_reasoning_events() ->
         event.delta for event in events if getattr(event, "type", "") == "response.reasoning_summary_text.delta"
     ]
     assert reasoning_deltas == ["Check Gemini thought."]
+
+
+@pytest.mark.asyncio
+async def test_litellm_reasoning_field_emits_reasoning_events() -> None:
+    """LiteLLM reasoning fields should be visible as reasoning stream deltas."""
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    patch = importlib.import_module("agency_swarm.streaming.litellm_reasoning")
+    patch.patch_litellm_thinking_blocks()
+    from agents.extensions.models.litellm_model import ChatCmplStreamHandler
+    from openai.types.responses import Response
+
+    async def stream():
+        yield SimpleNamespace(
+            id="chatcmpl_1",
+            model="xai/grok-code-fast",
+            usage=None,
+            choices=[
+                SimpleNamespace(
+                    logprobs=None,
+                    delta=SimpleNamespace(
+                        content=None,
+                        refusal=None,
+                        tool_calls=None,
+                        reasoning="Check xAI thought.",
+                    ),
+                )
+            ],
+        )
+
+    response = Response(
+        id="resp_1",
+        created_at=0.0,
+        model="xai/grok-code-fast",
+        object="response",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    events = [
+        event
+        async for event in ChatCmplStreamHandler.handle_stream(
+            response,
+            stream(),
+            "xai/grok-code-fast",
+        )
+    ]
+
+    reasoning_deltas = [
+        event.delta for event in events if getattr(event, "type", "") == "response.reasoning_summary_text.delta"
+    ]
+    assert reasoning_deltas == ["Check xAI thought."]
+
+
+@pytest.mark.asyncio
+async def test_litellm_stream_patch_forwards_strict_feature_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wrapper should preserve newer Agents SDK stream-handler keyword args."""
+    litellm_model = pytest.importorskip("agents.extensions.models.litellm_model")
+    patch = importlib.import_module("agency_swarm.streaming.litellm_reasoning")
+    seen: dict[str, object] = {}
+    chunk = SimpleNamespace(choices=[])
+
+    class Handler:
+        @classmethod
+        async def handle_stream(
+            cls,
+            response,
+            stream,
+            model=None,
+            strict_feature_validation: bool = False,
+        ):
+            seen["response"] = response
+            seen["model"] = model
+            seen["strict_feature_validation"] = strict_feature_validation
+            async for item in stream:
+                yield item
+
+    monkeypatch.setattr(litellm_model, "ChatCmplStreamHandler", Handler)
+    patch.patch_litellm_thinking_blocks()
+
+    async def stream():
+        yield chunk
+
+    events = [
+        event
+        async for event in Handler.handle_stream(
+            "response",
+            stream(),
+            "model",
+            strict_feature_validation=True,
+        )
+    ]
+
+    assert events == [chunk]
+    assert seen == {
+        "response": "response",
+        "model": "model",
+        "strict_feature_validation": True,
+    }

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -847,6 +847,7 @@ def test_gateway_provider_model_override_moves_provider_variant_args_to_extra_bo
             api_key="sk-gateway",
             base_url="https://gateway.example/v1",
             model_settings_extra_args={
+                "include": ["reasoning.encrypted_content"],
                 "thinking": {"type": "enabled", "budgetTokens": 16000},
                 "effort": "high",
             },
@@ -857,6 +858,7 @@ def test_gateway_provider_model_override_moves_provider_variant_args_to_extra_bo
     assert isinstance(agent.model._client, AsyncOpenAI)
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
+    assert agent.model_settings.response_include is None
     assert agent.model_settings.extra_body == {"thinking": {"type": "enabled", "budget_tokens": 16000}}
     assert agent.model_settings.extra_args is None
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -229,6 +229,32 @@ def test_litellm_anthropic_does_not_use_codex_base_url_fallback() -> None:
     assert agent.model.api_key == "sk-ant"
 
 
+def test_litellm_google_wrapper_uses_gemini_request_key() -> None:
+    """Existing Google Gemini LiteLLM wrappers should resolve keys against Gemini."""
+    pytest.importorskip("agents")
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents.extensions.models.litellm_model import LitellmModel
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    class _Agency:
+        def __init__(self, agent: Agent):
+            self.agents = {"A": agent}
+
+    original_model = LitellmModel(model="google/gemini-2.5-pro", base_url=None, api_key=None)
+    agent = Agent(name="A", instructions="x", model=original_model)
+    agency = _Agency(agent)
+
+    apply_openai_client_config(agency, ClientConfig(litellm_keys={"gemini": "AIza-request"}))
+
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model.model == "google/gemini-2.5-pro"
+    assert agent.model.api_key == "AIza-request"
+
+
 def test_litellm_openai_provider_can_use_generic_api_key_fallback() -> None:
     """For openai-ish LiteLLM providers, config.api_key remains a valid fallback."""
     pytest.importorskip("agents")
@@ -601,8 +627,8 @@ async def test_litellm_gemini_budget_forwards_only_thinking_payload(monkeypatch)
     assert seen["reasoning_effort"] is None
 
 
-async def test_litellm_anthropic_variant_preserves_reasoning_for_tool_replay(monkeypatch) -> None:
-    """Anthropic thinking variants should replay signed thinking blocks across tool calls."""
+async def test_litellm_anthropic_budget_variant_preserves_reasoning_for_tool_replay(monkeypatch) -> None:
+    """Anthropic budget-only thinking variants should replay signed thinking blocks across tool calls."""
     pytest.importorskip("agents")
     litellm = pytest.importorskip("litellm")
     pytest.importorskip("agents.extensions.models.litellm_model")
@@ -631,8 +657,7 @@ async def test_litellm_anthropic_variant_preserves_reasoning_for_tool_replay(mon
         ClientConfig(
             model="litellm/anthropic/claude-sonnet-4-6",
             model_settings_extra_args={
-                "thinking": {"type": "adaptive"},
-                "effort": "high",
+                "thinking": {"type": "enabled", "budgetTokens": 16000},
             },
         ),
     )
@@ -640,6 +665,7 @@ async def test_litellm_anthropic_variant_preserves_reasoning_for_tool_replay(mon
     assert isinstance(agent.model, LitellmModel)
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
+    assert agent.model_settings.extra_args == {"thinking": {"type": "enabled", "budget_tokens": 16000}}
 
     await agent.model._fetch_response(
         None,
@@ -671,7 +697,7 @@ async def test_litellm_anthropic_variant_preserves_reasoning_for_tool_replay(mon
     )
 
     assert seen["reasoning_effort"] == "high"
-    assert seen["thinking"] == {"type": "adaptive"}
+    assert seen["thinking"] == {"type": "enabled", "budget_tokens": 16000}
     messages = seen["messages"]
     assert isinstance(messages, list)
     assistant = messages[0]
@@ -710,7 +736,7 @@ def test_litellm_gemini_variant_maps_top_level_thinking_level() -> None:
     assert agent.model.model == "gemini/gemini-3.5-flash"
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
-    assert agent.model_settings.reasoning.summary == "auto"
+    assert agent.model_settings.reasoning.summary is None
     assert agent.model_settings.extra_args is None
 
 
@@ -737,6 +763,101 @@ def test_openai_model_override_applies_explicit_variant_reasoning() -> None:
     assert agent.model_settings.reasoning is not None
     assert agent.model_settings.reasoning.effort == "high"
     assert agent.model_settings.reasoning.summary == "auto"
+    assert agent.model_settings.extra_args is None
+
+
+def test_openai_model_override_applies_summary_without_effort() -> None:
+    """OpenAI summary-only variants should not forward raw reasoning_summary."""
+    pytest.importorskip("agents")
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    control = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    control_agency = type("Agency", (), {"agents": {"A": control}})()
+    apply_openai_client_config(control_agency, ClientConfig(model="gpt-5"))
+    default_effort = control.model_settings.reasoning.effort if control.model_settings.reasoning is not None else None
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="gpt-5",
+            model_settings_extra_args={"reasoning_summary": "auto"},
+        ),
+    )
+
+    assert agent.model == "gpt-5"
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == default_effort
+    assert agent.model_settings.reasoning.summary == "auto"
+    assert agent.model_settings.extra_args is None
+
+
+def test_litellm_extra_arg_reasoning_effort_clears_stale_reasoning() -> None:
+    """LiteLLM extra-arg providers should not keep stale template reasoning."""
+    pytest.importorskip("agents.extensions.models.litellm_model")
+
+    from agents import ModelSettings
+    from agents.extensions.models.litellm_model import LitellmModel
+    from openai.types.shared import Reasoning
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(
+        name="A",
+        instructions="x",
+        model=LitellmModel(model="xai/grok-code-fast"),
+        model_settings=ModelSettings(reasoning=Reasoning(effort="low")),
+    )
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(model_settings_extra_args={"reasoning_effort": "high"}),
+    )
+
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args == {"reasoning_effort": "high"}
+
+
+def test_gateway_provider_model_override_moves_provider_variant_args_to_extra_body() -> None:
+    """Gateway-routed provider models should not leak provider args as OpenAI kwargs."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIResponsesModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    agent = Agent(name="A", instructions="x", model="gpt-4o-mini")
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="anthropic/claude-sonnet-4-6",
+            api_key="sk-gateway",
+            base_url="https://gateway.example/v1",
+            model_settings_extra_args={
+                "thinking": {"type": "enabled", "budgetTokens": 16000},
+                "effort": "high",
+            },
+        ),
+    )
+
+    assert isinstance(agent.model, OpenAIResponsesModel)
+    assert isinstance(agent.model._client, AsyncOpenAI)
+    assert agent.model_settings.reasoning is not None
+    assert agent.model_settings.reasoning.effort == "high"
+    assert agent.model_settings.extra_body == {"thinking": {"type": "enabled", "budget_tokens": 16000}}
     assert agent.model_settings.extra_args is None
 
 
@@ -845,6 +966,7 @@ async def test_litellm_openai_variant_forwards_reasoning_summary_to_litellm(monk
     )
 
     assert seen["reasoning_effort"] == {"effort": "high", "summary": "auto"}
+    assert "reasoning_summary" not in seen
 
 
 def test_litellm_prefixed_string_model_normalizes_variant_extra_args_without_model_override() -> None:


### PR DESCRIPTION
### Summary

- Keeps gateway include values out of response settings while preserving provider-specific settings.
- Keeps LiteLLM imports lazy and covers provider reasoning/settings behavior with focused tests.

### Test plan

- Focused provider settings and LiteLLM reasoning tests pass locally.
- Focused Ruff format and lint checks pass on the changed files.
- The patch diff has no whitespace errors and merges cleanly into `feat/provider-specific-settings`.

### Issue number

Related to #654

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [x] I've made sure tests pass
