### PR TITLE
chore: bump agency-swarm to 1.10.0

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,8 @@ This directory contains runnable examples demonstrating key features of Agency S
 - **`multi_agent_workflow.py`** – Multi-agent collaboration with validation patterns
 - **`agency_context.py`** – Sharing data between agents using agency context
 - **`streaming.py`** – Real-time streaming responses
-- **`guardrails.py`** – Input and output guardrails
+- **`guardrails_input.py`** – Input guardrails
+- **`guardrails_output.py`** – Output guardrails
 - **`custom_persistence.py`** – Chat history persistence between sessions
 - **`tools.py`** – Tool patterns: BaseTool and @function_tool with validation
 
@@ -32,7 +33,7 @@ This directory contains runnable examples demonstrating key features of Agency S
 - **`connectors.py`** – Google Calendar integration using OpenAI hosted tools
 
 ## Model Providers
-- **`third_party_models.py`** – Using third-party models (Claude, Gemini, Grok) via LiteLLM
+- **`interactive/third_party_models.py`** – Using third-party models (Claude, Gemini, Grok) via LiteLLM
 
 ## Observability
 - **`observability.py`** – OpenAI, Langfuse and AgentOps tracing integration

--- a/examples/interactive/hybrid_communication_flows.py
+++ b/examples/interactive/hybrid_communication_flows.py
@@ -20,7 +20,7 @@ The agency demonstrates a real-world software development workflow:
 
 ## Usage
 
-Run this example with: python examples/hybrid_communication_flows.py
+Run this example with: python examples/interactive/hybrid_communication_flows.py
 
 It will open the TUI for the agency, where you can interact with the agency.
 Ask ProjectManager to implement a new feature with code quality review and security audit.

--- a/examples/interactive/third_party_models.py
+++ b/examples/interactive/third_party_models.py
@@ -13,7 +13,7 @@ Pre-requisites:
 2. Install openai-agents optional litellm package by running `pip install 'openai-agents[litellm]'`
 3. Install litellm[proxy] separatelly by running `pip install 'litellm[proxy]'`
 
-Run the agency by running `python examples/third_party_models.py`
+Run the agency by running `python examples/interactive/third_party_models.py`
 This will open the TUI for a startup validation agency with 3 agents:
 1. strategy_agent - gpt agent coordinates and summarizes work of other agents.
 2. market_research_agent - gemini agent that performs market research and competitive analysis.

--- a/examples/observability.py
+++ b/examples/observability.py
@@ -12,7 +12,7 @@ AgentOps setup guide: https://docs.agentops.ai/v2/integrations/openai_agents_pyt
 
 Results can be found in the platform's respective dashboards.
 
-Run with: python examples/observability_demo.py
+Run with: python examples/observability.py
 """
 
 import asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.9.9"
+version = "1.10.0"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.9.9"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
## Summary

Bumps Agency Swarm to `1.10.0` for the next minor release.

## Why minor

The release includes provider-specific settings, OpenRouter support, FastAPI file URL provenance, Codex replay role fixes, UTF-8 instruction loading, dependency updates, and CI/test stabilization.

## Release notes

Draft release notes are at `/tmp/agency-swarm-v1.10.0-release-notes.md`.

## Checks

Earlier release checks passed: lock refresh, lint, mypy, module tests with 765 passing and 2 skipped, package build, and Codex review.
