### PR TITLE
refactor: deprecate agency user context

### DIFF
--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -4,15 +4,15 @@ description: "Sharing data and state across tools and agents using agency contex
 icon: "database"
 ---
 
-`Agency Context` is a centralized data store accessible by all tools and agents within an agency. It allows you to share data between agents, control execution flow, and maintain state across tool calls without passing large data structures in messages.
+`Agency Context` is run-scoped data stored on `MasterContext`. It lets tools and agents share structured data during a run without putting that data in messages.
 
 <Note>
-Agency context is available when tools are deployed together with agents. If tools are deployed as separate APIs, they won't share the same context, and you'll need to implement your own state management solution.
+Agency context lives in the `MasterContext` for a run. Keep session state outside the `Agency` instance and pass it into each call with `context_override`.
 </Note>
 
 ## Understanding Agency Context
 
-Agency context is particularly useful when your agents interact with multiple tools that need to exchange information. Here's why:
+Agency context is useful when your agents interact with multiple tools that need to exchange information. Here's why:
 
 - **Without Agency Context**: Suppose `Tool A` collects data that `Tool B` needs. The agent must explicitly pass this data as a parameter to `Tool B`, consuming tokens and potentially hitting message limits.
 
@@ -115,7 +115,7 @@ In this example, calling the Query Database tool stores database context, which 
 ## Advanced Agency Context Patterns
 
 ### Complex Data Structures
-Agency context can store any Python object, making it perfect for complex workflows:
+Agency context can store any Python object, making it useful for complex workflows:
 
 ```python
 @function_tool
@@ -182,22 +182,31 @@ async def step_2_data_processing(ctx: RunContextWrapper[MasterContext]) -> str:
 ```
 
 ### Session Management
-Agency context is perfect for maintaining session state:
+Keep session state outside the agency and pass it into each run:
 
 ```python
-# Initialize agency with session context
-agency = Agency(
-    entry_agent,
-    communication_flows=[(entry_agent, worker_agent)],
-    user_context={
-        'session_id': 'user_123',
-        'user_preferences': {
-            'language': 'en',
-            'timezone': 'UTC',
-            'risk_tolerance': 'moderate'
-        },
-        'session_start': datetime.now().isoformat()
-    }
+agency = Agency(entry_agent, communication_flows=[(entry_agent, worker_agent)])
+
+session_context = {
+    'session_id': 'user_123',
+    'user_preferences': {
+        'language': 'en',
+        'timezone': 'UTC',
+        'risk_tolerance': 'moderate'
+    },
+    'session_start': datetime.now().isoformat()
+}
+
+response = await agency.get_response(
+    "Analyze my portfolio.",
+    context_override=session_context,
+)
+
+# Carry tool changes into the next turn without storing state on the agency.
+session_context = response.context_wrapper.context.user_context
+next_response = await agency.get_response(
+    "Use the same preferences for the next analysis.",
+    context_override=session_context,
 )
 ```
 
@@ -229,7 +238,7 @@ risk_level = ctx.context.get('risk_tolerance')
 ```
 
 ### Clean Up Unneeded Data
-For long-running sessions, clean up temporary data to avoid memory issues:
+For long-running sessions, clean up temporary data before carrying the context into the next run:
 
 ```python
 @function_tool
@@ -278,4 +287,4 @@ For a full example showing agency context in action, see the [Agency Context Wor
 - Workflow coordination
 - Context monitoring and debugging
 
-Agency context eliminates the need for complex parameter passing and enables multi-agent workflows while maintaining clean separation of concerns.
+Agency context eliminates complex parameter passing during a run while keeping session state separate from the agency definition.

--- a/docs/additional-features/agency-context.mdx
+++ b/docs/additional-features/agency-context.mdx
@@ -202,7 +202,7 @@ response = await agency.get_response(
     context_override=session_context,
 )
 
-# Carry tool changes into the next turn without storing state on the agency.
+# Carry tool changes into the next turn through caller-owned state.
 session_context = response.context_wrapper.context.user_context
 next_response = await agency.get_response(
     "Use the same preferences for the next analysis.",

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -297,7 +297,7 @@ print("Response:", agency_response.json())
 ### How user_context is applied
 - Passed as run-scoped `context_override`.
 - Useful for structured data (ids, preferences, feature flags) you do not want in the prompt.
-- Accessible within tools for the duration of the run. It does not mutate the agency instance. See [Agency Context](/additional-features/agency-context).
+- Accessible within tools for the duration of the run. See [Agency Context](/additional-features/agency-context).
 
 ### How client_config is applied
 - Applies only to **OpenAI models** (no prefix or `openai/...`) and **LiteLLM models** (`litellm/...`).

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -295,9 +295,9 @@ print("Response:", agency_response.json())
 | `client_config` | object | No | Override `base_url` / `api_key` for this request (and optional `litellm_keys` for `litellm/` models). |
 
 ### How user_context is applied
-- Merges with any `user_context` set on the agency instance.
+- Passed as run-scoped `context_override`.
 - Useful for structured data (ids, preferences, feature flags) you do not want in the prompt.
-- Accessible within tools for the duration of the run. See [Agency Context](/additional-features/agency-context).
+- Accessible within tools for the duration of the run. It does not mutate the agency instance. See [Agency Context](/additional-features/agency-context).
 
 ### How client_config is applied
 - Applies only to **OpenAI models** (no prefix or `openai/...`) and **LiteLLM models** (`litellm/...`).

--- a/docs/core-framework/agencies/overview.mdx
+++ b/docs/core-framework/agencies/overview.mdx
@@ -48,7 +48,6 @@ Overview of parameters in the new `Agency` class:
 | Send Message Tool Class *(optional)* | `send_message_tool_class` | Fallback SendMessage tool class when a `communication_flows` entry does not specify its own tool. Prefer configuring SendMessage variants directly through `communication_flows`. Default: `None` |
 | Load Threads Callback *(optional)* | `load_threads_callback` | A callable to load conversation threads for persistence. Default: `None` |
 | Save Threads Callback *(optional)* | `save_threads_callback` | A callable to save conversation threads for persistence. Default: `None` |
-| User Context *(optional)* | `user_context` | Initial shared context accessible to all agents during runs. Default: `None` |
 
 ## Example
 
@@ -80,7 +79,6 @@ agency = Agency(
     ],
     shared_instructions="./shared_instructions.md",
     shared_tools=[get_current_time],  # Available to all agents
-    user_context={"project_type": "web_application"}
 )
 ```
 

--- a/docs/references/api.mdx
+++ b/docs/references/api.mdx
@@ -25,7 +25,6 @@ class Agency:
         send_message_tool_class: type | None = None,
         load_threads_callback: ThreadLoadCallback | None = None,
         save_threads_callback: ThreadSaveCallback | None = None,
-        user_context: dict[str, Any] | None = None,
     ):
         """
         Initialize an Agency instance.
@@ -42,7 +41,6 @@ class Agency:
             send_message_tool_class: Fallback SendMessage tool class when a communication flow does not define its own
             load_threads_callback: Callable used to load persisted conversation threads
             save_threads_callback: Callable used to save conversation threads
-            user_context: Initial shared context accessible to all agents
         """
 ```
 
@@ -65,7 +63,6 @@ class Agency:
 - **`shared_tools_folder`** (str | None): Path to folder containing shared tool files
 - **`shared_files_folder`** (str | None): Path to folder of files shared via a common vector store
 - **`shared_mcp_servers`** (list[Any] | None): MCP server instances attached to all agents
-- **`user_context`** (dict[str, Any]): Shared user-defined context accessible within MasterContext
 - **`send_message_tool_class`** (type | None): Fallback SendMessage tool when no flow-specific tool is set
 
 ### Key Methods
@@ -91,7 +88,7 @@ async def get_response(
     Parameters:
         message: The input message for the agent
         recipient_agent: Target agent instance or name (defaults to first entry point)
-        context_override: Additional context to pass to the agent run
+        context_override: Run-scoped context passed into MasterContext.user_context
         hooks_override: Specific hooks to use for this run, overriding agency defaults
         run_config: Configuration for the agent run
         file_ids: Additional file IDs for the agent run
@@ -123,7 +120,7 @@ def get_response_sync(
     Parameters:
         message: The input message for the agent
         recipient_agent: Target agent instance or name (defaults to first entry point)
-        context_override: Additional context to pass to the agent run
+        context_override: Run-scoped context passed into MasterContext.user_context
         hooks_override: Specific hooks to use for this run, overriding agency defaults
         run_config: Configuration for the agent run
         file_ids: Additional file IDs for the agent run
@@ -155,7 +152,7 @@ def get_response_stream(
     Parameters:
         message: The input message for the agent
         recipient_agent: Target agent instance or name (defaults to first entry point)
-        context_override: Additional context for the run
+        context_override: Run-scoped context passed into MasterContext.user_context
         hooks_override: Specific hooks for this run
         run_config_override: Specific run configuration for this run
         file_ids: Additional file IDs for the agent run
@@ -344,7 +341,7 @@ async def get_response(
     Parameters:
         message: Input message as string or structured input items list
         sender_name: Name of sending agent (None for user interactions)
-        context_override: Optional context data to override default MasterContext values
+        context_override: Run-scoped context passed into MasterContext.user_context
         hooks_override: Optional hooks to override default agent hooks
         run_config_override: Optional run configuration settings
         file_ids: List of OpenAI file IDs to attach to the message
@@ -376,7 +373,7 @@ def get_response_stream(
     Parameters:
         message: Input message or list of message items
         sender_name: Name of sending agent (None for user interactions)
-        context_override: Optional context data to override default values
+        context_override: Run-scoped context passed into MasterContext.user_context
         hooks_override: Optional hooks to override default agent hooks
         run_config_override: Optional run configuration
         file_ids: List of OpenAI file IDs to attach to the message

--- a/examples/agency_context.py
+++ b/examples/agency_context.py
@@ -105,7 +105,6 @@ analyst_agent = Agent(
 agency = Agency(
     data_agent,
     communication_flows=[data_agent > analyst_agent],
-    user_context={"session_id": "demo_session", "system": "agency_context_demo"},
 )
 
 # --- Demo --- #
@@ -113,24 +112,35 @@ agency = Agency(
 
 async def run_demo():
     """Demonstrate agency context sharing between agents."""
+    session_context = {"session_id": "demo_session", "system": "agency_context_demo"}
+
     print("Agency Context Demo")
     print("=" * 40)
 
     # Step 1: Store customer data
     print("\nStep 1: Storing customer data...")
-    response1 = await agency.get_response(message="Please store customer data: ID 'CUST123', name 'Alice Johnson'")
+    response1 = await agency.get_response(
+        message="Please store customer data: ID 'CUST123', name 'Alice Johnson'",
+        context_override=session_context,
+    )
+    session_context = response1.context_wrapper.context.user_context
     print(f"✅ {response1.final_output}")
 
     # Step 2: Delegate analysis to another agent
     print("\nStep 2: Asking data agent to delegate analysis...")
     response2 = await agency.get_response(
-        message="Please ask the analyst agent to analyze the customer data I just stored."
+        message="Please ask the analyst agent to analyze the customer data I just stored.",
+        context_override=session_context,
     )
+    session_context = response2.context_wrapper.context.user_context
     print(f"✅ {response2.final_output}")
 
     # Step 3: Show final context state
     print("\nStep 3: Checking final agency context...")
-    response3 = await agency.get_response(message="Show me a summary of what's currently stored in the agency context.")
+    response3 = await agency.get_response(
+        message="Show me a summary of what's currently stored in the agency context.",
+        context_override=session_context,
+    )
     print(f"✅ {response3.final_output}")
 
     print("\nDemo complete!")

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -1,4 +1,3 @@
-# --- Core Agency class definition ---
 import asyncio
 import atexit
 import logging
@@ -27,6 +26,7 @@ from .setup import (
     parse_agent_flows,
     register_all_agents_and_set_entry_points,
 )
+from .user_context import deprecated_user_context, warn_agency_user_context_init_deprecated
 
 if TYPE_CHECKING:
     from agency_swarm.agent.context_types import AgentRuntimeState
@@ -73,8 +73,7 @@ class Agency:
     send_message_tool_class: type | None  # Fallback SendMessage tool class when flows have no override
 
     _agent_runtime_state: dict[str, "AgentRuntimeState"]
-
-    # Communication tool class mappings for agent-to-agent specific tools
+    user_context = deprecated_user_context
     _communication_tool_classes: dict[tuple[str, str], type]  # (sender_name, receiver_name) -> tool_class
 
     def __init__(
@@ -161,13 +160,7 @@ class Agency:
         else:
             self.shared_instructions = ""
         if user_context is not None:
-            warnings.warn(
-                "`Agency(user_context=...)` is deprecated and will be removed in a future release. "
-                "Pass per-run context with `get_response(..., context_override=...)`, "
-                "`get_response_stream(..., context_override=...)`, or construct `MasterContext` directly.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_agency_user_context_init_deprecated()
         self._initial_user_context = dict(user_context or {})
         self.send_message_tool_class = send_message_tool_class
         self.shared_tools = shared_tools
@@ -211,28 +204,6 @@ class Agency:
         # Register MCP shutdown at process exit so persistent servers are cleaned in scripts
         if default_mcp_manager.mark_atexit_registered():
             atexit.register(default_mcp_manager.shutdown_sync)
-
-    @property
-    def user_context(self) -> dict[str, Any]:
-        """Deprecated initial context seed; use per-run `context_override` instead."""
-        warnings.warn(
-            "`Agency.user_context` is deprecated and will be removed in a future release. "
-            "Read run context from `RunResult.context_wrapper.context.user_context` and pass it back with "
-            "`context_override` when you need caller-owned state.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._initial_user_context
-
-    @user_context.setter
-    def user_context(self, value: dict[str, Any]) -> None:
-        warnings.warn(
-            "`Agency.user_context` is deprecated and will be removed in a future release. "
-            "Keep state outside the agency and pass it per run with `context_override`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self._initial_user_context = dict(value or {})
 
     def get_agent_context(
         self,

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -161,7 +161,7 @@ class Agency:
             self.shared_instructions = ""
         if user_context is not None:
             warn_agency_user_context_init_deprecated()
-        self._initial_user_context = dict(user_context or {})
+        self._initial_user_context = user_context or {}
         self.send_message_tool_class = send_message_tool_class
         self.shared_tools = shared_tools
         self.shared_tools_folder = shared_tools_folder

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -55,7 +55,7 @@ class Agency:
         thread_manager (ThreadManager): The manager responsible for handling conversation threads.
         persistence_hooks (PersistenceHooks | None): Optional hooks for loading/saving thread state.
         shared_instructions (str | None): Optional instructions prepended to every agent's system prompt.
-        user_context (dict[str, Any]): A dictionary for shared user-defined context within `MasterContext` during runs.
+        user_context (dict[str, Any]): Deprecated initial context seed. Use per-run `context_override` instead.
         send_message_tool_class (type | None): Optional fallback SendMessage tool class when no
             flow-specific tool is provided.
     """
@@ -69,7 +69,7 @@ class Agency:
     shared_tools_folder: str | None  # Folder path containing tools for all agents
     shared_files_folder: str | None  # Folder path containing files for all agents
     shared_mcp_servers: list[Any] | None  # MCP servers shared across all agents
-    user_context: dict[str, Any]  # Shared user context for MasterContext
+    _initial_user_context: dict[str, Any]  # Deprecated initial context seed for MasterContext
     send_message_tool_class: type | None  # Fallback SendMessage tool class when flows have no override
 
     _agent_runtime_state: dict[str, "AgentRuntimeState"]
@@ -123,7 +123,8 @@ class Agency:
                 a tool via `communication_flows`. Prefer per-flow configuration.
             load_threads_callback (ThreadLoadCallback | None, optional): Callable to load conversation threads.
             save_threads_callback (ThreadSaveCallback | None, optional): Callable to save conversation threads.
-            user_context (dict[str, Any] | None, optional): Initial shared context accessible to all agents.
+            user_context (dict[str, Any] | None, optional): Deprecated. Pass per-run context with
+                `get_response(..., context_override=...)` instead.
 
         Raises:
             ValueError: If the agency structure is not defined, or if agent names are duplicated.
@@ -159,7 +160,15 @@ class Agency:
                 self.shared_instructions = shared_instructions
         else:
             self.shared_instructions = ""
-        self.user_context = user_context or {}
+        if user_context is not None:
+            warnings.warn(
+                "`Agency(user_context=...)` is deprecated and will be removed in a future release. "
+                "Pass per-run context with `get_response(..., context_override=...)`, "
+                "`get_response_stream(..., context_override=...)`, or construct `MasterContext` directly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self._initial_user_context = dict(user_context or {})
         self.send_message_tool_class = send_message_tool_class
         self.shared_tools = shared_tools
         self.shared_tools_folder = shared_tools_folder
@@ -202,6 +211,28 @@ class Agency:
         # Register MCP shutdown at process exit so persistent servers are cleaned in scripts
         if default_mcp_manager.mark_atexit_registered():
             atexit.register(default_mcp_manager.shutdown_sync)
+
+    @property
+    def user_context(self) -> dict[str, Any]:
+        """Deprecated initial context seed; use per-run `context_override` instead."""
+        warnings.warn(
+            "`Agency.user_context` is deprecated and will be removed in a future release. "
+            "Read run context from `RunResult.context_wrapper.context.user_context` and pass it back with "
+            "`context_override` when you need caller-owned state.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._initial_user_context
+
+    @user_context.setter
+    def user_context(self, value: dict[str, Any]) -> None:
+        warnings.warn(
+            "`Agency.user_context` is deprecated and will be removed in a future release. "
+            "Keep state outside the agency and pass it per run with `context_override`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._initial_user_context = dict(value or {})
 
     def get_agent_context(
         self,
@@ -250,7 +281,8 @@ class Agency:
             message (str | list[dict[str, Any]]): The input message for the agent.
             recipient_agent (str | Agent | None, optional): The target agent instance or its name.
                                                            If None, defaults to the first entry point agent.
-            context_override (dict[str, Any] | None, optional): Additional context to pass to the agent run.
+            context_override (dict[str, Any] | None, optional): Run-scoped context passed into
+                `MasterContext.user_context`.
             agency_context_override (AgencyContext | None, optional): Run-scoped agency context to use instead of
                 the default context derived from the agency instance.
             hooks_override (RunHooks | None, optional): Specific hooks to use for this run, overriding
@@ -331,7 +363,8 @@ class Agency:
             message (str | list[dict[str, Any]]): The input message for the agent.
             recipient_agent (str | Agent | None, optional): The target agent instance or its name.
                                                            If None, defaults to the first entry point agent.
-            context_override (dict[str, Any] | None, optional): Additional context for the run.
+            context_override (dict[str, Any] | None, optional): Run-scoped context passed into
+                `MasterContext.user_context`.
             agency_context_override (AgencyContext | None, optional): Run-scoped agency context to use instead of
                 the default context derived from the agency instance.
             hooks_override (RunHooks | None, optional): Specific hooks for this run.

--- a/src/agency_swarm/agency/helpers.py
+++ b/src/agency_swarm/agency/helpers.py
@@ -82,6 +82,11 @@ def build_fastapi_agencies(agency: "Agency") -> dict[str, Callable[..., "Agency"
             tool_cls = agency._communication_tool_classes.get((sender.name, receiver.name))
             flows.append((sender, receiver, tool_cls) if tool_cls else (sender, receiver))
 
+        kwargs: dict[str, Any] = {}
+        initial_user_context = deepcopy(getattr(agency, "_initial_user_context", {}))
+        if initial_user_context:
+            kwargs["user_context"] = initial_user_context
+
         return agency_cls(
             *agency.entry_points,
             communication_flows=flows,
@@ -94,7 +99,7 @@ def build_fastapi_agencies(agency: "Agency") -> dict[str, Callable[..., "Agency"
             send_message_tool_class=agency.send_message_tool_class,
             load_threads_callback=load_threads_callback,
             save_threads_callback=save_threads_callback,
-            user_context=deepcopy(agency.user_context),
+            **kwargs,
         )
 
     return {agency.name or "agency": agency_factory}

--- a/src/agency_swarm/agency/responses.py
+++ b/src/agency_swarm/agency/responses.py
@@ -156,7 +156,8 @@ async def get_response(
         message (str | list[dict[str, Any]]): The input message for the agent.
         recipient_agent (str | Agent | None, optional): The target agent instance or its name.
                                                        If None, defaults to the first entry point agent.
-        context_override (dict[str, Any] | None, optional): Additional context to pass to the agent run.
+        context_override (dict[str, Any] | None, optional): Run-scoped context passed into
+            `MasterContext.user_context`.
         hooks_override (RunHooks | None, optional): Specific hooks to use for this run, overriding
                                                    agency-level persistence hooks.
         run_config (RunConfig | None, optional): Configuration for the agent run.
@@ -291,7 +292,8 @@ def get_response_stream(
         message (str | list[dict[str, Any]]): The input message for the agent.
         recipient_agent (str | Agent | None, optional): The target agent instance or its name.
                                                        If None, defaults to the first entry point agent.
-        context_override (dict[str, Any] | None, optional): Additional context for the run.
+        context_override (dict[str, Any] | None, optional): Run-scoped context passed into
+            `MasterContext.user_context`.
         hooks_override (RunHooks | None, optional): Specific hooks for this run.
         run_config_override (RunConfig | None, optional): Specific run configuration for this run.
         file_ids (list[str] | None, optional): Additional file IDs for the agent run.

--- a/src/agency_swarm/agency/user_context.py
+++ b/src/agency_swarm/agency/user_context.py
@@ -1,3 +1,10 @@
+"""Deprecated Agency.user_context compatibility seam.
+
+This module exists only to keep the deprecated agency-owned context API alive
+until the next breaking release. Future removal should delete this property,
+the Agency constructor parameter, and the `_initial_user_context` store together.
+"""
+
 import warnings
 from typing import Any, Protocol
 

--- a/src/agency_swarm/agency/user_context.py
+++ b/src/agency_swarm/agency/user_context.py
@@ -1,0 +1,40 @@
+import warnings
+from typing import Any, Protocol
+
+
+class _HasInitialUserContext(Protocol):
+    _initial_user_context: dict[str, Any]
+
+
+def warn_agency_user_context_init_deprecated() -> None:
+    warnings.warn(
+        "`Agency(user_context=...)` is deprecated and will be removed in a future release. "
+        "Pass per-run context with `get_response(..., context_override=...)`, "
+        "`get_response_stream(..., context_override=...)`, or construct `MasterContext` directly.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _get_user_context(self: _HasInitialUserContext) -> dict[str, Any]:
+    warnings.warn(
+        "`Agency.user_context` is deprecated and will be removed in a future release. "
+        "Read run context from `RunResult.context_wrapper.context.user_context` and pass it back with "
+        "`context_override` when you need caller-owned state.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return self._initial_user_context
+
+
+def _set_user_context(self: _HasInitialUserContext, value: dict[str, Any]) -> None:
+    warnings.warn(
+        "`Agency.user_context` is deprecated and will be removed in a future release. "
+        "Keep state outside the agency and pass it per run with `context_override`.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    self._initial_user_context = dict(value or {})
+
+
+deprecated_user_context = property(_get_user_context, _set_user_context)

--- a/src/agency_swarm/agency/user_context.py
+++ b/src/agency_swarm/agency/user_context.py
@@ -34,7 +34,7 @@ def _set_user_context(self: _HasInitialUserContext, value: dict[str, Any]) -> No
         DeprecationWarning,
         stacklevel=2,
     )
-    self._initial_user_context = dict(value or {})
+    self._initial_user_context = value
 
 
 deprecated_user_context = property(_get_user_context, _set_user_context)

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -396,7 +396,7 @@ class Agent(BaseAgent[MasterContext]):
         Args:
             message: The input message as a string or structured input items list
             sender_name: Name of the sending agent (None for user interactions)
-            context_override: Optional context data to override default MasterContext values
+            context_override: Run-scoped context passed into MasterContext.user_context
             hooks_override: Optional hooks to override default agent hooks
             run_config_override: Optional run configuration settings
             file_ids: List of OpenAI file IDs to attach to the message
@@ -441,7 +441,7 @@ class Agent(BaseAgent[MasterContext]):
         Args:
             message: The input message or list of message items
             sender_name: Name of the sending agent (None for user interactions)
-            context_override: Optional context data to override default values
+            context_override: Run-scoped context passed into MasterContext.user_context
             hooks_override: Optional hooks to override default agent hooks
             run_config_override: Optional run configuration
             additional_instructions: Additional instructions to be appended to the agent's

--- a/src/agency_swarm/agent/execution.py
+++ b/src/agency_swarm/agent/execution.py
@@ -376,7 +376,13 @@ class Execution:
         finally:
             # Cleanup execution state
             if "master_context_for_run" in locals() and master_context_for_run is not None:  # type: ignore[used-before-def]
-                cleanup_execution(self.agent, original_instructions, agency_context)
+                cleanup_execution(
+                    self.agent,
+                    original_instructions,
+                    context_override,
+                    agency_context,
+                    master_context_for_run,
+                )
             else:
                 # Ensure instructions are restored even if context was not prepared
                 self.agent.instructions = original_instructions
@@ -615,7 +621,13 @@ class Execution:
                 raise
             finally:
                 if master_context_for_run is not None:
-                    cleanup_execution(self.agent, original_instructions, agency_context)
+                    cleanup_execution(
+                        self.agent,
+                        original_instructions,
+                        context_override,
+                        agency_context,
+                        master_context_for_run,
+                    )
                 else:
                     self.agent.instructions = original_instructions
                 if (

--- a/src/agency_swarm/agent/execution.py
+++ b/src/agency_swarm/agent/execution.py
@@ -90,7 +90,7 @@ class Execution:
         Args:
             message: The input message as a string or structured input items list
             sender_name: Name of the sending agent (None for user interactions)
-            context_override: Optional context data to override default MasterContext values
+            context_override: Run-scoped context passed into MasterContext.user_context
             hooks_override: Optional hooks to override default agent hooks
             run_config_override: Optional run configuration settings
             file_ids: List of OpenAI file IDs to attach to the message
@@ -371,29 +371,12 @@ class Execution:
                 except Exception as e:
                     logger.debug(f"Failed to cache conversation starter: {e}")
 
-            # Sync back context changes if we used a merged context due to override
-            if context_override and agency_context and agency_context.agency_instance is not None:
-                from agency_swarm.agency.core import Agency
-
-                agency_instance = agency_context.agency_instance
-                if isinstance(agency_instance, Agency):
-                    base_user_context = agency_instance.user_context
-                else:
-                    base_user_context = None
-                # Sync back any new keys that weren't part of the original override
-                if base_user_context is not None:
-                    for key, value in master_context_for_run.user_context.items():
-                        if key not in context_override:  # Don't sync back override keys
-                            base_user_context[key] = value
-
             return run_result
 
         finally:
             # Cleanup execution state
             if "master_context_for_run" in locals() and master_context_for_run is not None:  # type: ignore[used-before-def]
-                cleanup_execution(
-                    self.agent, original_instructions, context_override, agency_context, master_context_for_run
-                )
+                cleanup_execution(self.agent, original_instructions, agency_context)
             else:
                 # Ensure instructions are restored even if context was not prepared
                 self.agent.instructions = original_instructions
@@ -423,7 +406,7 @@ class Execution:
         Args:
             message: The input message as a string or structured input items list
             sender_name: Name of the sending agent (None for user interactions)
-            context_override: Optional context data to override default MasterContext values
+            context_override: Run-scoped context passed into MasterContext.user_context
             hooks_override: Optional hooks to override default agent hooks
             run_config_override: Optional run configuration settings
             file_ids: List of OpenAI file IDs to attach to the message
@@ -632,9 +615,7 @@ class Execution:
                 raise
             finally:
                 if master_context_for_run is not None:
-                    cleanup_execution(
-                        self.agent, original_instructions, context_override, agency_context, master_context_for_run
-                    )
+                    cleanup_execution(self.agent, original_instructions, agency_context)
                 else:
                     self.agent.instructions = original_instructions
                 if (

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -29,6 +29,7 @@ from agency_swarm.messages import MessageFormatter
 from agency_swarm.tools.mcp_manager import default_mcp_manager
 
 from .execution_guardrails import append_guardrail_feedback, extract_guardrail_texts
+from .run_context import get_agency_user_context_store, resolve_latest_shared_instructions, sync_context_back_to_agency
 
 if TYPE_CHECKING:
     from agency_swarm.agent.core import AgencyContext, Agent
@@ -195,29 +196,6 @@ def run_item_to_tresponse_input_item(item: RunItem) -> TResponseInputItem | None
         return None
 
 
-def _resolve_latest_shared_instructions(agency_context: "AgencyContext | None") -> str | None:
-    """Return the freshest shared instructions and keep the context in sync."""
-    if not agency_context:
-        return None
-
-    agency_instance = getattr(agency_context, "agency_instance", None)
-    if agency_instance and hasattr(agency_instance, "shared_instructions"):
-        latest = getattr(agency_instance, "shared_instructions", None)
-        normalized = latest if isinstance(latest, str) else None
-        normalized = normalized or None
-        agency_context.shared_instructions = normalized
-        return normalized
-
-    existing = agency_context.shared_instructions
-    if isinstance(existing, str):
-        normalized = existing or None
-        agency_context.shared_instructions = normalized
-        return normalized
-
-    agency_context.shared_instructions = None
-    return None
-
-
 def prepare_master_context(
     agent: "Agent", context_override: dict[str, Any] | None, agency_context: "AgencyContext | None" = None
 ) -> MasterContext:
@@ -227,7 +205,7 @@ def prepare_master_context(
 
     thread_manager = agency_context.thread_manager
     agency_instance = agency_context.agency_instance
-    shared_instructions_for_run = _resolve_latest_shared_instructions(agency_context)
+    shared_instructions_for_run = resolve_latest_shared_instructions(agency_context)
 
     # For standalone agent usage (no agency), create minimal context
     if not agency_instance or not hasattr(agency_instance, "agents"):
@@ -240,16 +218,13 @@ def prepare_master_context(
             agent_runtime_state={agent.name: AgentRuntimeState(agent.tool_concurrency_manager)},
         )
 
-    shared_run_user_context = getattr(agency_instance, "_shared_run_user_context", None)
-    if isinstance(shared_run_user_context, dict) and context_override is None:
-        user_context = shared_run_user_context
-    else:
-        base_user_context = (
-            shared_run_user_context
-            if isinstance(shared_run_user_context, dict)
-            else getattr(agency_instance, "_initial_user_context", {})
-        )
+    base_user_context = get_agency_user_context_store(agency_instance)
+    if base_user_context is None:
+        base_user_context = {}
+    if context_override:
         user_context = {**base_user_context, **(context_override or {})}
+    else:
+        user_context = base_user_context
 
     runtime_state_map = getattr(agency_instance, "_agent_runtime_state", {})
     if not isinstance(runtime_state_map, dict):
@@ -314,7 +289,7 @@ def setup_execution(
     original_instructions = agent.instructions
 
     # Temporarily modify instructions if shared or additional instructions provided
-    shared_instructions_text = _resolve_latest_shared_instructions(agency_context)
+    shared_instructions_text = resolve_latest_shared_instructions(agency_context)
 
     if additional_instructions and not isinstance(additional_instructions, str):
         raise ValueError("additional_instructions must be a string")
@@ -425,9 +400,13 @@ def _validate_agency_for_delegation(
 def cleanup_execution(
     agent: "Agent",
     original_instructions: str | Callable | None,
+    context_override: dict[str, Any] | None,
     agency_context: "AgencyContext | None",
+    master_context_for_run: MasterContext,
 ) -> None:
     """Common cleanup logic for execution methods."""
+    sync_context_back_to_agency(context_override, agency_context, master_context_for_run)
+
     # Always restore original instructions
     agent.instructions = original_instructions
 

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -234,15 +234,14 @@ def prepare_master_context(
         return MasterContext(
             thread_manager=thread_manager,
             agents={agent.name: agent},  # Only include self
-            user_context=context_override or {},
+            user_context=dict(context_override or {}),
             current_agent_name=agent.name,
             shared_instructions=shared_instructions_for_run,
             agent_runtime_state={agent.name: AgentRuntimeState(agent.tool_concurrency_manager)},
         )
 
-    # Use reference for persistence, or create merged copy if override provided
-    base_user_context = getattr(agency_instance, "user_context", {})
-    user_context = {**base_user_context, **context_override} if context_override else base_user_context
+    base_user_context = getattr(agency_instance, "_initial_user_context", {})
+    user_context = {**base_user_context, **(context_override or {})}
 
     runtime_state_map = getattr(agency_instance, "_agent_runtime_state", {})
     if not isinstance(runtime_state_map, dict):
@@ -418,19 +417,9 @@ def _validate_agency_for_delegation(
 def cleanup_execution(
     agent: "Agent",
     original_instructions: str | Callable | None,
-    context_override: dict[str, Any] | None,
     agency_context: "AgencyContext | None",
-    master_context_for_run: MasterContext,
 ) -> None:
     """Common cleanup logic for execution methods."""
-    # Sync back context changes if we used a merged context due to override
-    if context_override and agency_context and agency_context.agency_instance:
-        base_user_context = getattr(agency_context.agency_instance, "user_context", {})
-        # Sync back any new keys that weren't part of the original override
-        for key, value in master_context_for_run.user_context.items():
-            if key not in context_override:  # Don't sync back override keys
-                base_user_context[key] = value
-
     # Always restore original instructions
     agent.instructions = original_instructions
 

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -240,8 +240,16 @@ def prepare_master_context(
             agent_runtime_state={agent.name: AgentRuntimeState(agent.tool_concurrency_manager)},
         )
 
-    base_user_context = getattr(agency_instance, "_initial_user_context", {})
-    user_context = {**base_user_context, **(context_override or {})}
+    shared_run_user_context = getattr(agency_instance, "_shared_run_user_context", None)
+    if isinstance(shared_run_user_context, dict) and context_override is None:
+        user_context = shared_run_user_context
+    else:
+        base_user_context = (
+            shared_run_user_context
+            if isinstance(shared_run_user_context, dict)
+            else getattr(agency_instance, "_initial_user_context", {})
+        )
+        user_context = {**base_user_context, **(context_override or {})}
 
     runtime_state_map = getattr(agency_instance, "_agent_runtime_state", {})
     if not isinstance(runtime_state_map, dict):

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -212,7 +212,7 @@ def prepare_master_context(
         return MasterContext(
             thread_manager=thread_manager,
             agents={agent.name: agent},  # Only include self
-            user_context=dict(context_override or {}),
+            user_context=context_override or {},
             current_agent_name=agent.name,
             shared_instructions=shared_instructions_for_run,
             agent_runtime_state={agent.name: AgentRuntimeState(agent.tool_concurrency_manager)},

--- a/src/agency_swarm/agent/run_context.py
+++ b/src/agency_swarm/agent/run_context.py
@@ -1,3 +1,9 @@
+"""Run context helpers and deprecated agency-context compatibility.
+
+The deprecated Agency.user_context sync-back path is isolated here so the next
+breaking release can remove it without changing the run-scoped context flow.
+"""
+
 from typing import TYPE_CHECKING, Any
 
 from agency_swarm.context import MasterContext

--- a/src/agency_swarm/agent/run_context.py
+++ b/src/agency_swarm/agent/run_context.py
@@ -1,0 +1,64 @@
+from typing import TYPE_CHECKING, Any
+
+from agency_swarm.context import MasterContext
+
+if TYPE_CHECKING:
+    from agency_swarm.agent.core import AgencyContext
+
+
+def resolve_latest_shared_instructions(agency_context: "AgencyContext | None") -> str | None:
+    """Return the freshest shared instructions and keep the context in sync."""
+    if not agency_context:
+        return None
+
+    agency_instance = getattr(agency_context, "agency_instance", None)
+    if agency_instance and hasattr(agency_instance, "shared_instructions"):
+        latest = getattr(agency_instance, "shared_instructions", None)
+        normalized = latest if isinstance(latest, str) else None
+        normalized = normalized or None
+        agency_context.shared_instructions = normalized
+        return normalized
+
+    existing = agency_context.shared_instructions
+    if isinstance(existing, str):
+        normalized = existing or None
+        agency_context.shared_instructions = normalized
+        return normalized
+
+    agency_context.shared_instructions = None
+    return None
+
+
+def get_agency_user_context_store(agency_instance: object) -> dict[str, Any] | None:
+    """Return the mutable context store used for legacy agency-level state."""
+    shared_run_user_context = getattr(agency_instance, "_shared_run_user_context", None)
+    if isinstance(shared_run_user_context, dict):
+        return shared_run_user_context
+
+    initial_user_context = getattr(agency_instance, "_initial_user_context", None)
+    if isinstance(initial_user_context, dict):
+        return initial_user_context
+
+    legacy_user_context = getattr(agency_instance, "user_context", None)
+    if isinstance(legacy_user_context, dict):
+        return legacy_user_context
+
+    return None
+
+
+def sync_context_back_to_agency(
+    context_override: dict[str, Any] | None,
+    agency_context: "AgencyContext | None",
+    master_context_for_run: MasterContext,
+) -> None:
+    """Preserve legacy Agency.user_context sync-back for override runs."""
+    if not context_override or not agency_context or not agency_context.agency_instance:
+        return
+
+    base_user_context = get_agency_user_context_store(agency_context.agency_instance)
+    if base_user_context is None:
+        return
+
+    for key, value in master_context_for_run.user_context.items():
+        if key not in context_override:
+            base_user_context[key] = value

--- a/src/agency_swarm/integrations/fastapi_utils/request_models.py
+++ b/src/agency_swarm/integrations/fastapi_utils/request_models.py
@@ -106,7 +106,7 @@ class RunAgentInputCustom(RunAgentInput):
     additional_instructions: str | None = None
     user_context: dict[str, Any] | None = Field(
         default=None,
-        description="Structured context merged into MasterContext.user_context for this run only.",
+        description="Structured context passed into MasterContext.user_context for this run only.",
     )
     file_ids: list[str] | None = None
     file_urls: dict[str, str] | None = Field(
@@ -153,7 +153,7 @@ class BaseRequest(BaseModel):
     additional_instructions: str | None = None
     user_context: dict[str, Any] | None = Field(
         default=None,
-        description="Structured context merged into MasterContext.user_context for this run only.",
+        description="Structured context passed into MasterContext.user_context for this run only.",
     )
     generate_chat_name: bool | None = Field(
         default=False, description="Generate a fitting chat name for the user input."

--- a/src/agency_swarm/tools/send_message.py
+++ b/src/agency_swarm/tools/send_message.py
@@ -281,7 +281,7 @@ class SendMessage(FunctionTool):
         class MinimalAgency:
             def __init__(self, agents_dict, user_context, runtime_state_map):
                 self.agents = agents_dict
-                self.user_context = user_context
+                self._shared_run_user_context = user_context
                 self._agent_runtime_state = runtime_state_map
                 self.shared_instructions = shared_instructions_from_context
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def mock_thread_manager():
 def mock_agency_instance(mock_thread_manager):
     agency = MagicMock()
     agency.agents = {}
-    agency.user_context = {}
+    agency._initial_user_context = {}
     agency.thread_manager = mock_thread_manager
     return agency
 

--- a/tests/deterministic_model.py
+++ b/tests/deterministic_model.py
@@ -34,6 +34,7 @@ from openai.types.responses.response_usage import InputTokensDetails, OutputToke
 
 _STORE_RE = re.compile(r"store\s+(?P<key>\w+)\s+with\s+value\s+(?P<value>\w+)", re.IGNORECASE)
 _GET_RE = re.compile(r"value\s+for\s+(?P<key>\w+)", re.IGNORECASE)
+_SHARED_SET_RE = re.compile(r"set\s+test_value\s+to\s+'?(?P<value>[\w-]+)'?", re.IGNORECASE)
 _MESSAGE_RE = re.compile(r"message:\s*(?P<message>.+)$", re.IGNORECASE)
 _SECRET_RE = re.compile(r"secret code:\s*(?P<secret>[\w-]+)", re.IGNORECASE)
 _HANDLE_RE = re.compile(r"handle\s+(?P<task>[\w-]+)", re.IGNORECASE)
@@ -343,6 +344,16 @@ class DeterministicModel(Model):
             get_match = _GET_RE.search(user_text)
             if get_match:
                 return _build_tool_call_response("get_data", {"key": get_match.group("key")})
+
+        if "SharedStateTool" in tool_map:
+            shared_set_match = _SHARED_SET_RE.search(user_text)
+            if shared_set_match:
+                return _build_tool_call_response(
+                    "SharedStateTool",
+                    {"action": "set", "value": shared_set_match.group("value")},
+                )
+            if "current test_value" in lower or "get" in lower:
+                return _build_tool_call_response("SharedStateTool", {"action": "get", "value": ""})
 
         if "send_message" in tool_map:
             schema = tool_map["send_message"].params_json_schema

--- a/tests/integration/agency/test_agency_context_sharing.py
+++ b/tests/integration/agency/test_agency_context_sharing.py
@@ -1,8 +1,8 @@
 """
 Integration test for agency context sharing between agents.
 
-This test verifies that agents can share data through the agency context,
-ensuring that changes made by one agent are visible to other agents.
+This test verifies that agents can share data through run context,
+ensuring callers can carry that state between agency calls.
 """
 
 import pytest
@@ -51,48 +51,48 @@ async def test_context_sharing_between_agents():
         tool_use_behavior="stop_on_first_tool",
     )
 
-    # Create agency with both agents as entry points
     agency = Agency(
         agent1,
         agent2,
         communication_flows=[agent1 > agent2],
-        user_context={"initial": "test"},
     )
 
-    # Agent1 stores data
+    session_context = {"initial": "test"}
+
     response1 = await agency.get_response(
         "Store shared_key with value shared_value",
         recipient_agent=agent1,
+        context_override=session_context,
     )
     tool_outputs_1 = [item.output for item in response1.new_items if hasattr(item, "output")]
     assert any("Stored shared_key=shared_value" in str(output) for output in tool_outputs_1)
 
-    # Verify data is in agency context
-    assert agency.user_context.get("shared_key") == "shared_value"
-    assert agency.user_context.get("initial") == "test"  # Original value preserved
+    session_context = response1.context_wrapper.context.user_context
+    assert session_context["shared_key"] == "shared_value"
+    assert session_context["initial"] == "test"
 
-    # Directly ask Agent2 to retrieve the data
     response2 = await agency.get_response(
         "Get the value for shared_key",
         recipient_agent=agent2,
+        context_override=session_context,
     )
     tool_outputs_2 = [item.output for item in response2.new_items if hasattr(item, "output")]
     assert any("Value for shared_key: shared_value" in str(output) for output in tool_outputs_2)
 
-    # Agent2 can also store data that's visible to the agency
-    await agency.get_response(
+    response3 = await agency.get_response(
         "Store agent2_key with value agent2_value",
         recipient_agent=agent2,
+        context_override=response2.context_wrapper.context.user_context,
     )
 
-    # Verify Agent2's data is in agency context
-    assert agency.user_context.get("agent2_key") == "agent2_value"
-    assert agency.user_context.get("shared_key") == "shared_value"  # Previous data preserved
+    session_context = response3.context_wrapper.context.user_context
+    assert session_context["agent2_key"] == "agent2_value"
+    assert session_context["shared_key"] == "shared_value"
 
-    # Retrieve Agent2's data directly from Agent2
     response4 = await agency.get_response(
         "Get the value for agent2_key",
         recipient_agent=agent2,
+        context_override=session_context,
     )
     tool_outputs_4 = [item.output for item in response4.new_items if hasattr(item, "output")]
     assert any("Value for agent2_key: agent2_value" in str(output) for output in tool_outputs_4)

--- a/tests/integration/agency/test_agency_context_sharing.py
+++ b/tests/integration/agency/test_agency_context_sharing.py
@@ -96,3 +96,32 @@ async def test_context_sharing_between_agents():
     )
     tool_outputs_4 = [item.output for item in response4.new_items if hasattr(item, "output")]
     assert any("Value for agent2_key: agent2_value" in str(output) for output in tool_outputs_4)
+
+
+@pytest.mark.asyncio
+async def test_context_override_is_shared_with_send_message_recipient():
+    """Sub-agents called by send_message receive the caller's run context."""
+    agent1 = Agent(
+        name="Agent1",
+        instructions="You delegate context reads to Agent2.",
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+    )
+    agent2 = Agent(
+        name="Agent2",
+        instructions="You retrieve data from the context.",
+        tools=[get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
+    )
+    agency = Agency(agent1, communication_flows=[agent1 > agent2])
+
+    response = await agency.get_response(
+        "Ask Agent2 for the value for shared_key",
+        recipient_agent=agent1,
+        context_override={"shared_key": "shared_value"},
+    )
+
+    tool_outputs = [item.output for item in response.new_items if hasattr(item, "output")]
+    assert any("Value for shared_key: shared_value" in str(output) for output in tool_outputs)

--- a/tests/integration/agency/test_multi_agency_support.py
+++ b/tests/integration/agency/test_multi_agency_support.py
@@ -9,12 +9,13 @@ import asyncio
 from typing import Literal
 
 import pytest
-from agents import RunResult
+from agents import ModelSettings, RunResult
 from agents.items import ToolCallOutputItem
 from pydantic import Field
 
 from agency_swarm import Agency, Agent
 from agency_swarm.tools import BaseTool
+from tests.deterministic_model import DeterministicModel
 
 
 class SharedStateTool(BaseTool):
@@ -59,20 +60,26 @@ def shared_agent():
         name="SharedAgent",
         instructions="You are a shared agent that can set and get values using the SharedStateTool.",
         tools=[SharedStateTool],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
     )
 
 
 @pytest.fixture
 def agency1(shared_agent):
     """Create the first agency."""
-    assistant1 = Agent(name="Assistant1", instructions="You are Assistant1 in Agency1")
+    assistant1 = Agent(
+        name="Assistant1",
+        instructions="You are Assistant1 in Agency1",
+        model=DeterministicModel(),
+    )
 
     agency = Agency(
         shared_agent,
         assistant1,
         communication_flows=[shared_agent > assistant1],
         name="Agency1",
-        user_context={"agency_name": "Agency1", "test_data": "agency1_data"},
     )
     return agency
 
@@ -80,16 +87,31 @@ def agency1(shared_agent):
 @pytest.fixture
 def agency2(shared_agent):
     """Create the second agency using the same shared agent."""
-    assistant2 = Agent(name="Assistant2", instructions="You are Assistant2 in Agency2")
+    assistant2 = Agent(
+        name="Assistant2",
+        instructions="You are Assistant2 in Agency2",
+        model=DeterministicModel(),
+    )
 
     agency = Agency(
         shared_agent,
         assistant2,
         communication_flows=[shared_agent > assistant2],
         name="Agency2",
-        user_context={"agency_name": "Agency2", "test_data": "agency2_data"},
     )
     return agency
+
+
+@pytest.fixture
+def agency1_context():
+    """Create caller-owned context for the first agency."""
+    return {"agency_name": "Agency1", "test_data": "agency1_data"}
+
+
+@pytest.fixture
+def agency2_context():
+    """Create caller-owned context for the second agency."""
+    return {"agency_name": "Agency2", "test_data": "agency2_data"}
 
 
 class TestMultiAgencySupport:
@@ -141,24 +163,35 @@ class TestMultiAgencySupport:
         assert messages1 != messages2
 
     @pytest.mark.asyncio
-    async def test_context_isolation_between_agencies(self, shared_agent, agency1, agency2):
+    async def test_context_isolation_between_agencies(
+        self, shared_agent, agency1, agency2, agency1_context, agency2_context
+    ):
         """Test that MasterContext is isolated between agencies."""
-        # Set values in agency1
-        await agency1.get_response("Use SharedStateTool to set test_value to 'agency1_secret'")
+        response_set_1 = await agency1.get_response(
+            "Use SharedStateTool to set test_value to 'agency1_secret'",
+            context_override=agency1_context,
+        )
+        agency1_context = response_set_1.context_wrapper.context.user_context
 
-        # Get value in agency2 - should not see agency1's value
-        response2 = await agency2.get_response("Use SharedStateTool to get the current test_value")
+        response2 = await agency2.get_response(
+            "Use SharedStateTool to get the current test_value",
+            context_override=agency2_context,
+        )
 
-        # The value should be isolated - agency2 shouldn't see agency1's value
         _assert_tool_output_excludes(response2, "agency1_secret")
 
-        # Set different value in agency2
-        await agency2.get_response("Use SharedStateTool to set test_value to 'agency2_secret'")
+        response_set_2 = await agency2.get_response(
+            "Use SharedStateTool to set test_value to 'agency2_secret'",
+            context_override=response2.context_wrapper.context.user_context,
+        )
 
-        # Verify agency1 still has its own value
-        response1 = await agency1.get_response("Use SharedStateTool to get the current test_value")
+        response1 = await agency1.get_response(
+            "Use SharedStateTool to get the current test_value",
+            context_override=agency1_context,
+        )
         _assert_tool_output_contains(response1, "agency1_secret")
         _assert_tool_output_excludes(response1, "agency2_secret")
+        assert response_set_2.context_wrapper.context.user_context["test_value"] == "agency2_secret"
 
     @pytest.mark.asyncio
     async def test_subagent_registration_isolation(self, shared_agent, agency1, agency2):
@@ -178,65 +211,69 @@ class TestMultiAgencySupport:
         assert "Assistant2" not in subagents1
 
     @pytest.mark.asyncio
-    async def test_user_context_isolation(self, shared_agent, agency1, agency2):
-        """Test that user context is isolated between agencies."""
-        # Verify each agency has its own user context
-        assert agency1.user_context["agency_name"] == "Agency1"
-        assert agency1.user_context["test_data"] == "agency1_data"
-
-        assert agency2.user_context["agency_name"] == "Agency2"
-        assert agency2.user_context["test_data"] == "agency2_data"
-
-        # User contexts should be different
-        assert agency1.user_context != agency2.user_context
+    async def test_user_context_isolation(self, shared_agent, agency1, agency2, agency1_context, agency2_context):
+        """Test that caller-owned user context is isolated between agencies."""
+        assert agency1_context["agency_name"] == "Agency1"
+        assert agency1_context["test_data"] == "agency1_data"
+        assert agency2_context["agency_name"] == "Agency2"
+        assert agency2_context["test_data"] == "agency2_data"
+        assert agency1_context != agency2_context
 
     @pytest.mark.asyncio
-    async def test_concurrent_agency_operations(self, shared_agent, agency1, agency2):
+    async def test_concurrent_agency_operations(self, shared_agent, agency1, agency2, agency1_context, agency2_context):
         """Test concurrent operations on the same agent from different agencies (now safe with stateless design)."""
-        # Run concurrent operations - this should be safe with stateless context passing
         import asyncio
 
-        task1 = asyncio.create_task(agency1.get_response("Use SharedStateTool to set test_value to 'concurrent1'"))
-        task2 = asyncio.create_task(agency2.get_response("Use SharedStateTool to set test_value to 'concurrent2'"))
+        task1 = asyncio.create_task(
+            agency1.get_response(
+                "Use SharedStateTool to set test_value to 'concurrent1'", context_override=agency1_context
+            )
+        )
+        task2 = asyncio.create_task(
+            agency2.get_response(
+                "Use SharedStateTool to set test_value to 'concurrent2'", context_override=agency2_context
+            )
+        )
 
-        # Wait for both to complete
         response1, response2 = await asyncio.gather(task1, task2)
 
-        # Both should complete successfully with no race conditions
         assert response1.final_output is not None
         assert response2.final_output is not None
-
-        # Each context should have its own value without relying on live-model phrasing.
-        assert agency1.user_context["test_value"] == "concurrent1"
-        assert agency2.user_context["test_value"] == "concurrent2"
+        assert response1.context_wrapper.context.user_context["test_value"] == "concurrent1"
+        assert response2.context_wrapper.context.user_context["test_value"] == "concurrent2"
 
     @pytest.mark.asyncio
-    async def test_streaming_context_isolation(self, shared_agent, agency1, agency2):
+    async def test_streaming_context_isolation(self, shared_agent, agency1, agency2, agency1_context, agency2_context):
         """Test that streaming responses maintain context isolation."""
-        # Test streaming from agency1
         events1 = []
-        async for event in agency1.get_response_stream("Use SharedStateTool to set test_value to 'stream1'"):
+        stream1 = agency1.get_response_stream(
+            "Use SharedStateTool to set test_value to 'stream1'",
+            context_override=agency1_context,
+        )
+        async for event in stream1:
             events1.append(event)
 
-        # Test streaming from agency2
         events2 = []
-        async for event in agency2.get_response_stream("Use SharedStateTool to set test_value to 'stream2'"):
+        stream2 = agency2.get_response_stream(
+            "Use SharedStateTool to set test_value to 'stream2'",
+            context_override=agency2_context,
+        )
+        async for event in stream2:
             events2.append(event)
 
-        # Both streams should complete
         assert len(events1) > 0
         assert len(events2) > 0
+        assert stream1.final_result is not None
+        assert stream2.final_result is not None
 
-        # Verify context isolation after streaming
-        response1 = await agency1.get_response("Use SharedStateTool to get the current test_value")
-        response2 = await agency2.get_response("Use SharedStateTool to get the current test_value")
+        stream_context_1 = stream1.final_result.context_wrapper.context.user_context
+        stream_context_2 = stream2.final_result.context_wrapper.context.user_context
 
-        # Should have different values
-        outputs1 = _tool_outputs(response1)
-        outputs2 = _tool_outputs(response2)
-        assert any("stream1" in output for output in outputs1), f"Expected stream1 in tool outputs: {outputs1}"
-        assert any("stream2" in output for output in outputs2), f"Expected stream2 in tool outputs: {outputs2}"
-        assert outputs1 != outputs2
+        assert stream_context_1["agency_name"] == "Agency1"
+        assert stream_context_2["agency_name"] == "Agency2"
+        assert stream_context_1["test_data"] == "agency1_data"
+        assert stream_context_2["test_data"] == "agency2_data"
+        assert stream_context_1 != stream_context_2
 
 
 class TestStatelessContextPassing:

--- a/tests/integration/files/test_file_handling.py
+++ b/tests/integration/files/test_file_handling.py
@@ -50,7 +50,7 @@ async def test_agent_processes_message_files_attachment(real_openai_client: Asyn
     attachment_tester_agent._openai_client = real_openai_client
 
     # 3. Setup a real Agency for proper testing
-    agency = Agency(attachment_tester_agent, user_context=None)
+    agency = Agency(attachment_tester_agent)
 
     # 4. Call get_response with file_ids - OpenAI will automatically process the file
     message_to_agent = "What is my favorite food?"
@@ -135,7 +135,7 @@ async def test_multi_file_type_processing(real_openai_client: AsyncOpenAI, tmp_p
         file_processor_agent._openai_client = real_openai_client
 
         # Initialize agency for the agent
-        Agency(file_processor_agent, user_context=None)
+        Agency(file_processor_agent)
 
         # Test processing the PDF file
         question = "What is my favorite food?"
@@ -301,7 +301,7 @@ async def test_files_folder_reuse_without_missing_directory_warning(
     first_agent = Agent(**agent_kwargs)
     first_agent._openai_client = real_openai_client
 
-    Agency(first_agent, user_context=None)
+    Agency(first_agent)
     await _wait_for_vector_store(real_openai_client, first_agent)
 
     initial_folder = first_agent.files_folder_path
@@ -317,7 +317,7 @@ async def test_files_folder_reuse_without_missing_directory_warning(
     reuse_agent = Agent(**agent_kwargs)
     reuse_agent._openai_client = real_openai_client
 
-    Agency(reuse_agent, user_context=None)
+    Agency(reuse_agent)
     await _wait_for_vector_store(real_openai_client, reuse_agent)
 
     assert reuse_agent.files_folder_path == initial_folder
@@ -345,7 +345,7 @@ async def test_file_search_tool(real_openai_client: AsyncOpenAI, tmp_path: Path)
         await _wait_for_vector_store(real_openai_client, file_search_agent)
 
         # Initialize agency and run test
-        agency = Agency(file_search_agent, user_context=None)
+        agency = Agency(file_search_agent)
         question = (
             "Use FileSearch with the query 'hobbit' to find the answer: What is the title of the 4th book in the list?"
         )
@@ -431,7 +431,7 @@ async def test_code_interpreter_tool(real_openai_client: AsyncOpenAI, tmp_path: 
         assert folder_path, "No vector store folder found"
 
         # Initialize agency for the agent
-        agency = Agency(code_interpreter_agent, user_context=None)
+        agency = Agency(code_interpreter_agent)
 
         # Test the simple usage of the code interpreter tool (answer is always 37)
         # Use a deterministic script to avoid RNG differences across environments
@@ -523,7 +523,7 @@ async def test_agent_vision_capabilities(real_openai_client: AsyncOpenAI, tmp_pa
     vision_agent._openai_client = real_openai_client
 
     # Initialize agency for the agent
-    Agency(vision_agent, user_context=None)
+    Agency(vision_agent)
 
     # Test processing each image
     for image_path, question, expected_content in test_images:
@@ -611,7 +611,7 @@ async def test_vector_store_cleanup_on_init(real_openai_client: AsyncOpenAI, tmp
     # First init: uploads both files and creates VS
     agent1 = Agent(**agent_kwargs)
     agent1._openai_client = real_openai_client
-    Agency(agent1, user_context=None)
+    Agency(agent1)
     await _wait_for_vector_store(real_openai_client, agent1)
 
     # Find VS folder and collect uploaded ids
@@ -637,7 +637,7 @@ async def test_vector_store_cleanup_on_init(real_openai_client: AsyncOpenAI, tmp
     # Re-init: should detach removed from VS and delete OpenAI file object
     agent2 = Agent(**agent_kwargs)
     agent2._openai_client = real_openai_client
-    Agency(agent2, user_context=None)
+    Agency(agent2)
     await _wait_for_vector_store(real_openai_client, agent2)
 
     vs_id = agent2._associated_vector_store_id
@@ -682,7 +682,7 @@ async def test_file_reupload_on_mtime_update(real_openai_client: AsyncOpenAI, tm
     # First init: upload original file
     agent1 = Agent(**agent_kwargs)
     agent1._openai_client = real_openai_client
-    Agency(agent1, user_context=None)
+    Agency(agent1)
     await _wait_for_vector_store(real_openai_client, agent1)
 
     # Locate vector store folder and uploaded file id
@@ -710,7 +710,7 @@ async def test_file_reupload_on_mtime_update(real_openai_client: AsyncOpenAI, tm
     # Re-init agent: should detect newer mtime and re-upload
     agent2 = Agent(**agent_kwargs)
     agent2._openai_client = real_openai_client
-    Agency(agent2, user_context=None)
+    Agency(agent2)
     await _wait_for_vector_store(real_openai_client, agent2)
 
     vs_id = agent2._associated_vector_store_id

--- a/tests/integration/mcp/test_mcp_integration.py
+++ b/tests/integration/mcp/test_mcp_integration.py
@@ -40,7 +40,6 @@ def _agency_factory() -> Agency:
     return Agency(
         agent,
         name="mcp_stdio_agency",
-        user_context={"session_id": "mcp_stdio_session"},
         shared_instructions="Test MCP StdIO Integration",
     )
 

--- a/tests/integration/persistence/test_context_persistence.py
+++ b/tests/integration/persistence/test_context_persistence.py
@@ -2,7 +2,8 @@
 Integration test for context persistence across agent calls.
 
 This test verifies that modifications to user_context can be carried
-between agent invocations without storing state on the Agency.
+between agent invocations while preserving deprecated Agency.user_context
+sync-back compatibility.
 """
 
 import pytest
@@ -59,12 +60,12 @@ async def test_caller_owned_context_can_be_carried_between_calls():
     assert response2.context_wrapper.context.user_context["initial"] == "value"
 
     with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
-        assert agency.user_context == {}
+        assert agency.user_context == {"stored_key": "test_data"}
 
 
 @pytest.mark.asyncio
-async def test_deprecated_agency_user_context_is_only_an_initial_seed():
-    """Deprecated agency user_context seeds a run but is not mutated by that run."""
+async def test_deprecated_agency_user_context_syncs_new_override_run_keys():
+    """Deprecated agency user_context preserves legacy sync-back for override runs."""
     agent = Agent(
         name="TestAgent",
         instructions="You store and retrieve data using the provided tools.",
@@ -91,4 +92,33 @@ async def test_deprecated_agency_user_context_is_only_an_initial_seed():
         "stored_key": "test_data",
     }
     with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
-        assert agency.user_context == {"agency_key": "agency_value"}
+        assert agency.user_context == {
+            "agency_key": "agency_value",
+            "stored_key": "test_data",
+        }
+
+
+@pytest.mark.asyncio
+async def test_deprecated_agency_user_context_persists_without_override():
+    """Deprecated agency user_context is still the mutable run context without an override."""
+    agent = Agent(
+        name="TestAgent",
+        instructions="You store and retrieve data using the provided tools.",
+        tools=[store_data, get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
+    )
+
+    with pytest.warns(DeprecationWarning, match=r"Agency\(user_context"):
+        agency = Agency(agent, user_context={"agency_key": "agency_value"})
+
+    response = await agency.get_response("Store stored_key with value test_data")
+
+    tool_outputs = [item.output for item in response.new_items if hasattr(item, "output")]
+    assert any("Stored stored_key=test_data" in str(output) for output in tool_outputs)
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        assert agency.user_context == {
+            "agency_key": "agency_value",
+            "stored_key": "test_data",
+        }

--- a/tests/integration/persistence/test_context_persistence.py
+++ b/tests/integration/persistence/test_context_persistence.py
@@ -1,104 +1,94 @@
 """
 Integration test for context persistence across agent calls.
 
-This test verifies that modifications to user_context are preserved
-between different agent invocations within the same agency.
+This test verifies that modifications to user_context can be carried
+between agent invocations without storing state on the Agency.
 """
 
 import pytest
-from pydantic import Field
+from agents import ModelSettings, RunContextWrapper, function_tool
 
-from agency_swarm import Agency, Agent
-from agency_swarm.tools import BaseTool
+from agency_swarm import Agency, Agent, MasterContext
+from tests.deterministic_model import DeterministicModel
 
 
-class StoreValueTool(BaseTool):
+@function_tool
+async def store_data(ctx: RunContextWrapper[MasterContext], key: str, value: str) -> str:
     """Store a value in the shared context."""
-
-    key: str = Field(..., description="Key to store")
-    value: str = Field(..., description="Value to store")
-
-    def run(self):
-        if self.context:
-            self.context.set(self.key, self.value)
-            return f"Stored {self.key}={self.value}"
-        return "No context available"
+    ctx.context.set(key, value)
+    return f"Stored {key}={value}"
 
 
-class ReadValueTool(BaseTool):
+@function_tool
+async def get_data(ctx: RunContextWrapper[MasterContext], key: str) -> str:
     """Read a value from the shared context."""
-
-    key: str = Field(..., description="Key to read")
-
-    def run(self):
-        if self.context:
-            value = self.context.get(self.key, "not_found")
-            return f"Value for {self.key}: {value}"
-        return "No context available"
+    value = ctx.context.get(key, "not_found")
+    return f"Value for {key}: {value}"
 
 
 @pytest.mark.asyncio
-async def test_context_persistence_between_calls():
-    """Test that context changes persist between separate agent calls."""
-
-    # Create agent with both tools
+async def test_caller_owned_context_can_be_carried_between_calls():
+    """Context changes persist when the caller passes the returned run context forward."""
     agent = Agent(
         name="ContextAgent",
         instructions="You store and retrieve data using the provided tools.",
-        tools=[StoreValueTool, ReadValueTool],
-        model="gpt-5.4-mini",
+        tools=[store_data, get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
+    )
+    agency = Agency(agent)
+
+    session_context = {"initial": "value"}
+    response1 = await agency.get_response(
+        "Store stored_key with value test_data",
+        context_override=session_context,
     )
 
-    # Create agency with initial context
-    agency = Agency(
-        agent,
-        user_context={"initial": "value"},
-    )
-
-    # First call: Store a value
-    response1 = await agency.get_response("Store the value 'test_data' with key 'stored_key' using StoreValueTool")
-
-    # Verify the tool was called
     tool_outputs = [item.output for item in response1.new_items if hasattr(item, "output")]
     assert any("Stored stored_key=test_data" in str(output) for output in tool_outputs)
 
-    # Second call: Read the value back
-    response2 = await agency.get_response("Read the value for key 'stored_key' using ReadValueTool")
+    next_context = response1.context_wrapper.context.user_context
+    response2 = await agency.get_response(
+        "Read the value for stored_key",
+        context_override=next_context,
+    )
 
-    # Verify the value was persisted
     tool_outputs2 = [item.output for item in response2.new_items if hasattr(item, "output")]
     assert any("Value for stored_key: test_data" in str(output) for output in tool_outputs2)
+    assert response2.context_wrapper.context.user_context["initial"] == "value"
 
-    # Verify agency context was updated
-    assert agency.user_context.get("stored_key") == "test_data"
-    assert agency.user_context.get("initial") == "value"  # Original value still there
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        assert agency.user_context == {}
 
 
 @pytest.mark.asyncio
-async def test_context_override_does_not_affect_agency():
-    """Test that context_override doesn't modify the agency's user_context."""
-
+async def test_deprecated_agency_user_context_is_only_an_initial_seed():
+    """Deprecated agency user_context seeds a run but is not mutated by that run."""
     agent = Agent(
         name="TestAgent",
-        instructions="You read data using ReadValueTool.",
-        tools=[ReadValueTool],
-        model="gpt-5.4-mini",
+        instructions="You store and retrieve data using the provided tools.",
+        tools=[store_data, get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
     )
 
-    agency = Agency(
-        agent,
-        user_context={"agency_key": "agency_value"},
-    )
+    with pytest.warns(DeprecationWarning, match=r"Agency\(user_context"):
+        agency = Agency(agent, user_context={"agency_key": "agency_value"})
 
-    # Call with context override
     response = await agency.get_response(
-        "Read the value for key 'override_key' using ReadValueTool", context_override={"override_key": "override_value"}
+        "Store stored_key with value test_data",
+        context_override={"override_key": "override_value"},
     )
 
-    # Verify the override was used in the call
     tool_outputs = [item.output for item in response.new_items if hasattr(item, "output")]
-    assert any("Value for override_key: override_value" in str(output) for output in tool_outputs)
+    assert any("Stored stored_key=test_data" in str(output) for output in tool_outputs)
 
-    # Verify agency context was NOT modified
-    assert "override_key" not in agency.user_context
-    assert agency.user_context == {"agency_key": "agency_value"}
+    assert response.context_wrapper.context.user_context == {
+        "agency_key": "agency_value",
+        "override_key": "override_value",
+        "stored_key": "test_data",
+    }
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        assert agency.user_context == {"agency_key": "agency_value"}

--- a/tests/integration/persistence/test_context_persistence.py
+++ b/tests/integration/persistence/test_context_persistence.py
@@ -122,3 +122,57 @@ async def test_deprecated_agency_user_context_persists_without_override():
             "agency_key": "agency_value",
             "stored_key": "test_data",
         }
+
+
+@pytest.mark.asyncio
+async def test_deprecated_agency_user_context_preserves_constructor_dict_reference():
+    """Deprecated agency user_context keeps the caller-provided dict identity."""
+    agent = Agent(
+        name="TestAgent",
+        instructions="You store and retrieve data using the provided tools.",
+        tools=[store_data, get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
+    )
+    user_context = {"agency_key": "agency_value"}
+
+    with pytest.warns(DeprecationWarning, match=r"Agency\(user_context"):
+        agency = Agency(agent, user_context=user_context)
+
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        assert agency.user_context is user_context
+
+    await agency.get_response("Store stored_key with value test_data")
+
+    assert user_context == {
+        "agency_key": "agency_value",
+        "stored_key": "test_data",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deprecated_agency_user_context_setter_preserves_dict_reference():
+    """Deprecated agency user_context assignment keeps the assigned dict identity."""
+    agent = Agent(
+        name="TestAgent",
+        instructions="You store and retrieve data using the provided tools.",
+        tools=[store_data, get_data],
+        model=DeterministicModel(),
+        model_settings=ModelSettings(tool_choice="required"),
+        tool_use_behavior="stop_on_first_tool",
+    )
+    agency = Agency(agent)
+    user_context = {"agency_key": "agency_value"}
+
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        agency.user_context = user_context
+    with pytest.warns(DeprecationWarning, match=r"Agency\.user_context"):
+        assert agency.user_context is user_context
+
+    await agency.get_response("Store stored_key with value test_data")
+
+    assert user_context == {
+        "agency_key": "agency_value",
+        "stored_key": "test_data",
+    }

--- a/tests/integration/tools/test_basetool_context_integration.py
+++ b/tests/integration/tools/test_basetool_context_integration.py
@@ -30,14 +30,14 @@ async def test_basetool_context_integration():
         model="gpt-5.4-mini",
     )
 
-    # Create agency with initial context
-    agency = Agency(
-        agent,
-        user_context={"test_key": "test_value", "another_key": "another_value"},
-    )
+    agency = Agency(agent)
 
     # Test reading from context
-    response = await agency.get_response("Read the value of test_key using ContextReaderTool", recipient_agent=agent)
+    response = await agency.get_response(
+        "Read the value of test_key using ContextReaderTool",
+        recipient_agent=agent,
+        context_override={"test_key": "test_value", "another_key": "another_value"},
+    )
 
     # Check that the tool was called and returned the correct value
     tool_outputs = [item.output for item in response.new_items if hasattr(item, "output")]
@@ -67,12 +67,12 @@ async def test_basetool_async_context():
         model="gpt-5.4-mini",
     )
 
-    agency = Agency(
-        agent,
-        user_context={"async_key": "async_value"},
-    )
+    agency = Agency(agent)
 
-    response = await agency.get_response("Process 'test_data' using AsyncContextTool")
+    response = await agency.get_response(
+        "Process 'test_data' using AsyncContextTool",
+        context_override={"async_key": "async_value"},
+    )
     # Check that the tool was called with context
     tool_outputs = [item.output for item in response.new_items if hasattr(item, "output")]
     assert any("Async processed: test_data with context: async_value" in str(output) for output in tool_outputs)

--- a/tests/test_agent_modules/test_execution_context.py
+++ b/tests/test_agent_modules/test_execution_context.py
@@ -1,0 +1,18 @@
+from agency_swarm import Agent
+from agency_swarm.agent.context_types import AgencyContext
+from agency_swarm.agent.execution_helpers import prepare_master_context
+from agency_swarm.utils.thread import ThreadManager
+
+
+def test_standalone_context_override_preserves_dict_reference() -> None:
+    """Standalone Agent context keeps the non-empty override dict identity."""
+    agent = Agent(name="StandaloneAgent", instructions="Test")
+    context_override = {"key": "value"}
+    agency_context = AgencyContext(
+        agency_instance=None,
+        thread_manager=ThreadManager(),
+    )
+
+    master_context = prepare_master_context(agent, context_override, agency_context)
+
+    assert master_context.user_context is context_override


### PR DESCRIPTION
This pull request deprecates Agency-owned `user_context` and moves the documented state path to run-scoped `MasterContext.user_context` supplied through `context_override`.

Root cause:
- `Agency.user_context` stores mutable session state on the agency instance.
- That conflicts with the target architecture where the caller owns session state.
- Existing releases also sync new/non-overridden context keys back to the agency instance, so this PR keeps that deprecated compatibility path for now.

Changes:
- Emits deprecation warnings for `Agency(user_context=...)` and direct `Agency.user_context` access.
- Builds `MasterContext.user_context` from the deprecated seed plus `context_override`.
- Preserves legacy sync-back for new/non-overridden context keys to avoid a breaking release.
- Preserves legacy dict-reference behavior for `Agency(user_context=...)`, `Agency.user_context = ...`, and standalone non-empty `context_override`.
- Preserves active run context for `send_message` recipient calls so sub-agents share the same run context.
- Moves context helpers out of oversized modules and keeps touched modules within the 500-line gate.
- Isolates deprecated compatibility seams in `agency/user_context.py` and `agent/run_context.py` so the next breaking release can remove them cleanly.
- Updates docs and examples to use `context_override` and carry `RunResult.context_wrapper.context.user_context` forward.
- Updates tests for caller-owned context, deprecated sync-back compatibility, legacy reference compatibility, delegated context sharing, and FastAPI request `user_context` behavior.

Future removal path:
- Delete `agency/user_context.py`, the `Agency.user_context` property assignment, the `Agency(user_context=...)` constructor parameter, and `_initial_user_context`.
- Delete deprecated sync-back support from `agent/run_context.py` and the legacy compatibility tests.
- Keep the run-scoped `MasterContext.user_context` and `context_override` path as the target API.

Validation:
- `make format`
- `make check`
- `OPENAI_API_KEY=sk-test OPENAI_AGENTS_DISABLE_TRACING=1 uv run pytest tests/test_agent_modules/test_execution_context.py tests/integration/persistence/test_context_persistence.py tests/integration/agency/test_agency_context_sharing.py tests/integration/agency/test_multi_agency_support.py tests/test_agency_modules/test_agency_responses.py tests/integration/fastapi/test_fastapi_user_context.py`
- `git diff --check`
- Local Codex review artifact: `/tmp/codex_review_11f629f3.txt`
