### PR TITLE
Fix OpenRouter reasoning detail handling

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -198,6 +198,8 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
         if source_openrouter_model is not None:
             gateway_client = _resolve_request_gateway_client(agent, config)
             openrouter_client = gateway_client if gateway_client is not None else _get_openai_client_from_agent(agent)
+        elif not _has_request_openai_overrides(config):
+            openrouter_client = _get_non_default_openai_client_from_agent(agent)
         agent.model = build_openrouter_chat_model(
             model_name,
             api_key=None if openrouter_client is not None or config is None else config.api_key,
@@ -268,6 +270,16 @@ def _resolve_request_gateway_client(agent: Agent, config: ClientConfig | None) -
     if config.base_url is None and config.api_key is None and config.default_headers is None:
         return None
     return _build_openai_client_for_agent(agent, config)
+
+
+def _get_non_default_openai_client_from_agent(agent: Agent) -> AsyncOpenAI | None:
+    client = _get_openai_client_from_agent(agent)
+    if client is None:
+        return None
+    base_url = str(client.base_url).rstrip("/")
+    if base_url == "https://api.openai.com/v1":
+        return None
+    return client
 
 
 def _resolve_openai_client_after_openrouter_override(config: ClientConfig | None) -> AsyncOpenAI | None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import json
 import logging
+import os
 import threading
 import time
 import traceback
@@ -90,6 +91,8 @@ from agency_swarm.tools.mcp_manager import attach_persistent_mcp_servers
 from agency_swarm.ui.core.agui_adapter import AguiAdapter
 from agency_swarm.utils.dry_run import force_dry_run
 from agency_swarm.utils.openrouter import (
+    OPENROUTER_API_KEY_ENV,
+    OPENROUTER_BASE_URL,
     build_openrouter_chat_model,
     get_openrouter_model_name,
     is_openrouter_model_name,
@@ -195,16 +198,27 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
         source_openrouter_model = get_openrouter_model_name(model)
         gateway_client = None
         openrouter_client = None
+        source_default_headers: dict[str, str] | None = None
         if source_openrouter_model is not None:
             gateway_client = _resolve_request_gateway_client(agent, config)
             openrouter_client = gateway_client if gateway_client is not None else _get_openai_client_from_agent(agent)
-        elif not _has_request_openai_overrides(config):
-            openrouter_client = _get_non_default_openai_client_from_agent(agent)
+        elif _has_request_openai_overrides(config):
+            source_client = _get_openai_client_from_agent(agent)
+            if source_client is not None and _should_copy_source_openai_client_for_openrouter(source_client, config):
+                openrouter_client = _copy_source_openai_client_for_openrouter(source_client, config)
+        else:
+            source_client = _get_openai_client_from_agent(agent)
+            if _should_reuse_source_openai_client(source_client):
+                openrouter_client = source_client
+            elif source_client is not None and _should_copy_source_openai_client_for_openrouter(source_client):
+                openrouter_client = _copy_source_openai_client_for_openrouter(source_client, config)
+            elif source_client is not None and _should_preserve_source_openai_headers(source_client):
+                source_default_headers = cast(dict[str, str], dict(source_client.default_headers or {})) or None
         agent.model = build_openrouter_chat_model(
             model_name,
             api_key=None if openrouter_client is not None or config is None else config.api_key,
             base_url=None if openrouter_client is not None or config is None else config.base_url,
-            default_headers=None if openrouter_client is not None or config is None else config.default_headers,
+            default_headers=_openrouter_override_default_headers(config, openrouter_client, source_default_headers),
             openai_client=openrouter_client,
             should_replay_reasoning_content=getattr(model, "should_replay_reasoning_content", None),
         )
@@ -272,14 +286,63 @@ def _resolve_request_gateway_client(agent: Agent, config: ClientConfig | None) -
     return _build_openai_client_for_agent(agent, config)
 
 
-def _get_non_default_openai_client_from_agent(agent: Agent) -> AsyncOpenAI | None:
-    client = _get_openai_client_from_agent(agent)
+def _should_reuse_source_openai_client(client: AsyncOpenAI | None) -> bool:
     if client is None:
-        return None
+        return False
     base_url = str(client.base_url).rstrip("/")
     if base_url == "https://api.openai.com/v1":
+        return False
+    return True
+
+
+def _should_preserve_source_openai_headers(client: AsyncOpenAI | None) -> bool:
+    if client is None:
+        return False
+    if client is get_default_openai_client():
+        return False
+    base_url = str(client.base_url).rstrip("/")
+    if base_url != "https://api.openai.com/v1":
+        return False
+    return bool(client.default_headers)
+
+
+def _should_copy_source_openai_client_for_openrouter(
+    client: AsyncOpenAI | None,
+    config: ClientConfig | None = None,
+) -> bool:
+    if client is None:
+        return False
+    if client is get_default_openai_client():
+        return False
+    base_url = str(client.base_url).rstrip("/")
+    if base_url != "https://api.openai.com/v1":
+        return False
+    return bool((None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV))
+
+
+def _copy_source_openai_client_for_openrouter(
+    client: AsyncOpenAI,
+    config: ClientConfig | None,
+) -> AsyncOpenAI:
+    return client.copy(
+        api_key=(None if config is None else config.api_key) or os.environ[OPENROUTER_API_KEY_ENV],
+        base_url=(None if config is None else config.base_url) or OPENROUTER_BASE_URL,
+        default_headers=(None if config is None else config.default_headers)
+        or cast(dict[str, str], dict(client.default_headers or {}))
+        or None,
+    )
+
+
+def _openrouter_override_default_headers(
+    config: ClientConfig | None,
+    openrouter_client: AsyncOpenAI | None,
+    source_default_headers: dict[str, str] | None,
+) -> dict[str, str] | None:
+    if openrouter_client is not None:
         return None
-    return client
+    if config is not None and config.default_headers is not None:
+        return config.default_headers
+    return source_default_headers
 
 
 def _resolve_openai_client_after_openrouter_override(config: ClientConfig | None) -> AsyncOpenAI | None:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -317,7 +317,7 @@ def _should_copy_source_openai_client_for_openrouter(
     base_url = str(client.base_url).rstrip("/")
     if base_url != "https://api.openai.com/v1":
         return False
-    return bool((None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV))
+    return bool((None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV) or client.api_key)
 
 
 def _copy_source_openai_client_for_openrouter(
@@ -325,7 +325,7 @@ def _copy_source_openai_client_for_openrouter(
     config: ClientConfig | None,
 ) -> AsyncOpenAI:
     return client.copy(
-        api_key=(None if config is None else config.api_key) or os.environ[OPENROUTER_API_KEY_ENV],
+        api_key=(None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV) or client.api_key,
         base_url=(None if config is None else config.base_url) or OPENROUTER_BASE_URL,
         default_headers=(None if config is None else config.default_headers)
         or cast(dict[str, str], dict(client.default_headers or {}))

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -204,6 +204,7 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
             base_url=None if openrouter_client is not None or config is None else config.base_url,
             default_headers=None if openrouter_client is not None or config is None else config.default_headers,
             openai_client=openrouter_client,
+            should_replay_reasoning_content=getattr(model, "should_replay_reasoning_content", None),
         )
         return gateway_client is not None or (source_openrouter_model is None and _has_request_openai_overrides(config))
 
@@ -2075,7 +2076,11 @@ def _apply_client_to_agent(agent: Agent, client: AsyncOpenAI | None, config: Cli
         if openrouter_model_name is not None:
             if client is None:
                 return
-            agent.model = build_openrouter_chat_model(openrouter_model_name, openai_client=client)
+            agent.model = build_openrouter_chat_model(
+                openrouter_model_name,
+                openai_client=client,
+                should_replay_reasoning_content=getattr(model, "should_replay_reasoning_content", None),
+            )
             return
         if _is_litellm_model(model.model):
             if has_litellm_overrides:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -290,9 +290,7 @@ def _should_reuse_source_openai_client(client: AsyncOpenAI | None) -> bool:
     if client is None:
         return False
     base_url = str(client.base_url).rstrip("/")
-    if base_url == "https://api.openai.com/v1":
-        return False
-    return True
+    return base_url == OPENROUTER_BASE_URL
 
 
 def _should_preserve_source_openai_headers(client: AsyncOpenAI | None) -> bool:
@@ -317,7 +315,7 @@ def _should_copy_source_openai_client_for_openrouter(
     base_url = str(client.base_url).rstrip("/")
     if base_url != "https://api.openai.com/v1":
         return False
-    return bool((None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV) or client.api_key)
+    return bool((None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV))
 
 
 def _copy_source_openai_client_for_openrouter(
@@ -325,7 +323,7 @@ def _copy_source_openai_client_for_openrouter(
     config: ClientConfig | None,
 ) -> AsyncOpenAI:
     return client.copy(
-        api_key=(None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV) or client.api_key,
+        api_key=(None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV),
         base_url=(None if config is None else config.base_url) or OPENROUTER_BASE_URL,
         default_headers=(None if config is None else config.default_headers)
         or cast(dict[str, str], dict(client.default_headers or {}))

--- a/src/agency_swarm/streaming/litellm_reasoning.py
+++ b/src/agency_swarm/streaming/litellm_reasoning.py
@@ -48,6 +48,8 @@ def _copy_thinking_blocks_to_reasoning_content(chunk: Any) -> None:
         delta = getattr(choice, "delta", None)
         if delta is None:
             continue
+        if getattr(delta, "_agency_swarm_skip_reasoning_content_copy", False):
+            continue
         if getattr(delta, "reasoning_content", None):
             continue
 

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -163,6 +163,9 @@ class _OpenRouterCompletionsProxy:
 
 
 def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[str, object]]]:
+    if len(response.choices) > 1 and any(_has_openrouter_reasoning(choice.message) for choice in response.choices):
+        raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
+
     output_details: list[dict[str, object]] = []
     for index, choice in enumerate(response.choices):
         message = choice.message
@@ -188,6 +191,8 @@ async def _normalize_openrouter_reasoning_stream(
     output = _OPENROUTER_OUTPUT_DETAILS.get()
     async for chunk in stream:
         if isinstance(chunk, ChatCompletionChunk):
+            if len(chunk.choices) > 1 and any(_has_openrouter_reasoning(choice.delta) for choice in chunk.choices):
+                raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
             primary = chunk.choices[0].index if chunk.choices else None
             _normalize_openrouter_reasoning_chunk(chunk, states)
             state = states.get(primary) if primary is not None else None
@@ -230,6 +235,15 @@ def _normalize_openrouter_reasoning_chunk(
             dynamic.thinking_blocks = [{"signature": "\n".join(state.signatures)}]
 
         state.has_reasoning = state.has_reasoning or bool(summary or text)
+
+
+def _has_openrouter_reasoning(value: Any) -> bool:
+    return bool(
+        _field(value, "reasoning")
+        or _field(value, "reasoning_content")
+        or _field(value, "reasoning_details")
+        or _field(value, "thinking_blocks")
+    )
 
 
 def _openrouter_reasoning_summary(value: Any) -> str:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -34,14 +34,23 @@ class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
     """OpenRouter chat model with provider reasoning normalized for Agents."""
 
     async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
-        result = await super()._fetch_response(*args, **kwargs)
-        if isinstance(result, ChatCompletion):
-            _normalize_openrouter_reasoning(result)
+        input_value = args[1] if len(args) > 1 else kwargs.get("input")
+        current = getattr(self, "_agency_swarm_openrouter_replay_details", [])
+        self._agency_swarm_openrouter_replay_details = _openrouter_replay_details(input_value)
+        try:
+            result = await super()._fetch_response(*args, **kwargs)
+            if isinstance(result, ChatCompletion):
+                _normalize_openrouter_reasoning(result)
+                return result
+            if isinstance(result, tuple):
+                response, stream = result
+                return response, _normalize_openrouter_reasoning_stream(stream)
             return result
-        if isinstance(result, tuple):
-            response, stream = result
-            return response, _normalize_openrouter_reasoning_stream(stream)
-        return result
+        finally:
+            self._agency_swarm_openrouter_replay_details = current
+
+    def _get_client(self) -> Any:
+        return _OpenRouterClientProxy(super()._get_client(), self)
 
 
 def build_openrouter_chat_model(
@@ -80,6 +89,40 @@ def _default_settings_model_name(actual_model: str) -> str:
 def is_openrouter_model(model: Any) -> bool:
     """Return whether a model object was built for OpenRouter."""
     return get_openrouter_model_name(model) is not None
+
+
+class _OpenRouterClientProxy:
+    def __init__(self, client: Any, model: OpenRouterChatCompletionsModel) -> None:
+        self._client = client
+        self.chat = _OpenRouterChatProxy(client.chat, model)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
+class _OpenRouterChatProxy:
+    def __init__(self, chat: Any, model: OpenRouterChatCompletionsModel) -> None:
+        self._chat = chat
+        self.completions = _OpenRouterCompletionsProxy(chat.completions, model)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._chat, name)
+
+
+class _OpenRouterCompletionsProxy:
+    def __init__(self, completions: Any, model: OpenRouterChatCompletionsModel) -> None:
+        self._completions = completions
+        self._model = model
+
+    async def create(self, **kwargs: Any) -> Any:
+        _attach_openrouter_replay_details(
+            kwargs.get("messages"),
+            getattr(self._model, "_agency_swarm_openrouter_replay_details", []),
+        )
+        return await self._completions.create(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._completions, name)
 
 
 def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
@@ -146,6 +189,93 @@ def _openrouter_reasoning_summary(value: Any) -> str:
     )
 
 
+def _openrouter_replay_details(input_value: Any) -> list[list[dict[str, object]]]:
+    if not isinstance(input_value, list):
+        return []
+
+    pending: list[dict[str, object]] | None = None
+    replay: list[list[dict[str, object]]] = []
+    for item in input_value:
+        item_type = _field(item, "type")
+        if item_type == "reasoning":
+            pending = _details_from_reasoning_item(item)
+            continue
+        if pending and _is_assistant_output_item(item):
+            replay.append(pending)
+            pending = None
+    return replay
+
+
+def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str, object]]]) -> None:
+    if not isinstance(messages, list) or not replay:
+        return
+
+    remaining = list(replay)
+    for message in messages:
+        if not remaining:
+            return
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        if "reasoning_details" in message:
+            continue
+        message["reasoning_details"] = remaining.pop(0)
+
+
+def _is_assistant_output_item(item: Any) -> bool:
+    item_type = _field(item, "type")
+    if item_type in {"message", "function_call"}:
+        return True
+    return _field(item, "role") == "assistant"
+
+
+def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    encrypted = _encrypted_parts(item)
+    contents = _content_texts(_field(item, "content"))
+
+    for summary in _summary_texts(item):
+        if summary != OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER or contents:
+            details.append({"type": "reasoning.summary", "summary": summary})
+
+    extra_count = max(0, len(encrypted) - len(contents))
+    for value in encrypted[:extra_count]:
+        details.append({"type": "reasoning.encrypted", "data": value})
+
+    signatures = encrypted[extra_count:]
+    for index, text in enumerate(contents):
+        detail: dict[str, object] = {"type": "reasoning.text", "text": text}
+        if index < len(signatures):
+            detail["signature"] = signatures[index]
+        details.append(detail)
+
+    return details
+
+
+def _summary_texts(item: Any) -> list[str]:
+    summary = _field(item, "summary")
+    if not isinstance(summary, list):
+        return []
+    return [text for value in summary for text in [_first_text_from_any(value, ("text", "summary"))] if text]
+
+
+def _content_texts(content: Any) -> list[str]:
+    if not isinstance(content, list):
+        return []
+    return [
+        text
+        for value in content
+        for text in [_first_text_from_any(value, ("text", "thinking", "reasoning", "content"))]
+        if text
+    ]
+
+
+def _encrypted_parts(item: Any) -> list[str]:
+    encrypted = _field(item, "encrypted_content")
+    if not isinstance(encrypted, str):
+        return []
+    return [part for part in encrypted.split("\n") if part]
+
+
 def _reasoning_details_summary(details: Any) -> str:
     if not isinstance(details, list):
         return ""
@@ -207,6 +337,16 @@ def _openrouter_reasoning_signatures(details: Any) -> list[str]:
 def _first_text(value: dict[str, Any], keys: tuple[str, ...]) -> str:
     for key in keys:
         found = value.get(key)
+        if isinstance(found, str):
+            return found
+    return ""
+
+
+def _first_text_from_any(value: Any, keys: tuple[str, ...]) -> str:
+    if isinstance(value, dict):
+        return _first_text(value, keys)
+    for key in keys:
+        found = getattr(value, key, None)
         if isinstance(found, str):
             return found
     return ""

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -315,7 +315,7 @@ def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
     contents = _content_texts(_field(item, "content"))
 
     for summary in _summary_texts(item):
-        if summary != OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER or contents:
+        if summary != OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER:
             details.append({"type": "reasoning.summary", "summary": summary})
 
     extra_count = max(0, len(encrypted) - len(contents))

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -2,7 +2,9 @@
 
 import os
 from collections.abc import AsyncIterator
+from contextvars import ContextVar
 from copy import deepcopy
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -14,6 +16,14 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODEL_PREFIX = "openrouter/"
 OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER = "[REDACTED]"
 OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
+_OPENROUTER_OUTPUT_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
+    "_OPENROUTER_OUTPUT_DETAILS",
+    default=None,
+)
+_OPENROUTER_REPLAY_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
+    "_OPENROUTER_REPLAY_DETAILS",
+    default=None,
+)
 
 
 def is_openrouter_model_name(model_name: str) -> bool:
@@ -35,57 +45,47 @@ def get_openrouter_model_name(model: object) -> str | None:
 class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
     """OpenRouter chat model with provider reasoning normalized for Agents."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._agency_swarm_openrouter_output_details: list[list[dict[str, object]]] = []
-        self._agency_swarm_openrouter_replay_details: list[list[dict[str, object]]] = []
-
     async def get_response(self, *args: Any, **kwargs: Any) -> Any:
-        current = getattr(self, "_agency_swarm_openrouter_output_details", [])
-        self._agency_swarm_openrouter_output_details = []
+        details: list[list[dict[str, object]]] = []
+        token = _OPENROUTER_OUTPUT_DETAILS.set(details)
         try:
             response = await super().get_response(*args, **kwargs)
-            _attach_openrouter_output_details(
-                response.output,
-                getattr(self, "_agency_swarm_openrouter_output_details", []),
-            )
+            _attach_openrouter_output_details(response.output, details)
             return response
         finally:
-            self._agency_swarm_openrouter_output_details = current
+            _OPENROUTER_OUTPUT_DETAILS.reset(token)
 
     async def stream_response(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        current = getattr(self, "_agency_swarm_openrouter_output_details", [])
-        self._agency_swarm_openrouter_output_details = []
+        details: list[list[dict[str, object]]] = []
+        token = _OPENROUTER_OUTPUT_DETAILS.set(details)
         try:
             async for event in super().stream_response(*args, **kwargs):
                 if getattr(event, "type", None) == "response.completed":
                     completed = cast(Any, event)
-                    _attach_openrouter_output_details(
-                        completed.response.output,
-                        getattr(self, "_agency_swarm_openrouter_output_details", []),
-                    )
+                    _attach_openrouter_output_details(completed.response.output, details)
                 yield event
         finally:
-            self._agency_swarm_openrouter_output_details = current
+            _OPENROUTER_OUTPUT_DETAILS.reset(token)
 
     async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
         input_value = args[1] if len(args) > 1 else kwargs.get("input")
-        current = getattr(self, "_agency_swarm_openrouter_replay_details", [])
-        self._agency_swarm_openrouter_replay_details = _openrouter_replay_details(input_value)
+        token = _OPENROUTER_REPLAY_DETAILS.set(_openrouter_replay_details(input_value))
         try:
             result = await super()._fetch_response(*args, **kwargs)
             if isinstance(result, ChatCompletion):
-                self._agency_swarm_openrouter_output_details = _normalize_openrouter_reasoning(result)
+                details = _OPENROUTER_OUTPUT_DETAILS.get()
+                if details is not None:
+                    details[:] = _normalize_openrouter_reasoning(result)
                 return result
             if isinstance(result, tuple):
                 response, stream = result
-                return response, _normalize_openrouter_reasoning_stream(stream, self)
+                return response, _normalize_openrouter_reasoning_stream(stream)
             return result
         finally:
-            self._agency_swarm_openrouter_replay_details = current
+            _OPENROUTER_REPLAY_DETAILS.reset(token)
 
     def _get_client(self) -> Any:
-        return _OpenRouterClientProxy(super()._get_client(), self)
+        return _OpenRouterClientProxy(super()._get_client())
 
 
 def build_openrouter_chat_model(
@@ -127,32 +127,31 @@ def is_openrouter_model(model: Any) -> bool:
 
 
 class _OpenRouterClientProxy:
-    def __init__(self, client: Any, model: OpenRouterChatCompletionsModel) -> None:
+    def __init__(self, client: Any) -> None:
         self._client = client
-        self.chat = _OpenRouterChatProxy(client.chat, model)
+        self.chat = _OpenRouterChatProxy(client.chat)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._client, name)
 
 
 class _OpenRouterChatProxy:
-    def __init__(self, chat: Any, model: OpenRouterChatCompletionsModel) -> None:
+    def __init__(self, chat: Any) -> None:
         self._chat = chat
-        self.completions = _OpenRouterCompletionsProxy(chat.completions, model)
+        self.completions = _OpenRouterCompletionsProxy(chat.completions)
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._chat, name)
 
 
 class _OpenRouterCompletionsProxy:
-    def __init__(self, completions: Any, model: OpenRouterChatCompletionsModel) -> None:
+    def __init__(self, completions: Any) -> None:
         self._completions = completions
-        self._model = model
 
     async def create(self, **kwargs: Any) -> Any:
         _attach_openrouter_replay_details(
             kwargs.get("messages"),
-            getattr(self._model, "_agency_swarm_openrouter_replay_details", []),
+            _OPENROUTER_REPLAY_DETAILS.get() or [],
         )
         return await self._completions.create(**kwargs)
 
@@ -181,34 +180,40 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[
 
 async def _normalize_openrouter_reasoning_stream(
     stream: AsyncIterator[Any],
-    model: OpenRouterChatCompletionsModel,
 ) -> AsyncIterator[Any]:
-    signatures: list[str] = []
-    has_reasoning = False
-    output_details: list[dict[str, object]] = []
+    states: dict[int, _OpenRouterStreamState] = {}
+    output = _OPENROUTER_OUTPUT_DETAILS.get()
     async for chunk in stream:
         if isinstance(chunk, ChatCompletionChunk):
-            has_reasoning = _normalize_openrouter_reasoning_chunk(chunk, signatures, has_reasoning, output_details)
-            if output_details:
-                model._agency_swarm_openrouter_output_details = [output_details]
+            _normalize_openrouter_reasoning_chunk(chunk, states)
+            if output is not None:
+                output[:] = [
+                    state.output_details for _, state in sorted(states.items()) if state.output_details
+                ]
         yield chunk
+
+
+@dataclass
+class _OpenRouterStreamState:
+    signatures: list[str] = field(default_factory=list)
+    has_reasoning: bool = False
+    output_details: list[dict[str, object]] = field(default_factory=list)
 
 
 def _normalize_openrouter_reasoning_chunk(
     chunk: ChatCompletionChunk,
-    signatures: list[str],
-    has_reasoning: bool,
-    output_details: list[dict[str, object]],
-) -> bool:
+    states: dict[int, _OpenRouterStreamState],
+) -> None:
     for choice in chunk.choices:
+        state = states.setdefault(choice.index, _OpenRouterStreamState())
         delta = choice.delta
         dynamic = cast(Any, delta)
         dynamic._agency_swarm_skip_reasoning_content_copy = True
         details = _field(delta, "reasoning_details")
-        output_details.extend(_copy_reasoning_details(details))
+        state.output_details.extend(_copy_reasoning_details(details))
         text = _reasoning_details_text(details)
         summary = _reasoning_details_summary(details)
-        if not summary and not text and not has_reasoning:
+        if not summary and not text and not state.has_reasoning:
             summary = _encrypted_reasoning_placeholder(details)
 
         if summary and not _field(delta, "reasoning_content"):
@@ -217,12 +222,11 @@ def _normalize_openrouter_reasoning_chunk(
         if text and not _field(delta, "reasoning"):
             dynamic.reasoning = text
 
-        signatures.extend(_openrouter_reasoning_signatures(details))
-        if signatures and not _field(delta, "thinking_blocks"):
-            dynamic.thinking_blocks = [{"signature": "\n".join(signatures)}]
+        state.signatures.extend(_openrouter_reasoning_signatures(details))
+        if state.signatures and not _field(delta, "thinking_blocks"):
+            dynamic.thinking_blocks = [{"signature": "\n".join(state.signatures)}]
 
-        has_reasoning = has_reasoning or bool(summary or text)
-    return has_reasoning
+        state.has_reasoning = state.has_reasoning or bool(summary or text)
 
 
 def _openrouter_reasoning_summary(value: Any) -> str:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -1,10 +1,11 @@
 """OpenRouter model helpers."""
 
 import os
-from typing import Any
+from typing import Any, cast
 
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
 
 OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -27,6 +28,17 @@ def get_openrouter_model_name(model: object) -> str | None:
     return value if isinstance(value, str) and is_openrouter_model_name(value) else None
 
 
+class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
+    """OpenRouter chat model with provider reasoning normalized for Agents."""
+
+    async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
+        result = await super()._fetch_response(*args, **kwargs)
+        if isinstance(result, ChatCompletion):
+            _normalize_openrouter_reasoning(result)
+            return result
+        return result
+
+
 def build_openrouter_chat_model(
     model_name: str,
     *,
@@ -47,7 +59,7 @@ def build_openrouter_chat_model(
             base_url=base_url or OPENROUTER_BASE_URL,
             default_headers=default_headers,
         )
-    model = OpenAIChatCompletionsModel(model=actual_model, openai_client=client)
+    model = OpenRouterChatCompletionsModel(model=actual_model, openai_client=client)
     model._agency_swarm_openrouter_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]
     model._agency_swarm_usage_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]
     model._agency_swarm_default_model_name = _default_settings_model_name(actual_model)  # type: ignore[attr-defined]
@@ -63,3 +75,84 @@ def _default_settings_model_name(actual_model: str) -> str:
 def is_openrouter_model(model: Any) -> bool:
     """Return whether a model object was built for OpenRouter."""
     return get_openrouter_model_name(model) is not None
+
+
+def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
+    for choice in response.choices:
+        message = choice.message
+        dynamic = cast(Any, message)
+        text = _openrouter_reasoning_text(message)
+        if text and not _field(message, "reasoning_content"):
+            dynamic.reasoning_content = text
+
+        blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
+        if blocks and not _field(message, "thinking_blocks"):
+            dynamic.thinking_blocks = blocks
+
+
+def _openrouter_reasoning_text(value: Any) -> str:
+    reasoning = _field(value, "reasoning")
+    if isinstance(reasoning, str):
+        return reasoning
+    if isinstance(reasoning, dict):
+        return _first_text(reasoning, ("thinking", "text", "reasoning", "content"))
+    return _reasoning_details_text(_field(value, "reasoning_details"))
+
+
+def _reasoning_details_text(details: Any) -> str:
+    if not isinstance(details, list):
+        return ""
+    return "".join(
+        text
+        for item in details
+        if isinstance(item, dict)
+        for text in [_first_text(item, ("thinking", "text", "reasoning", "content"))]
+        if text
+    )
+
+
+def _openrouter_reasoning_blocks(details: Any) -> list[dict[str, str]]:
+    if not isinstance(details, list):
+        return []
+
+    blocks: list[dict[str, str]] = []
+    for item in details:
+        if not isinstance(item, dict):
+            continue
+        text = _first_text(item, ("thinking", "text", "reasoning", "content"))
+        signature = _first_text(item, ("signature", "data", "encrypted_content"))
+        block: dict[str, str] = {}
+        if text:
+            block["thinking"] = text
+        if signature:
+            block["signature"] = signature
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _first_text(value: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        found = value.get(key)
+        if isinstance(found, str):
+            return found
+    return ""
+
+
+def _field(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        found = value.get(key)
+        if found is not None:
+            return found
+
+    found = getattr(value, key, None)
+    if found is not None:
+        return found
+
+    extra = getattr(value, "model_extra", None)
+    if isinstance(extra, dict):
+        found = extra.get(key)
+        if found is not None:
+            return found
+
+    return None

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -216,8 +216,9 @@ def _normalize_openrouter_reasoning_chunk(
         state = states.setdefault(choice.index, _OpenRouterStreamState())
         delta = choice.delta
         dynamic = cast(Any, delta)
-        dynamic._agency_swarm_skip_reasoning_content_copy = True
         details = _field(delta, "reasoning_details")
+        if details:
+            dynamic._agency_swarm_skip_reasoning_content_copy = True
         state.output_details.extend(_copy_reasoning_details(details))
         text = _reasoning_details_text(details)
         summary = _reasoning_details_summary(details)
@@ -247,6 +248,9 @@ def _has_openrouter_reasoning(value: Any) -> bool:
 
 
 def _openrouter_reasoning_summary(value: Any) -> str:
+    content = _field(value, "reasoning_content")
+    if isinstance(content, str):
+        return content
     reasoning = _field(value, "reasoning")
     if isinstance(reasoning, str):
         return reasoning
@@ -256,6 +260,7 @@ def _openrouter_reasoning_summary(value: Any) -> str:
     return (
         _reasoning_details_summary(details)
         or _reasoning_details_text(details)
+        or _reasoning_details_text(_field(value, "thinking_blocks"))
         or _encrypted_reasoning_placeholder(details)
     )
 

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -281,15 +281,17 @@ def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str,
     if not isinstance(messages, list) or not replay:
         return
 
-    remaining = list(replay)
-    for message in messages:
-        if not remaining:
-            return
-        if not isinstance(message, dict) or message.get("role") != "assistant":
-            continue
-        if "reasoning_details" in message:
-            continue
-        message["reasoning_details"] = remaining.pop(0)
+    targets = [
+        message
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("role") == "assistant"
+        and "reasoning_details" not in message
+    ]
+    selected = targets[-len(replay) :]
+    selected_replay = replay[-len(selected) :] if selected else []
+    for message, details in zip(selected, selected_replay, strict=True):
+        message["reasoning_details"] = details
 
 
 def _is_assistant_output_item(item: Any) -> bool:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -149,7 +149,16 @@ def is_openrouter_model(model: Any) -> bool:
 
 
 def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) -> bool:
-    return OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
+    origin = context.reasoning.origin_model
+    return (
+        OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
+        and origin is not None
+        and _model_family(origin) == _model_family(context.model)
+    )
+
+
+def _model_family(model: str) -> str:
+    return strip_openrouter_prefix(model).split("/", 1)[0].lower()
 
 
 class _OpenRouterClientProxy:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -1,11 +1,12 @@
 """OpenRouter model helpers."""
 
 import os
+from collections.abc import AsyncIterator
 from typing import Any, cast
 
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
 OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -36,6 +37,9 @@ class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
         if isinstance(result, ChatCompletion):
             _normalize_openrouter_reasoning(result)
             return result
+        if isinstance(result, tuple):
+            response, stream = result
+            return response, _normalize_openrouter_reasoning_stream(stream)
         return result
 
 
@@ -81,22 +85,57 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
     for choice in response.choices:
         message = choice.message
         dynamic = cast(Any, message)
-        text = _openrouter_reasoning_text(message)
-        if text and not _field(message, "reasoning_content"):
-            dynamic.reasoning_content = text
+        summary = _openrouter_reasoning_summary(message)
+        if summary and not _field(message, "reasoning_content"):
+            dynamic.reasoning_content = summary
 
         blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
         if blocks and not _field(message, "thinking_blocks"):
             dynamic.thinking_blocks = blocks
 
 
-def _openrouter_reasoning_text(value: Any) -> str:
+async def _normalize_openrouter_reasoning_stream(stream: AsyncIterator[Any]) -> AsyncIterator[Any]:
+    signatures: list[str] = []
+    async for chunk in stream:
+        if isinstance(chunk, ChatCompletionChunk):
+            _normalize_openrouter_reasoning_chunk(chunk, signatures)
+        yield chunk
+
+
+def _normalize_openrouter_reasoning_chunk(chunk: ChatCompletionChunk, signatures: list[str]) -> None:
+    for choice in chunk.choices:
+        delta = choice.delta
+        dynamic = cast(Any, delta)
+        details = _field(delta, "reasoning_details")
+        summary = _reasoning_details_summary(details)
+        if summary and not _field(delta, "reasoning_content"):
+            dynamic.reasoning_content = summary
+
+        text = _reasoning_details_text(details)
+        if text and not _field(delta, "reasoning"):
+            dynamic.reasoning = text
+
+        signatures.extend(_openrouter_reasoning_signatures(details))
+        if signatures and not _field(delta, "thinking_blocks"):
+            dynamic.thinking_blocks = [{"signature": "\n".join(signatures)}]
+
+
+def _openrouter_reasoning_summary(value: Any) -> str:
     reasoning = _field(value, "reasoning")
     if isinstance(reasoning, str):
         return reasoning
     if isinstance(reasoning, dict):
-        return _first_text(reasoning, ("thinking", "text", "reasoning", "content"))
-    return _reasoning_details_text(_field(value, "reasoning_details"))
+        return _first_text(reasoning, ("summary", "thinking", "text", "reasoning", "content"))
+    details = _field(value, "reasoning_details")
+    return _reasoning_details_summary(details) or _reasoning_details_text(details)
+
+
+def _reasoning_details_summary(details: Any) -> str:
+    if not isinstance(details, list):
+        return ""
+    return "".join(
+        text for item in details if isinstance(item, dict) for text in [_first_text(item, ("summary",))] if text
+    )
 
 
 def _reasoning_details_text(details: Any) -> str:
@@ -111,7 +150,7 @@ def _reasoning_details_text(details: Any) -> str:
     )
 
 
-def _openrouter_reasoning_blocks(details: Any) -> list[dict[str, str]]:
+def _openrouter_reasoning_blocks(details: Any, *, include_text: bool = True) -> list[dict[str, str]]:
     if not isinstance(details, list):
         return []
 
@@ -119,7 +158,7 @@ def _openrouter_reasoning_blocks(details: Any) -> list[dict[str, str]]:
     for item in details:
         if not isinstance(item, dict):
             continue
-        text = _first_text(item, ("thinking", "text", "reasoning", "content"))
+        text = _first_text(item, ("thinking", "text", "reasoning", "content")) if include_text else ""
         signature = _first_text(item, ("signature", "data", "encrypted_content"))
         block: dict[str, str] = {}
         if text:
@@ -129,6 +168,18 @@ def _openrouter_reasoning_blocks(details: Any) -> list[dict[str, str]]:
         if block:
             blocks.append(block)
     return blocks
+
+
+def _openrouter_reasoning_signatures(details: Any) -> list[str]:
+    if not isinstance(details, list):
+        return []
+    return [
+        signature
+        for item in details
+        if isinstance(item, dict)
+        for signature in [_first_text(item, ("signature", "data", "encrypted_content"))]
+        if signature
+    ]
 
 
 def _first_text(value: dict[str, Any], keys: tuple[str, ...]) -> str:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -2,6 +2,7 @@
 
 import os
 from collections.abc import AsyncIterator
+from copy import deepcopy
 from typing import Any, cast
 
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -12,6 +13,7 @@ OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODEL_PREFIX = "openrouter/"
 OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER = "[REDACTED]"
+OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
 
 
 def is_openrouter_model_name(model_name: str) -> bool:
@@ -33,6 +35,39 @@ def get_openrouter_model_name(model: object) -> str | None:
 class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
     """OpenRouter chat model with provider reasoning normalized for Agents."""
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._agency_swarm_openrouter_output_details: list[list[dict[str, object]]] = []
+        self._agency_swarm_openrouter_replay_details: list[list[dict[str, object]]] = []
+
+    async def get_response(self, *args: Any, **kwargs: Any) -> Any:
+        current = getattr(self, "_agency_swarm_openrouter_output_details", [])
+        self._agency_swarm_openrouter_output_details = []
+        try:
+            response = await super().get_response(*args, **kwargs)
+            _attach_openrouter_output_details(
+                response.output,
+                getattr(self, "_agency_swarm_openrouter_output_details", []),
+            )
+            return response
+        finally:
+            self._agency_swarm_openrouter_output_details = current
+
+    async def stream_response(self, *args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        current = getattr(self, "_agency_swarm_openrouter_output_details", [])
+        self._agency_swarm_openrouter_output_details = []
+        try:
+            async for event in super().stream_response(*args, **kwargs):
+                if getattr(event, "type", None) == "response.completed":
+                    completed = cast(Any, event)
+                    _attach_openrouter_output_details(
+                        completed.response.output,
+                        getattr(self, "_agency_swarm_openrouter_output_details", []),
+                    )
+                yield event
+        finally:
+            self._agency_swarm_openrouter_output_details = current
+
     async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
         input_value = args[1] if len(args) > 1 else kwargs.get("input")
         current = getattr(self, "_agency_swarm_openrouter_replay_details", [])
@@ -40,11 +75,11 @@ class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
         try:
             result = await super()._fetch_response(*args, **kwargs)
             if isinstance(result, ChatCompletion):
-                _normalize_openrouter_reasoning(result)
+                self._agency_swarm_openrouter_output_details = _normalize_openrouter_reasoning(result)
                 return result
             if isinstance(result, tuple):
                 response, stream = result
-                return response, _normalize_openrouter_reasoning_stream(stream)
+                return response, _normalize_openrouter_reasoning_stream(stream, self)
             return result
         finally:
             self._agency_swarm_openrouter_replay_details = current
@@ -125,10 +160,15 @@ class _OpenRouterCompletionsProxy:
         return getattr(self._completions, name)
 
 
-def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
+def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[str, object]]]:
+    output_details: list[list[dict[str, object]]] = []
     for choice in response.choices:
         message = choice.message
         dynamic = cast(Any, message)
+        details = _copy_reasoning_details(_field(message, "reasoning_details"))
+        if details:
+            output_details.append(details)
+
         summary = _openrouter_reasoning_summary(message)
         if summary and not _field(message, "reasoning_content"):
             dynamic.reasoning_content = summary
@@ -136,14 +176,21 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
         blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
         if blocks and not _field(message, "thinking_blocks"):
             dynamic.thinking_blocks = blocks
+    return output_details
 
 
-async def _normalize_openrouter_reasoning_stream(stream: AsyncIterator[Any]) -> AsyncIterator[Any]:
+async def _normalize_openrouter_reasoning_stream(
+    stream: AsyncIterator[Any],
+    model: OpenRouterChatCompletionsModel,
+) -> AsyncIterator[Any]:
     signatures: list[str] = []
     has_reasoning = False
+    output_details: list[dict[str, object]] = []
     async for chunk in stream:
         if isinstance(chunk, ChatCompletionChunk):
-            has_reasoning = _normalize_openrouter_reasoning_chunk(chunk, signatures, has_reasoning)
+            has_reasoning = _normalize_openrouter_reasoning_chunk(chunk, signatures, has_reasoning, output_details)
+            if output_details:
+                model._agency_swarm_openrouter_output_details = [output_details]
         yield chunk
 
 
@@ -151,11 +198,13 @@ def _normalize_openrouter_reasoning_chunk(
     chunk: ChatCompletionChunk,
     signatures: list[str],
     has_reasoning: bool,
+    output_details: list[dict[str, object]],
 ) -> bool:
     for choice in chunk.choices:
         delta = choice.delta
         dynamic = cast(Any, delta)
         details = _field(delta, "reasoning_details")
+        output_details.extend(_copy_reasoning_details(details))
         text = _reasoning_details_text(details)
         summary = _reasoning_details_summary(details)
         if not summary and not text and not has_reasoning:
@@ -198,7 +247,7 @@ def _openrouter_replay_details(input_value: Any) -> list[list[dict[str, object]]
     for item in input_value:
         item_type = _field(item, "type")
         if item_type == "reasoning":
-            pending = _details_from_reasoning_item(item)
+            pending = _original_reasoning_details(item) or _details_from_reasoning_item(item)
             continue
         if pending and _is_assistant_output_item(item):
             replay.append(pending)
@@ -228,6 +277,30 @@ def _is_assistant_output_item(item: Any) -> bool:
     return _field(item, "role") == "assistant"
 
 
+def _attach_openrouter_output_details(output: Any, details: list[list[dict[str, object]]]) -> None:
+    if not isinstance(output, list) or not details:
+        return
+
+    remaining = list(details)
+    for item in output:
+        if not remaining:
+            return
+        if _field(item, "type") != "reasoning":
+            continue
+        provider_data = _field(item, "provider_data")
+        provider = dict(provider_data) if isinstance(provider_data, dict) else {}
+        provider[OPENROUTER_REASONING_DETAILS_KEY] = _copy_reasoning_details(remaining.pop(0))
+        dynamic = cast(Any, item)
+        dynamic.provider_data = provider
+
+
+def _original_reasoning_details(item: Any) -> list[dict[str, object]]:
+    provider_data = _field(item, "provider_data")
+    if not isinstance(provider_data, dict):
+        return []
+    return _copy_reasoning_details(provider_data.get(OPENROUTER_REASONING_DETAILS_KEY))
+
+
 def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
     details: list[dict[str, object]] = []
     encrypted = _encrypted_parts(item)
@@ -249,6 +322,12 @@ def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
         details.append(detail)
 
     return details
+
+
+def _copy_reasoning_details(details: Any) -> list[dict[str, object]]:
+    if not isinstance(details, list):
+        return []
+    return [cast(dict[str, object], deepcopy(item)) for item in details if isinstance(item, dict)]
 
 
 def _summary_texts(item: Any) -> list[str]:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -152,6 +152,7 @@ def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) 
     origin = context.reasoning.origin_model
     return (
         OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
+        and context.base_url == OPENROUTER_BASE_URL
         and origin is not None
         and _model_family(origin) == _model_family(context.model)
     )

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -2,33 +2,47 @@
 
 import os
 from collections.abc import AsyncIterator
-from contextvars import ContextVar
-from copy import deepcopy
-from dataclasses import dataclass, field
 from typing import Any, cast
 
-from agents.models.chatcmpl_converter import (
-    ReasoningContentReplayContext,
-    ReasoningContentSource,
-    ShouldReplayReasoningContent,
-)
+from agents.models.chatcmpl_converter import ShouldReplayReasoningContent
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat import ChatCompletion
+
+from agency_swarm.utils.openrouter_reasoning import (
+    _OPENROUTER_OUTPUT_DETAILS,
+    _OPENROUTER_REPLAY_DETAILS,
+    OPENROUTER_BASE_URL,
+    OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER,
+    OPENROUTER_MODEL_PREFIX,
+    OPENROUTER_REASONING_DETAILS_KEY,
+    _attach_openrouter_output_details,
+    _details_from_reasoning_item,
+    _normalize_openrouter_reasoning,
+    _normalize_openrouter_reasoning_stream,
+    _openrouter_replay_details,
+    _OpenRouterClientProxy,
+    _should_replay_openrouter_reasoning,
+)
 
 OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
-OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
-OPENROUTER_MODEL_PREFIX = "openrouter/"
-OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER = "[REDACTED]"
-OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
-_OPENROUTER_OUTPUT_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
-    "_OPENROUTER_OUTPUT_DETAILS",
-    default=None,
-)
-_OPENROUTER_REPLAY_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
+
+__all__ = [
+    "OPENROUTER_API_KEY_ENV",
+    "OPENROUTER_BASE_URL",
+    "OPENROUTER_MODEL_PREFIX",
+    "OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER",
+    "OPENROUTER_REASONING_DETAILS_KEY",
+    "OpenRouterChatCompletionsModel",
+    "build_openrouter_chat_model",
+    "get_openrouter_model_name",
+    "is_openrouter_model",
+    "is_openrouter_model_name",
+    "strip_openrouter_prefix",
     "_OPENROUTER_REPLAY_DETAILS",
-    default=None,
-)
+    "_details_from_reasoning_item",
+    "_normalize_openrouter_reasoning_stream",
+]
 
 
 def is_openrouter_model_name(model_name: str) -> bool:
@@ -146,434 +160,3 @@ def _default_settings_model_name(actual_model: str) -> str:
 def is_openrouter_model(model: Any) -> bool:
     """Return whether a model object was built for OpenRouter."""
     return get_openrouter_model_name(model) is not None
-
-
-def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) -> bool:
-    origin = context.reasoning.origin_model
-    return (
-        _is_openrouter_base_url(context.base_url)
-        and origin is not None
-        and _model_family(origin) == _model_family(context.model)
-    )
-
-
-def _is_openrouter_base_url(base_url: str | None) -> bool:
-    return base_url is not None and base_url.rstrip("/") == OPENROUTER_BASE_URL
-
-
-def _model_family(model: str) -> str:
-    return strip_openrouter_prefix(model).split("/", 1)[0].lower()
-
-
-class _OpenRouterClientProxy:
-    def __init__(self, client: Any) -> None:
-        self._client = client
-        self.chat = _OpenRouterChatProxy(client.chat)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._client, name)
-
-
-class _OpenRouterChatProxy:
-    def __init__(self, chat: Any) -> None:
-        self._chat = chat
-        self.completions = _OpenRouterCompletionsProxy(chat.completions)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._chat, name)
-
-
-class _OpenRouterCompletionsProxy:
-    def __init__(self, completions: Any) -> None:
-        self._completions = completions
-
-    async def create(self, **kwargs: Any) -> Any:
-        replay = _OPENROUTER_REPLAY_DETAILS.get() or []
-        if replay and isinstance(kwargs.get("messages"), list):
-            kwargs = {**kwargs, "messages": deepcopy(kwargs["messages"])}
-        _attach_openrouter_replay_details(
-            kwargs.get("messages"),
-            replay,
-        )
-        return await self._completions.create(**kwargs)
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._completions, name)
-
-
-def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[str, object]]]:
-    if len(response.choices) > 1 and any(_has_openrouter_reasoning(choice.message) for choice in response.choices):
-        raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
-
-    output_details: list[dict[str, object]] = []
-    for index, choice in enumerate(response.choices):
-        message = choice.message
-        dynamic = cast(Any, message)
-        details = _openrouter_message_details(message)
-        if index == 0:
-            output_details = details
-
-        summary = _openrouter_reasoning_summary(message)
-        if summary and not _field(message, "reasoning_content"):
-            dynamic.reasoning_content = summary
-
-        blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
-        if blocks and not _field(message, "thinking_blocks"):
-            dynamic.thinking_blocks = blocks
-    return [output_details] if output_details else []
-
-
-async def _normalize_openrouter_reasoning_stream(
-    stream: AsyncIterator[Any],
-) -> AsyncIterator[Any]:
-    states: dict[int, _OpenRouterStreamState] = {}
-    output = _OPENROUTER_OUTPUT_DETAILS.get()
-    async for chunk in stream:
-        if isinstance(chunk, ChatCompletionChunk):
-            if len(chunk.choices) > 1 and any(_has_openrouter_reasoning(choice.delta) for choice in chunk.choices):
-                raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
-            primary = chunk.choices[0].index if chunk.choices else None
-            _normalize_openrouter_reasoning_chunk(chunk, states)
-            state = states.get(primary) if primary is not None else None
-            if output is not None and state is not None:
-                output[:] = [state.output_details] if state.output_details else []
-        yield chunk
-
-
-@dataclass
-class _OpenRouterStreamState:
-    signatures: list[str] = field(default_factory=list)
-    has_reasoning: bool = False
-    output_details: list[dict[str, object]] = field(default_factory=list)
-
-
-def _normalize_openrouter_reasoning_chunk(
-    chunk: ChatCompletionChunk,
-    states: dict[int, _OpenRouterStreamState],
-) -> None:
-    for choice in chunk.choices:
-        state = states.setdefault(choice.index, _OpenRouterStreamState())
-        delta = choice.delta
-        dynamic = cast(Any, delta)
-        details = _field(delta, "reasoning_details")
-        if details:
-            dynamic._agency_swarm_skip_reasoning_content_copy = True
-        state.output_details.extend(_openrouter_message_details(delta))
-        text = _reasoning_details_text(details)
-        summary = _reasoning_details_summary(details)
-        if not summary and not text and not state.has_reasoning:
-            summary = _encrypted_reasoning_placeholder(details)
-
-        if summary and not _field(delta, "reasoning_content"):
-            dynamic.reasoning_content = summary
-
-        if text and not summary and not state.has_reasoning and not _field(delta, "reasoning_content"):
-            dynamic.reasoning_content = text
-
-        if text and not _field(delta, "reasoning"):
-            dynamic.reasoning = text
-
-        state.signatures.extend(_openrouter_reasoning_signatures(details))
-        if state.signatures and not _field(delta, "thinking_blocks"):
-            dynamic.thinking_blocks = [{"signature": "\n".join(state.signatures)}]
-
-        state.has_reasoning = state.has_reasoning or bool(summary or text)
-
-
-def _has_openrouter_reasoning(value: Any) -> bool:
-    return bool(
-        _field(value, "reasoning")
-        or _field(value, "reasoning_content")
-        or _field(value, "reasoning_details")
-        or _field(value, "thinking_blocks")
-    )
-
-
-def _openrouter_reasoning_summary(value: Any) -> str:
-    content = _field(value, "reasoning_content")
-    if isinstance(content, str):
-        return content
-    reasoning = _field(value, "reasoning")
-    if isinstance(reasoning, str):
-        return reasoning
-    if isinstance(reasoning, dict):
-        return _first_text(reasoning, ("summary", "thinking", "text", "reasoning", "content"))
-    details = _field(value, "reasoning_details")
-    return (
-        _reasoning_details_summary(details)
-        or _reasoning_details_text(details)
-        or _reasoning_details_text(_field(value, "thinking_blocks"))
-        or _encrypted_reasoning_placeholder(details)
-    )
-
-
-def _openrouter_replay_details(
-    input_value: Any,
-    *,
-    model: str,
-    base_url: str | None,
-    should_replay: ShouldReplayReasoningContent | None,
-) -> list[list[dict[str, object]]]:
-    if not isinstance(input_value, list):
-        return []
-
-    pending: list[dict[str, object]] | None = None
-    replay: list[list[dict[str, object]]] = []
-    for item in input_value:
-        item_type = _field(item, "type")
-        if item_type == "reasoning":
-            details = _original_reasoning_details(item) or _details_from_reasoning_item(item)
-            pending = (
-                details
-                if details and _should_replay_openrouter_item(item, model, base_url, should_replay)
-                else None
-            )
-            continue
-        if pending and _is_assistant_output_item(item):
-            replay.append(pending)
-            pending = None
-    return replay
-
-
-def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str, object]]]) -> None:
-    if not isinstance(messages, list) or not replay:
-        return
-
-    targets = [
-        message
-        for message in messages
-        if isinstance(message, dict)
-        and message.get("role") == "assistant"
-        and ("reasoning_content" in message or message.get("tool_calls"))
-        and "reasoning_details" not in message
-    ]
-    selected = targets[-len(replay) :]
-    selected_replay = replay[-len(selected) :] if selected else []
-    for message, details in zip(selected, selected_replay, strict=True):
-        message["reasoning_details"] = details
-
-
-def _is_assistant_output_item(item: Any) -> bool:
-    item_type = _field(item, "type")
-    if item_type in {"message", "function_call"}:
-        return True
-    return _field(item, "role") == "assistant"
-
-
-def _should_replay_openrouter_item(
-    item: Any,
-    model: str,
-    base_url: str | None,
-    should_replay: ShouldReplayReasoningContent | None,
-) -> bool:
-    provider_data = _field(item, "provider_data")
-    provider = provider_data if isinstance(provider_data, dict) else {}
-    origin = provider.get("model")
-    context = ReasoningContentReplayContext(
-        model=model,
-        base_url=base_url.rstrip("/") if base_url is not None else None,
-        reasoning=ReasoningContentSource(
-            item=item,
-            origin_model=origin if isinstance(origin, str) else None,
-            provider_data=provider,
-        ),
-    )
-    if should_replay is not None:
-        return should_replay(context)
-    return False
-
-
-def _attach_openrouter_output_details(output: Any, details: list[list[dict[str, object]]]) -> None:
-    if not isinstance(output, list) or not details:
-        return
-
-    remaining = list(details)
-    for item in output:
-        if not remaining:
-            return
-        if _field(item, "type") != "reasoning":
-            continue
-        provider_data = _field(item, "provider_data")
-        provider = dict(provider_data) if isinstance(provider_data, dict) else {}
-        provider[OPENROUTER_REASONING_DETAILS_KEY] = _copy_reasoning_details(remaining.pop(0))
-        dynamic = cast(Any, item)
-        dynamic.provider_data = provider
-
-
-def _original_reasoning_details(item: Any) -> list[dict[str, object]]:
-    provider_data = _field(item, "provider_data")
-    if not isinstance(provider_data, dict):
-        return []
-    return _copy_reasoning_details(provider_data.get(OPENROUTER_REASONING_DETAILS_KEY))
-
-
-def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
-    details: list[dict[str, object]] = []
-    encrypted = _encrypted_parts(item)
-    contents = _content_texts(_field(item, "content"))
-
-    for summary in _summary_texts(item):
-        if summary != OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER:
-            details.append({"type": "reasoning.summary", "summary": summary})
-
-    extra_count = max(0, len(encrypted) - len(contents))
-    for value in encrypted[:extra_count]:
-        details.append({"type": "reasoning.encrypted", "data": value})
-
-    signatures = encrypted[extra_count:]
-    for index, text in enumerate(contents):
-        detail: dict[str, object] = {"type": "reasoning.text", "text": text}
-        if index < len(signatures):
-            detail["signature"] = signatures[index]
-        details.append(detail)
-
-    return details
-
-
-def _openrouter_message_details(value: Any) -> list[dict[str, object]]:
-    details = _copy_reasoning_details(_field(value, "reasoning_details"))
-    if details:
-        return details
-
-    synthesized: list[dict[str, object]] = []
-    summary = _field(value, "reasoning_content") or _openrouter_reasoning_summary(value)
-    if isinstance(summary, str) and summary:
-        synthesized.append({"type": "reasoning.summary", "summary": summary})
-
-    for block in _openrouter_reasoning_blocks(_field(value, "thinking_blocks")):
-        text = block.get("thinking")
-        signature = block.get("signature")
-        if text:
-            detail: dict[str, object] = {"type": "reasoning.text", "text": text}
-            if signature:
-                detail["signature"] = signature
-            synthesized.append(detail)
-        elif signature:
-            synthesized.append({"type": "reasoning.encrypted", "data": signature})
-    return synthesized
-
-
-def _copy_reasoning_details(details: Any) -> list[dict[str, object]]:
-    if not isinstance(details, list):
-        return []
-    return [cast(dict[str, object], deepcopy(item)) for item in details if isinstance(item, dict)]
-
-
-def _summary_texts(item: Any) -> list[str]:
-    summary = _field(item, "summary")
-    if not isinstance(summary, list):
-        return []
-    return [text for value in summary for text in [_first_text_from_any(value, ("text", "summary"))] if text]
-
-
-def _content_texts(content: Any) -> list[str]:
-    if not isinstance(content, list):
-        return []
-    return [
-        text
-        for value in content
-        for text in [_first_text_from_any(value, ("text", "thinking", "reasoning", "content"))]
-        if text
-    ]
-
-
-def _encrypted_parts(item: Any) -> list[str]:
-    encrypted = _field(item, "encrypted_content")
-    if not isinstance(encrypted, str):
-        return []
-    return [part for part in encrypted.split("\n") if part]
-
-
-def _reasoning_details_summary(details: Any) -> str:
-    if not isinstance(details, list):
-        return ""
-    return "\n".join(
-        text for item in details if isinstance(item, dict) for text in [_first_text(item, ("summary",))] if text
-    )
-
-
-def _reasoning_details_text(details: Any) -> str:
-    if not isinstance(details, list):
-        return ""
-    return "\n".join(
-        text
-        for item in details
-        if isinstance(item, dict)
-        for text in [_first_text(item, ("thinking", "text", "reasoning", "content"))]
-        if text
-    )
-
-
-def _encrypted_reasoning_placeholder(details: Any) -> str:
-    if _openrouter_reasoning_signatures(details):
-        return OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER
-    return ""
-
-
-def _openrouter_reasoning_blocks(details: Any, *, include_text: bool = True) -> list[dict[str, str]]:
-    if not isinstance(details, list):
-        return []
-
-    blocks: list[dict[str, str]] = []
-    for item in details:
-        if not isinstance(item, dict):
-            continue
-        text = _first_text(item, ("thinking", "text", "reasoning", "content")) if include_text else ""
-        signature = _first_text(item, ("signature", "data", "encrypted_content"))
-        block: dict[str, str] = {}
-        if text:
-            block["thinking"] = text
-        if signature:
-            block["signature"] = signature
-        if block:
-            blocks.append(block)
-    return blocks
-
-
-def _openrouter_reasoning_signatures(details: Any) -> list[str]:
-    if not isinstance(details, list):
-        return []
-    return [
-        signature
-        for item in details
-        if isinstance(item, dict)
-        for signature in [_first_text(item, ("signature", "data", "encrypted_content"))]
-        if signature
-    ]
-
-
-def _first_text(value: dict[str, Any], keys: tuple[str, ...]) -> str:
-    for key in keys:
-        found = value.get(key)
-        if isinstance(found, str):
-            return found
-    return ""
-
-
-def _first_text_from_any(value: Any, keys: tuple[str, ...]) -> str:
-    if isinstance(value, dict):
-        return _first_text(value, keys)
-    for key in keys:
-        found = getattr(value, key, None)
-        if isinstance(found, str):
-            return found
-    return ""
-
-
-def _field(value: Any, key: str) -> Any:
-    if isinstance(value, dict):
-        found = value.get(key)
-        if found is not None:
-            return found
-
-    found = getattr(value, key, None)
-    if found is not None:
-        return found
-
-    extra = getattr(value, "model_extra", None)
-    if isinstance(extra, dict):
-        found = extra.get(key)
-        if found is not None:
-            return found
-
-    return None

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -149,9 +149,12 @@ class _OpenRouterCompletionsProxy:
         self._completions = completions
 
     async def create(self, **kwargs: Any) -> Any:
+        replay = _OPENROUTER_REPLAY_DETAILS.get() or []
+        if replay and isinstance(kwargs.get("messages"), list):
+            kwargs = {**kwargs, "messages": deepcopy(kwargs["messages"])}
         _attach_openrouter_replay_details(
             kwargs.get("messages"),
-            _OPENROUTER_REPLAY_DETAILS.get() or [],
+            replay,
         )
         return await self._completions.create(**kwargs)
 
@@ -160,13 +163,13 @@ class _OpenRouterCompletionsProxy:
 
 
 def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[str, object]]]:
-    output_details: list[list[dict[str, object]]] = []
-    for choice in response.choices:
+    output_details: list[dict[str, object]] = []
+    for index, choice in enumerate(response.choices):
         message = choice.message
         dynamic = cast(Any, message)
         details = _copy_reasoning_details(_field(message, "reasoning_details"))
-        if details:
-            output_details.append(details)
+        if index == 0:
+            output_details = details
 
         summary = _openrouter_reasoning_summary(message)
         if summary and not _field(message, "reasoning_content"):
@@ -175,7 +178,7 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[
         blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
         if blocks and not _field(message, "thinking_blocks"):
             dynamic.thinking_blocks = blocks
-    return output_details
+    return [output_details] if output_details else []
 
 
 async def _normalize_openrouter_reasoning_stream(
@@ -185,11 +188,11 @@ async def _normalize_openrouter_reasoning_stream(
     output = _OPENROUTER_OUTPUT_DETAILS.get()
     async for chunk in stream:
         if isinstance(chunk, ChatCompletionChunk):
+            primary = chunk.choices[0].index if chunk.choices else None
             _normalize_openrouter_reasoning_chunk(chunk, states)
-            if output is not None:
-                output[:] = [
-                    state.output_details for _, state in sorted(states.items()) if state.output_details
-                ]
+            state = states.get(primary) if primary is not None else None
+            if output is not None and state is not None:
+                output[:] = [state.output_details] if state.output_details else []
         yield chunk
 
 

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -196,7 +196,7 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[
     for index, choice in enumerate(response.choices):
         message = choice.message
         dynamic = cast(Any, message)
-        details = _copy_reasoning_details(_field(message, "reasoning_details"))
+        details = _openrouter_message_details(message)
         if index == 0:
             output_details = details
 
@@ -245,7 +245,7 @@ def _normalize_openrouter_reasoning_chunk(
         details = _field(delta, "reasoning_details")
         if details:
             dynamic._agency_swarm_skip_reasoning_content_copy = True
-        state.output_details.extend(_copy_reasoning_details(details))
+        state.output_details.extend(_openrouter_message_details(delta))
         text = _reasoning_details_text(details)
         summary = _reasoning_details_summary(details)
         if not summary and not text and not state.has_reasoning:
@@ -415,6 +415,29 @@ def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
         details.append(detail)
 
     return details
+
+
+def _openrouter_message_details(value: Any) -> list[dict[str, object]]:
+    details = _copy_reasoning_details(_field(value, "reasoning_details"))
+    if details:
+        return details
+
+    synthesized: list[dict[str, object]] = []
+    summary = _field(value, "reasoning_content") or _openrouter_reasoning_summary(value)
+    if isinstance(summary, str) and summary:
+        synthesized.append({"type": "reasoning.summary", "summary": summary})
+
+    for block in _openrouter_reasoning_blocks(_field(value, "thinking_blocks")):
+        text = block.get("thinking")
+        signature = block.get("signature")
+        if text:
+            detail: dict[str, object] = {"type": "reasoning.text", "text": text}
+            if signature:
+                detail["signature"] = signature
+            synthesized.append(detail)
+        elif signature:
+            synthesized.append({"type": "reasoning.encrypted", "data": signature})
+    return synthesized
 
 
 def _copy_reasoning_details(details: Any) -> list[dict[str, object]]:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -203,6 +203,7 @@ def _normalize_openrouter_reasoning_chunk(
     for choice in chunk.choices:
         delta = choice.delta
         dynamic = cast(Any, delta)
+        dynamic._agency_swarm_skip_reasoning_content_copy = True
         details = _field(delta, "reasoning_details")
         output_details.extend(_copy_reasoning_details(details))
         text = _reasoning_details_text(details)

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -11,6 +11,7 @@ from openai.types.chat import ChatCompletion, ChatCompletionChunk
 OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODEL_PREFIX = "openrouter/"
+OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER = "[REDACTED]"
 
 
 def is_openrouter_model_name(model_name: str) -> bool:
@@ -96,28 +97,39 @@ def _normalize_openrouter_reasoning(response: ChatCompletion) -> None:
 
 async def _normalize_openrouter_reasoning_stream(stream: AsyncIterator[Any]) -> AsyncIterator[Any]:
     signatures: list[str] = []
+    has_reasoning = False
     async for chunk in stream:
         if isinstance(chunk, ChatCompletionChunk):
-            _normalize_openrouter_reasoning_chunk(chunk, signatures)
+            has_reasoning = _normalize_openrouter_reasoning_chunk(chunk, signatures, has_reasoning)
         yield chunk
 
 
-def _normalize_openrouter_reasoning_chunk(chunk: ChatCompletionChunk, signatures: list[str]) -> None:
+def _normalize_openrouter_reasoning_chunk(
+    chunk: ChatCompletionChunk,
+    signatures: list[str],
+    has_reasoning: bool,
+) -> bool:
     for choice in chunk.choices:
         delta = choice.delta
         dynamic = cast(Any, delta)
         details = _field(delta, "reasoning_details")
+        text = _reasoning_details_text(details)
         summary = _reasoning_details_summary(details)
+        if not summary and not text and not has_reasoning:
+            summary = _encrypted_reasoning_placeholder(details)
+
         if summary and not _field(delta, "reasoning_content"):
             dynamic.reasoning_content = summary
 
-        text = _reasoning_details_text(details)
         if text and not _field(delta, "reasoning"):
             dynamic.reasoning = text
 
         signatures.extend(_openrouter_reasoning_signatures(details))
         if signatures and not _field(delta, "thinking_blocks"):
             dynamic.thinking_blocks = [{"signature": "\n".join(signatures)}]
+
+        has_reasoning = has_reasoning or bool(summary or text)
+    return has_reasoning
 
 
 def _openrouter_reasoning_summary(value: Any) -> str:
@@ -127,7 +139,11 @@ def _openrouter_reasoning_summary(value: Any) -> str:
     if isinstance(reasoning, dict):
         return _first_text(reasoning, ("summary", "thinking", "text", "reasoning", "content"))
     details = _field(value, "reasoning_details")
-    return _reasoning_details_summary(details) or _reasoning_details_text(details)
+    return (
+        _reasoning_details_summary(details)
+        or _reasoning_details_text(details)
+        or _encrypted_reasoning_placeholder(details)
+    )
 
 
 def _reasoning_details_summary(details: Any) -> str:
@@ -148,6 +164,12 @@ def _reasoning_details_text(details: Any) -> str:
         for text in [_first_text(item, ("thinking", "text", "reasoning", "content"))]
         if text
     )
+
+
+def _encrypted_reasoning_placeholder(details: Any) -> str:
+    if _openrouter_reasoning_signatures(details):
+        return OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER
+    return ""
 
 
 def _openrouter_reasoning_blocks(details: Any, *, include_text: bool = True) -> list[dict[str, str]]:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -152,10 +152,14 @@ def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) 
     origin = context.reasoning.origin_model
     return (
         OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
-        and context.base_url == OPENROUTER_BASE_URL
+        and _is_openrouter_base_url(context.base_url)
         and origin is not None
         and _model_family(origin) == _model_family(context.model)
     )
+
+
+def _is_openrouter_base_url(base_url: str | None) -> bool:
+    return base_url is not None and base_url.rstrip("/") == OPENROUTER_BASE_URL
 
 
 def _model_family(model: str) -> str:

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+from agents.models.chatcmpl_converter import ReasoningContentReplayContext
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
@@ -44,6 +45,10 @@ def get_openrouter_model_name(model: object) -> str | None:
 
 class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
     """OpenRouter chat model with provider reasoning normalized for Agents."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("should_replay_reasoning_content", _should_replay_openrouter_reasoning)
+        super().__init__(*args, **kwargs)
 
     async def get_response(self, *args: Any, **kwargs: Any) -> Any:
         details: list[list[dict[str, object]]] = []
@@ -124,6 +129,10 @@ def _default_settings_model_name(actual_model: str) -> str:
 def is_openrouter_model(model: Any) -> bool:
     """Return whether a model object was built for OpenRouter."""
     return get_openrouter_model_name(model) is not None
+
+
+def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) -> bool:
+    return OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
 
 
 class _OpenRouterClientProxy:
@@ -291,6 +300,7 @@ def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str,
         for message in messages
         if isinstance(message, dict)
         and message.get("role") == "assistant"
+        and "reasoning_content" in message
         and "reasoning_details" not in message
     ]
     selected = targets[-len(replay) :]
@@ -387,7 +397,7 @@ def _encrypted_parts(item: Any) -> list[str]:
 def _reasoning_details_summary(details: Any) -> str:
     if not isinstance(details, list):
         return ""
-    return "".join(
+    return "\n".join(
         text for item in details if isinstance(item, dict) for text in [_first_text(item, ("summary",))] if text
     )
 
@@ -395,7 +405,7 @@ def _reasoning_details_summary(details: Any) -> str:
 def _reasoning_details_text(details: Any) -> str:
     if not isinstance(details, list):
         return ""
-    return "".join(
+    return "\n".join(
         text
         for item in details
         if isinstance(item, dict)

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -151,8 +151,7 @@ def is_openrouter_model(model: Any) -> bool:
 def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) -> bool:
     origin = context.reasoning.origin_model
     return (
-        OPENROUTER_REASONING_DETAILS_KEY in context.reasoning.provider_data
-        and _is_openrouter_base_url(context.base_url)
+        _is_openrouter_base_url(context.base_url)
         and origin is not None
         and _model_family(origin) == _model_family(context.model)
     )

--- a/src/agency_swarm/utils/openrouter.py
+++ b/src/agency_swarm/utils/openrouter.py
@@ -7,7 +7,11 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, cast
 
-from agents.models.chatcmpl_converter import ReasoningContentReplayContext
+from agents.models.chatcmpl_converter import (
+    ReasoningContentReplayContext,
+    ReasoningContentSource,
+    ShouldReplayReasoningContent,
+)
 from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
@@ -47,7 +51,8 @@ class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
     """OpenRouter chat model with provider reasoning normalized for Agents."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs.setdefault("should_replay_reasoning_content", _should_replay_openrouter_reasoning)
+        if kwargs.get("should_replay_reasoning_content") is None:
+            kwargs["should_replay_reasoning_content"] = _should_replay_openrouter_reasoning
         super().__init__(*args, **kwargs)
 
     async def get_response(self, *args: Any, **kwargs: Any) -> Any:
@@ -74,7 +79,14 @@ class OpenRouterChatCompletionsModel(OpenAIChatCompletionsModel):
 
     async def _fetch_response(self, *args: Any, **kwargs: Any) -> Any:
         input_value = args[1] if len(args) > 1 else kwargs.get("input")
-        token = _OPENROUTER_REPLAY_DETAILS.set(_openrouter_replay_details(input_value))
+        token = _OPENROUTER_REPLAY_DETAILS.set(
+            _openrouter_replay_details(
+                input_value,
+                model=str(self.model),
+                base_url=str(self._client.base_url),
+                should_replay=self.should_replay_reasoning_content,
+            )
+        )
         try:
             result = await super()._fetch_response(*args, **kwargs)
             if isinstance(result, ChatCompletion):
@@ -100,6 +112,7 @@ def build_openrouter_chat_model(
     base_url: str | None = None,
     default_headers: dict[str, str] | None = None,
     openai_client: AsyncOpenAI | None = None,
+    should_replay_reasoning_content: ShouldReplayReasoningContent | None = None,
 ) -> OpenAIChatCompletionsModel:
     """Build an OpenAI-compatible Chat Completions model for OpenRouter."""
     actual_model = strip_openrouter_prefix(model_name)
@@ -113,7 +126,11 @@ def build_openrouter_chat_model(
             base_url=base_url or OPENROUTER_BASE_URL,
             default_headers=default_headers,
         )
-    model = OpenRouterChatCompletionsModel(model=actual_model, openai_client=client)
+    model = OpenRouterChatCompletionsModel(
+        model=actual_model,
+        openai_client=client,
+        should_replay_reasoning_content=should_replay_reasoning_content,
+    )
     model._agency_swarm_openrouter_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]
     model._agency_swarm_usage_model_name = f"{OPENROUTER_MODEL_PREFIX}{actual_model}"  # type: ignore[attr-defined]
     model._agency_swarm_default_model_name = _default_settings_model_name(actual_model)  # type: ignore[attr-defined]
@@ -237,6 +254,9 @@ def _normalize_openrouter_reasoning_chunk(
         if summary and not _field(delta, "reasoning_content"):
             dynamic.reasoning_content = summary
 
+        if text and not summary and not state.has_reasoning and not _field(delta, "reasoning_content"):
+            dynamic.reasoning_content = text
+
         if text and not _field(delta, "reasoning"):
             dynamic.reasoning = text
 
@@ -274,7 +294,13 @@ def _openrouter_reasoning_summary(value: Any) -> str:
     )
 
 
-def _openrouter_replay_details(input_value: Any) -> list[list[dict[str, object]]]:
+def _openrouter_replay_details(
+    input_value: Any,
+    *,
+    model: str,
+    base_url: str | None,
+    should_replay: ShouldReplayReasoningContent | None,
+) -> list[list[dict[str, object]]]:
     if not isinstance(input_value, list):
         return []
 
@@ -283,7 +309,12 @@ def _openrouter_replay_details(input_value: Any) -> list[list[dict[str, object]]
     for item in input_value:
         item_type = _field(item, "type")
         if item_type == "reasoning":
-            pending = _original_reasoning_details(item) or _details_from_reasoning_item(item)
+            details = _original_reasoning_details(item) or _details_from_reasoning_item(item)
+            pending = (
+                details
+                if details and _should_replay_openrouter_item(item, model, base_url, should_replay)
+                else None
+            )
             continue
         if pending and _is_assistant_output_item(item):
             replay.append(pending)
@@ -300,7 +331,7 @@ def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str,
         for message in messages
         if isinstance(message, dict)
         and message.get("role") == "assistant"
-        and "reasoning_content" in message
+        and ("reasoning_content" in message or message.get("tool_calls"))
         and "reasoning_details" not in message
     ]
     selected = targets[-len(replay) :]
@@ -314,6 +345,29 @@ def _is_assistant_output_item(item: Any) -> bool:
     if item_type in {"message", "function_call"}:
         return True
     return _field(item, "role") == "assistant"
+
+
+def _should_replay_openrouter_item(
+    item: Any,
+    model: str,
+    base_url: str | None,
+    should_replay: ShouldReplayReasoningContent | None,
+) -> bool:
+    provider_data = _field(item, "provider_data")
+    provider = provider_data if isinstance(provider_data, dict) else {}
+    origin = provider.get("model")
+    context = ReasoningContentReplayContext(
+        model=model,
+        base_url=base_url.rstrip("/") if base_url is not None else None,
+        reasoning=ReasoningContentSource(
+            item=item,
+            origin_model=origin if isinstance(origin, str) else None,
+            provider_data=provider,
+        ),
+    )
+    if should_replay is not None:
+        return should_replay(context)
+    return False
 
 
 def _attach_openrouter_output_details(output: Any, details: list[list[dict[str, object]]]) -> None:

--- a/src/agency_swarm/utils/openrouter_reasoning.py
+++ b/src/agency_swarm/utils/openrouter_reasoning.py
@@ -32,7 +32,7 @@ def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) 
     return (
         _is_openrouter_base_url(context.base_url)
         and origin is not None
-        and _model_family(origin) == _model_family(context.model)
+        and _normalized_model(origin) == _normalized_model(context.model)
     )
 
 
@@ -40,9 +40,9 @@ def _is_openrouter_base_url(base_url: str | None) -> bool:
     return base_url is not None and base_url.rstrip("/") == OPENROUTER_BASE_URL
 
 
-def _model_family(model: str) -> str:
+def _normalized_model(model: str) -> str:
     name = model[len(OPENROUTER_MODEL_PREFIX) :] if model.startswith(OPENROUTER_MODEL_PREFIX) else model
-    return name.split("/", 1)[0].lower()
+    return name.lower()
 
 
 class _OpenRouterClientProxy:
@@ -124,6 +124,8 @@ async def _normalize_openrouter_reasoning_stream(
 class _OpenRouterStreamState:
     signatures: list[str] = field(default_factory=list)
     has_reasoning: bool = False
+    has_summary: bool = False
+    has_text: bool = False
     output_details: list[dict[str, object]] = field(default_factory=list)
 
 
@@ -145,19 +147,26 @@ def _normalize_openrouter_reasoning_chunk(
             summary = _encrypted_reasoning_placeholder(details)
 
         if summary and not _field(delta, "reasoning_content"):
-            dynamic.reasoning_content = summary
+            dynamic.reasoning_content = _stream_reasoning_fragment(summary, state.has_summary)
+            state.has_summary = True
 
         if text and not summary and not state.has_reasoning and not _field(delta, "reasoning_content"):
-            dynamic.reasoning_content = text
+            dynamic.reasoning_content = _stream_reasoning_fragment(text, state.has_summary)
+            state.has_summary = True
 
         if text and not _field(delta, "reasoning"):
-            dynamic.reasoning = text
+            dynamic.reasoning = _stream_reasoning_fragment(text, state.has_text)
+            state.has_text = True
 
         state.signatures.extend(_openrouter_reasoning_signatures(details))
         if state.signatures and not _field(delta, "thinking_blocks"):
             dynamic.thinking_blocks = [{"signature": "\n".join(state.signatures)}]
 
         state.has_reasoning = state.has_reasoning or bool(summary or text)
+
+
+def _stream_reasoning_fragment(value: str, has_previous: bool) -> str:
+    return f"\n{value}" if has_previous else value
 
 
 def _has_openrouter_reasoning(value: Any) -> bool:
@@ -207,10 +216,12 @@ def _openrouter_replay_details(
                 details if details and _should_replay_openrouter_item(item, model, base_url, should_replay) else None
             )
             continue
-        if pending and _is_assistant_output_item(item):
-            replay.append(pending)
+        if _is_assistant_output_item(item):
+            replay.append(pending or [])
             pending = None
-    return replay
+            continue
+        pending = None
+    return replay if any(replay) else []
 
 
 def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str, object]]]) -> None:
@@ -220,15 +231,15 @@ def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str,
     targets = [
         message
         for message in messages
-        if isinstance(message, dict)
-        and message.get("role") == "assistant"
-        and ("reasoning_content" in message or message.get("tool_calls"))
-        and "reasoning_details" not in message
+        if isinstance(message, dict) and message.get("role") == "assistant" and "reasoning_details" not in message
     ]
-    selected = targets[-len(replay) :]
-    selected_replay = replay[-len(selected) :] if selected else []
-    for message, details in zip(selected, selected_replay, strict=True):
-        message["reasoning_details"] = details
+    if len(replay) != len(targets) and all(replay):
+        targets = targets[-len(replay) :]
+        replay = replay[-len(targets) :] if targets else []
+
+    for message, details in zip(targets, replay, strict=False):
+        if details:
+            message["reasoning_details"] = details
 
 
 def _is_assistant_output_item(item: Any) -> bool:

--- a/src/agency_swarm/utils/openrouter_reasoning.py
+++ b/src/agency_swarm/utils/openrouter_reasoning.py
@@ -1,0 +1,457 @@
+"""OpenRouter reasoning normalization helpers."""
+
+from collections.abc import AsyncIterator
+from contextvars import ContextVar
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from agents.models.chatcmpl_converter import (
+    ReasoningContentReplayContext,
+    ReasoningContentSource,
+    ShouldReplayReasoningContent,
+)
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+OPENROUTER_MODEL_PREFIX = "openrouter/"
+OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER = "[REDACTED]"
+OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
+_OPENROUTER_OUTPUT_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
+    "_OPENROUTER_OUTPUT_DETAILS",
+    default=None,
+)
+_OPENROUTER_REPLAY_DETAILS: ContextVar[list[list[dict[str, object]]] | None] = ContextVar(
+    "_OPENROUTER_REPLAY_DETAILS",
+    default=None,
+)
+
+
+def _should_replay_openrouter_reasoning(context: ReasoningContentReplayContext) -> bool:
+    origin = context.reasoning.origin_model
+    return (
+        _is_openrouter_base_url(context.base_url)
+        and origin is not None
+        and _model_family(origin) == _model_family(context.model)
+    )
+
+
+def _is_openrouter_base_url(base_url: str | None) -> bool:
+    return base_url is not None and base_url.rstrip("/") == OPENROUTER_BASE_URL
+
+
+def _model_family(model: str) -> str:
+    name = model[len(OPENROUTER_MODEL_PREFIX) :] if model.startswith(OPENROUTER_MODEL_PREFIX) else model
+    return name.split("/", 1)[0].lower()
+
+
+class _OpenRouterClientProxy:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self.chat = _OpenRouterChatProxy(client.chat)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
+class _OpenRouterChatProxy:
+    def __init__(self, chat: Any) -> None:
+        self._chat = chat
+        self.completions = _OpenRouterCompletionsProxy(chat.completions)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._chat, name)
+
+
+class _OpenRouterCompletionsProxy:
+    def __init__(self, completions: Any) -> None:
+        self._completions = completions
+
+    async def create(self, **kwargs: Any) -> Any:
+        replay = _OPENROUTER_REPLAY_DETAILS.get() or []
+        if replay and isinstance(kwargs.get("messages"), list):
+            kwargs = {**kwargs, "messages": deepcopy(kwargs["messages"])}
+        _attach_openrouter_replay_details(
+            kwargs.get("messages"),
+            replay,
+        )
+        return await self._completions.create(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._completions, name)
+
+
+def _normalize_openrouter_reasoning(response: ChatCompletion) -> list[list[dict[str, object]]]:
+    if len(response.choices) > 1 and any(_has_openrouter_reasoning(choice.message) for choice in response.choices):
+        raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
+
+    output_details: list[dict[str, object]] = []
+    for index, choice in enumerate(response.choices):
+        message = choice.message
+        dynamic = cast(Any, message)
+        details = _openrouter_message_details(message)
+        if index == 0:
+            output_details = details
+
+        summary = _openrouter_reasoning_summary(message)
+        if summary and not _field(message, "reasoning_content"):
+            dynamic.reasoning_content = summary
+
+        blocks = _openrouter_reasoning_blocks(_field(message, "reasoning_details"))
+        if blocks and not _field(message, "thinking_blocks"):
+            dynamic.thinking_blocks = blocks
+    return [output_details] if output_details else []
+
+
+async def _normalize_openrouter_reasoning_stream(
+    stream: AsyncIterator[Any],
+) -> AsyncIterator[Any]:
+    states: dict[int, _OpenRouterStreamState] = {}
+    output = _OPENROUTER_OUTPUT_DETAILS.get()
+    async for chunk in stream:
+        if isinstance(chunk, ChatCompletionChunk):
+            if len(chunk.choices) > 1 and any(_has_openrouter_reasoning(choice.delta) for choice in chunk.choices):
+                raise ValueError("OpenRouter reasoning is only supported for single-choice chat completions")
+            primary = chunk.choices[0].index if chunk.choices else None
+            _normalize_openrouter_reasoning_chunk(chunk, states)
+            state = states.get(primary) if primary is not None else None
+            if output is not None and state is not None:
+                output[:] = [state.output_details] if state.output_details else []
+        yield chunk
+
+
+@dataclass
+class _OpenRouterStreamState:
+    signatures: list[str] = field(default_factory=list)
+    has_reasoning: bool = False
+    output_details: list[dict[str, object]] = field(default_factory=list)
+
+
+def _normalize_openrouter_reasoning_chunk(
+    chunk: ChatCompletionChunk,
+    states: dict[int, _OpenRouterStreamState],
+) -> None:
+    for choice in chunk.choices:
+        state = states.setdefault(choice.index, _OpenRouterStreamState())
+        delta = choice.delta
+        dynamic = cast(Any, delta)
+        details = _field(delta, "reasoning_details")
+        if details:
+            dynamic._agency_swarm_skip_reasoning_content_copy = True
+        state.output_details.extend(_openrouter_message_details(delta))
+        text = _reasoning_details_text(details)
+        summary = _reasoning_details_summary(details)
+        if not summary and not text and not state.has_reasoning:
+            summary = _encrypted_reasoning_placeholder(details)
+
+        if summary and not _field(delta, "reasoning_content"):
+            dynamic.reasoning_content = summary
+
+        if text and not summary and not state.has_reasoning and not _field(delta, "reasoning_content"):
+            dynamic.reasoning_content = text
+
+        if text and not _field(delta, "reasoning"):
+            dynamic.reasoning = text
+
+        state.signatures.extend(_openrouter_reasoning_signatures(details))
+        if state.signatures and not _field(delta, "thinking_blocks"):
+            dynamic.thinking_blocks = [{"signature": "\n".join(state.signatures)}]
+
+        state.has_reasoning = state.has_reasoning or bool(summary or text)
+
+
+def _has_openrouter_reasoning(value: Any) -> bool:
+    return bool(
+        _field(value, "reasoning")
+        or _field(value, "reasoning_content")
+        or _field(value, "reasoning_details")
+        or _field(value, "thinking_blocks")
+    )
+
+
+def _openrouter_reasoning_summary(value: Any) -> str:
+    content = _field(value, "reasoning_content")
+    if isinstance(content, str):
+        return content
+    reasoning = _field(value, "reasoning")
+    if isinstance(reasoning, str):
+        return reasoning
+    if isinstance(reasoning, dict):
+        return _first_text(reasoning, ("summary", "thinking", "text", "reasoning", "content"))
+    details = _field(value, "reasoning_details")
+    return (
+        _reasoning_details_summary(details)
+        or _reasoning_details_text(details)
+        or _reasoning_details_text(_field(value, "thinking_blocks"))
+        or _encrypted_reasoning_placeholder(details)
+    )
+
+
+def _openrouter_replay_details(
+    input_value: Any,
+    *,
+    model: str,
+    base_url: str | None,
+    should_replay: ShouldReplayReasoningContent | None,
+) -> list[list[dict[str, object]]]:
+    if not isinstance(input_value, list):
+        return []
+
+    pending: list[dict[str, object]] | None = None
+    replay: list[list[dict[str, object]]] = []
+    for item in input_value:
+        item_type = _field(item, "type")
+        if item_type == "reasoning":
+            details = _original_reasoning_details(item) or _details_from_reasoning_item(item)
+            pending = (
+                details if details and _should_replay_openrouter_item(item, model, base_url, should_replay) else None
+            )
+            continue
+        if pending and _is_assistant_output_item(item):
+            replay.append(pending)
+            pending = None
+    return replay
+
+
+def _attach_openrouter_replay_details(messages: Any, replay: list[list[dict[str, object]]]) -> None:
+    if not isinstance(messages, list) or not replay:
+        return
+
+    targets = [
+        message
+        for message in messages
+        if isinstance(message, dict)
+        and message.get("role") == "assistant"
+        and ("reasoning_content" in message or message.get("tool_calls"))
+        and "reasoning_details" not in message
+    ]
+    selected = targets[-len(replay) :]
+    selected_replay = replay[-len(selected) :] if selected else []
+    for message, details in zip(selected, selected_replay, strict=True):
+        message["reasoning_details"] = details
+
+
+def _is_assistant_output_item(item: Any) -> bool:
+    item_type = _field(item, "type")
+    if item_type in {"message", "function_call"}:
+        return True
+    return _field(item, "role") == "assistant"
+
+
+def _should_replay_openrouter_item(
+    item: Any,
+    model: str,
+    base_url: str | None,
+    should_replay: ShouldReplayReasoningContent | None,
+) -> bool:
+    provider_data = _field(item, "provider_data")
+    provider = provider_data if isinstance(provider_data, dict) else {}
+    origin = provider.get("model")
+    context = ReasoningContentReplayContext(
+        model=model,
+        base_url=base_url.rstrip("/") if base_url is not None else None,
+        reasoning=ReasoningContentSource(
+            item=item,
+            origin_model=origin if isinstance(origin, str) else None,
+            provider_data=provider,
+        ),
+    )
+    if should_replay is not None:
+        return should_replay(context)
+    return False
+
+
+def _attach_openrouter_output_details(output: Any, details: list[list[dict[str, object]]]) -> None:
+    if not isinstance(output, list) or not details:
+        return
+
+    remaining = list(details)
+    for item in output:
+        if not remaining:
+            return
+        if _field(item, "type") != "reasoning":
+            continue
+        provider_data = _field(item, "provider_data")
+        provider = dict(provider_data) if isinstance(provider_data, dict) else {}
+        provider[OPENROUTER_REASONING_DETAILS_KEY] = _copy_reasoning_details(remaining.pop(0))
+        dynamic = cast(Any, item)
+        dynamic.provider_data = provider
+
+
+def _original_reasoning_details(item: Any) -> list[dict[str, object]]:
+    provider_data = _field(item, "provider_data")
+    if not isinstance(provider_data, dict):
+        return []
+    return _copy_reasoning_details(provider_data.get(OPENROUTER_REASONING_DETAILS_KEY))
+
+
+def _details_from_reasoning_item(item: Any) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    encrypted = _encrypted_parts(item)
+    contents = _content_texts(_field(item, "content"))
+
+    for summary in _summary_texts(item):
+        if summary != OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER:
+            details.append({"type": "reasoning.summary", "summary": summary})
+
+    extra_count = max(0, len(encrypted) - len(contents))
+    for value in encrypted[:extra_count]:
+        details.append({"type": "reasoning.encrypted", "data": value})
+
+    signatures = encrypted[extra_count:]
+    for index, text in enumerate(contents):
+        detail: dict[str, object] = {"type": "reasoning.text", "text": text}
+        if index < len(signatures):
+            detail["signature"] = signatures[index]
+        details.append(detail)
+
+    return details
+
+
+def _openrouter_message_details(value: Any) -> list[dict[str, object]]:
+    details = _copy_reasoning_details(_field(value, "reasoning_details"))
+    if details:
+        return details
+
+    synthesized: list[dict[str, object]] = []
+    summary = _field(value, "reasoning_content") or _openrouter_reasoning_summary(value)
+    if isinstance(summary, str) and summary:
+        synthesized.append({"type": "reasoning.summary", "summary": summary})
+
+    for block in _openrouter_reasoning_blocks(_field(value, "thinking_blocks")):
+        text = block.get("thinking")
+        signature = block.get("signature")
+        if text:
+            detail: dict[str, object] = {"type": "reasoning.text", "text": text}
+            if signature:
+                detail["signature"] = signature
+            synthesized.append(detail)
+        elif signature:
+            synthesized.append({"type": "reasoning.encrypted", "data": signature})
+    return synthesized
+
+
+def _copy_reasoning_details(details: Any) -> list[dict[str, object]]:
+    if not isinstance(details, list):
+        return []
+    return [cast(dict[str, object], deepcopy(item)) for item in details if isinstance(item, dict)]
+
+
+def _summary_texts(item: Any) -> list[str]:
+    summary = _field(item, "summary")
+    if not isinstance(summary, list):
+        return []
+    return [text for value in summary for text in [_first_text_from_any(value, ("text", "summary"))] if text]
+
+
+def _content_texts(content: Any) -> list[str]:
+    if not isinstance(content, list):
+        return []
+    return [
+        text
+        for value in content
+        for text in [_first_text_from_any(value, ("text", "thinking", "reasoning", "content"))]
+        if text
+    ]
+
+
+def _encrypted_parts(item: Any) -> list[str]:
+    encrypted = _field(item, "encrypted_content")
+    if not isinstance(encrypted, str):
+        return []
+    return [part for part in encrypted.split("\n") if part]
+
+
+def _reasoning_details_summary(details: Any) -> str:
+    if not isinstance(details, list):
+        return ""
+    return "\n".join(
+        text for item in details if isinstance(item, dict) for text in [_first_text(item, ("summary",))] if text
+    )
+
+
+def _reasoning_details_text(details: Any) -> str:
+    if not isinstance(details, list):
+        return ""
+    return "\n".join(
+        text
+        for item in details
+        if isinstance(item, dict)
+        for text in [_first_text(item, ("thinking", "text", "reasoning", "content"))]
+        if text
+    )
+
+
+def _encrypted_reasoning_placeholder(details: Any) -> str:
+    if _openrouter_reasoning_signatures(details):
+        return OPENROUTER_ENCRYPTED_REASONING_PLACEHOLDER
+    return ""
+
+
+def _openrouter_reasoning_blocks(details: Any, *, include_text: bool = True) -> list[dict[str, str]]:
+    if not isinstance(details, list):
+        return []
+
+    blocks: list[dict[str, str]] = []
+    for item in details:
+        if not isinstance(item, dict):
+            continue
+        text = _first_text(item, ("thinking", "text", "reasoning", "content")) if include_text else ""
+        signature = _first_text(item, ("signature", "data", "encrypted_content"))
+        block: dict[str, str] = {}
+        if text:
+            block["thinking"] = text
+        if signature:
+            block["signature"] = signature
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _openrouter_reasoning_signatures(details: Any) -> list[str]:
+    if not isinstance(details, list):
+        return []
+    return [
+        signature
+        for item in details
+        if isinstance(item, dict)
+        for signature in [_first_text(item, ("signature", "data", "encrypted_content"))]
+        if signature
+    ]
+
+
+def _first_text(value: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        found = value.get(key)
+        if isinstance(found, str):
+            return found
+    return ""
+
+
+def _first_text_from_any(value: Any, keys: tuple[str, ...]) -> str:
+    if isinstance(value, dict):
+        return _first_text(value, keys)
+    for key in keys:
+        found = getattr(value, key, None)
+        if isinstance(found, str):
+            return found
+    return ""
+
+
+def _field(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        found = value.get(key)
+        if found is not None:
+            return found
+
+    found = getattr(value, key, None)
+    if found is not None:
+        return found
+
+    extra = getattr(value, "model_extra", None)
+    if isinstance(extra, dict):
+        found = extra.get(key)
+        if found is not None:
+            return found
+
+    return None

--- a/tests/test_agent_modules/test_litellm_reasoning_patch.py
+++ b/tests/test_agent_modules/test_litellm_reasoning_patch.py
@@ -211,3 +211,16 @@ async def test_litellm_stream_patch_forwards_strict_feature_validation(monkeypat
         "model": "model",
         "strict_feature_validation": True,
     }
+
+
+def test_litellm_patch_skips_already_normalized_chunks() -> None:
+    patch = importlib.import_module("agency_swarm.streaming.litellm_reasoning")
+    delta = SimpleNamespace(
+        reasoning="OpenRouter text",
+        _agency_swarm_skip_reasoning_content_copy=True,
+    )
+    chunk = SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+    patch._copy_thinking_blocks_to_reasoning_content(chunk)
+
+    assert not hasattr(delta, "reasoning_content")

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -226,6 +226,56 @@ class _MixedChoiceClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _ReasoningContentCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.reasoning_content = "content reasoning"
+        return ChatCompletion(
+            id="chatcmpl_reasoning_content",
+            choices=[Choice(finish_reason="stop", index=0, logprobs=None, message=message)],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _ReasoningContentChat:
+    def __init__(self) -> None:
+        self.completions = _ReasoningContentCompletions()
+
+
+class _ReasoningContentClient:
+    def __init__(self) -> None:
+        self.chat = _ReasoningContentChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+class _ThinkingBlocksCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.thinking_blocks = [{"thinking": "block reasoning", "signature": "block-signature"}]
+        return ChatCompletion(
+            id="chatcmpl_thinking_blocks",
+            choices=[Choice(finish_reason="stop", index=0, logprobs=None, message=message)],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _ThinkingBlocksChat:
+    def __init__(self) -> None:
+        self.completions = _ThinkingBlocksCompletions()
+
+
+class _ThinkingBlocksClient:
+    def __init__(self) -> None:
+        self.chat = _ThinkingBlocksChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 class _MutationCompletions:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] | None = None
@@ -402,6 +452,39 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openrouter_runner_surfaces_non_stream_reasoning_content() -> None:
+    """OpenRouter sync responses can provide reasoning_content without details."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _ReasoningContentClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.summary[0].text == "content reasoning"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_runner_surfaces_non_stream_thinking_blocks() -> None:
+    """OpenRouter sync responses can provide thinking_blocks without details."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _ThinkingBlocksClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.summary[0].text == "block reasoning"
+    assert reasoning.encrypted_content == "block-signature"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_details_from_second_choice_do_not_attach_to_first_choice() -> None:
     """OpenRouter reasoning does not silently drop later chat choices."""
     set_tracing_disabled(True)
@@ -484,6 +567,22 @@ async def test_openrouter_streamed_reasoning_details_stay_separate_by_choice() -
 
     with pytest.raises(ValueError, match="single-choice"):
         _ = [chunk async for chunk in stream]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_without_details_keeps_litellm_reasoning_fallback() -> None:
+    """OpenRouter should not disable shared reasoning fallback without reasoning_details."""
+    delta = ChoiceDelta()
+    delta.thinking_blocks = [{"thinking": "fallback reasoning", "signature": "fallback-signature"}]
+    stream = _normalize_openrouter_reasoning_stream(_single_chunk_stream(_chunk("chunk_fallback", delta)))
+
+    chunks = [chunk async for chunk in stream]
+
+    normalized = chunks[0].choices[0].delta
+    assert not getattr(normalized, "_agency_swarm_skip_reasoning_content_copy", False)
+    assert normalized.thinking_blocks == [
+        {"thinking": "fallback reasoning", "signature": "fallback-signature"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -586,6 +685,10 @@ async def _multi_choice_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
         model="anthropic/claude-sonnet-4.5",
         object="chat.completion.chunk",
     )
+
+
+async def _single_chunk_stream(chunk: ChatCompletionChunk) -> AsyncIterator[ChatCompletionChunk]:
+    yield chunk
 
 
 def _chunk(chunk_id: str, delta: ChoiceDelta) -> ChatCompletionChunk:

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -530,6 +530,26 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openrouter_replay_accepts_trailing_slash_base_url() -> None:
+    """The default OpenRouter endpoint should replay with or without a trailing slash."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    client.base_url = "https://openrouter.ai/api/v1/"
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert assistant["reasoning_details"] == _reasoning_details()
+
+
+@pytest.mark.asyncio
 async def test_openrouter_replay_details_can_be_disabled() -> None:
     """A caller-provided replay policy should be able to block OpenRouter detail replay."""
     set_tracing_disabled(True)

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -436,6 +436,30 @@ async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None
     assert client.chat.completions.messages[0]["reasoning_details"] == _reasoning_details()
 
 
+@pytest.mark.asyncio
+async def test_openrouter_replay_details_attach_to_latest_assistant_message() -> None:
+    """Replay enrichment should not attach current reasoning to older assistant turns."""
+    client = _MutationClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    messages = [
+        {"role": "assistant", "content": "older"},
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "content": "current"},
+    ]
+    token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details()])
+    try:
+        await model._get_client().chat.completions.create(messages=messages)
+    finally:
+        _OPENROUTER_REPLAY_DETAILS.reset(token)
+
+    assert client.chat.completions.messages is not None
+    assert "reasoning_details" not in client.chat.completions.messages[0]
+    assert client.chat.completions.messages[2]["reasoning_details"] == _reasoning_details()
+
+
 def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
     """A local display placeholder should not be sent back as provider reasoning."""
     details = _details_from_reasoning_item(

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -1,8 +1,11 @@
+from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import pytest
-from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from agents.stream_events import RawResponsesStreamEvent
+from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
 from openai.types.completion_usage import CompletionUsage
 
 from agency_swarm import Agent, Runner, set_tracing_disabled
@@ -48,6 +51,56 @@ class _Client:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _DetailsCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.reasoning_details = _reasoning_details()
+        return ChatCompletion(
+            id="chatcmpl_test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=message,
+                )
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _DetailsChat:
+    def __init__(self) -> None:
+        self.completions = _DetailsCompletions()
+
+
+class _DetailsClient:
+    def __init__(self) -> None:
+        self.chat = _DetailsChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+class _StreamCompletions:
+    async def create(self, **kwargs: Any) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if kwargs.get("stream"):
+            return _stream_chunks()
+        raise AssertionError("streaming test must request stream=True")
+
+
+class _StreamChat:
+    def __init__(self) -> None:
+        self.completions = _StreamCompletions()
+
+
+class _StreamClient:
+    def __init__(self) -> None:
+        self.chat = _StreamChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 @pytest.mark.asyncio
 async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
     """Runner output should include OpenRouter reasoning from OpenAI-compatible chat."""
@@ -68,3 +121,102 @@ async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
     assert reasoning.content[0].text == "provider detail"
     assert reasoning.encrypted_content == "reasoning-signature"
     assert result.final_output == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_runner_preserves_documented_reasoning_details() -> None:
+    """Documented summary, encrypted, and text details should survive conversion."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _DetailsClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.type == "reasoning"
+    assert reasoning.summary[0].text == "documented summary"
+    assert reasoning.content[0].text == "documented text"
+    assert reasoning.encrypted_content == "encrypted-data\ntext-signature"
+    assert result.final_output == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_streamed_reasoning_details_surface_through_runner() -> None:
+    """Streaming delta.reasoning_details should reach the SDK reasoning events."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _StreamClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = Runner.run_streamed(agent, "hello")
+    events = [event async for event in result.stream_events()]
+    raw = [event.data for event in events if isinstance(event, RawResponsesStreamEvent)]
+
+    summary_deltas = [event.delta for event in raw if event.type == "response.reasoning_summary_text.delta"]
+    text_deltas = [event.delta for event in raw if event.type == "response.reasoning_text.delta"]
+    completed = next(event.response for event in raw if event.type == "response.completed")
+    reasoning = completed.output[0]
+
+    assert summary_deltas == ["documented summary"]
+    assert text_deltas == ["documented text"]
+    assert reasoning.type == "reasoning"
+    assert reasoning.summary[0].text == "documented summary"
+    assert reasoning.content[0].text == "documented text"
+    assert reasoning.encrypted_content == "encrypted-data\ntext-signature"
+
+
+def _reasoning_details() -> list[dict[str, object]]:
+    return [
+        {
+            "type": "reasoning.summary",
+            "summary": "documented summary",
+            "id": "reasoning-summary-1",
+            "format": "anthropic-claude-v1",
+            "index": 0,
+        },
+        {
+            "type": "reasoning.encrypted",
+            "data": "encrypted-data",
+            "id": "reasoning-encrypted-1",
+            "format": "anthropic-claude-v1",
+            "index": 1,
+        },
+        {
+            "type": "reasoning.text",
+            "text": "documented text",
+            "signature": "text-signature",
+            "id": "reasoning-text-1",
+            "format": "anthropic-claude-v1",
+            "index": 2,
+        },
+    ]
+
+
+async def _stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
+    for index, detail in enumerate(_reasoning_details()):
+        delta = ChoiceDelta()
+        delta.reasoning_details = [detail]
+        yield _chunk(f"chunk_{index}", delta)
+    yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
+
+
+def _chunk(chunk_id: str, delta: ChoiceDelta) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id=chunk_id,
+        choices=[
+            ChunkChoice(
+                delta=delta,
+                finish_reason=None,
+                index=0,
+                logprobs=None,
+            )
+        ],
+        created=0,
+        model="anthropic/claude-sonnet-4.5",
+        object="chat.completion.chunk",
+    )

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -574,6 +574,26 @@ async def test_openrouter_default_replay_blocks_cross_family_reasoning() -> None
 
 
 @pytest.mark.asyncio
+async def test_openrouter_default_replay_blocks_proxy_endpoint() -> None:
+    """OpenRouter details should not replay through non-OpenRouter gateways by default."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    client.base_url = "https://openrouter-proxy.test/v1"
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert "reasoning_details" not in assistant
+
+
+@pytest.mark.asyncio
 async def test_openrouter_replays_synthesized_reasoning_content() -> None:
     """Reasoning_content-only responses should keep replay metadata for the next turn."""
     set_tracing_disabled(True)

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -327,21 +327,7 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
 
     messages = client.chat.completions.requests[1]["messages"]
     assistant = next(message for message in messages if message["role"] == "assistant")
-    assert assistant["reasoning_details"] == [
-        {
-            "type": "reasoning.summary",
-            "summary": "documented summary",
-        },
-        {
-            "type": "reasoning.encrypted",
-            "data": "encrypted-data",
-        },
-        {
-            "type": "reasoning.text",
-            "text": "documented text",
-            "signature": "text-signature",
-        },
-    ]
+    assert assistant["reasoning_details"] == _reasoning_details()
 
 
 def _reasoning_details() -> list[dict[str, object]]:
@@ -352,6 +338,7 @@ def _reasoning_details() -> list[dict[str, object]]:
             "id": "reasoning-summary-1",
             "format": "anthropic-claude-v1",
             "index": 0,
+            "unknown_field": "summary-extra",
         },
         {
             "type": "reasoning.encrypted",
@@ -359,6 +346,7 @@ def _reasoning_details() -> list[dict[str, object]]:
             "id": "reasoning-encrypted-1",
             "format": "anthropic-claude-v1",
             "index": 1,
+            "unknown_field": "encrypted-extra",
         },
         {
             "type": "reasoning.text",
@@ -367,6 +355,7 @@ def _reasoning_details() -> list[dict[str, object]]:
             "id": "reasoning-text-1",
             "format": "anthropic-claude-v1",
             "index": 2,
+            "unknown_field": "text-extra",
         },
     ]
 

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -550,6 +550,30 @@ async def test_openrouter_replay_details_can_be_disabled() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openrouter_default_replay_blocks_cross_family_reasoning() -> None:
+    """OpenRouter reasoning should not replay across provider families by default."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    source = build_openrouter_chat_model(
+        "openrouter/openai/gpt-5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=source)
+
+    first = await Runner.run(agent, "hello")
+    target = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent.model = target
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert "reasoning_details" not in assistant
+
+
+@pytest.mark.asyncio
 async def test_openrouter_replays_synthesized_reasoning_content() -> None:
     """Reasoning_content-only responses should keep replay metadata for the next turn."""
     set_tracing_disabled(True)

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -9,7 +10,7 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, Choic
 from openai.types.completion_usage import CompletionUsage
 
 from agency_swarm import Agent, Runner, set_tracing_disabled
-from agency_swarm.utils.openrouter import build_openrouter_chat_model
+from agency_swarm.utils.openrouter import _normalize_openrouter_reasoning_stream, build_openrouter_chat_model
 
 
 class _Completions:
@@ -330,6 +331,47 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
     assert assistant["reasoning_details"] == _reasoning_details()
 
 
+@pytest.mark.asyncio
+async def test_openrouter_streamed_reasoning_details_stay_separate_by_choice() -> None:
+    """Multi-choice streams should not mix reasoning metadata across choices."""
+    stream = _normalize_openrouter_reasoning_stream(_multi_choice_stream_chunks())
+
+    chunks = [chunk async for chunk in stream]
+
+    first = chunks[0].choices[0].delta
+    second = chunks[0].choices[1].delta
+    assert first.reasoning_content == "choice zero"
+    assert first.reasoning == "zero text"
+    assert first.thinking_blocks == [{"signature": "zero-signature"}]
+    assert second.reasoning_content == "choice one"
+    assert second.reasoning == "one text"
+    assert second.thinking_blocks == [{"signature": "one-signature"}]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_parallel_runs_keep_provider_data_separate() -> None:
+    """Overlapping runs on one model should attach their own reasoning_details."""
+    set_tracing_disabled(True)
+    client = _ParallelClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first, second = await asyncio.gather(
+        Runner.run(agent, "first"),
+        Runner.run(agent, "second"),
+    )
+
+    assert first.raw_responses[0].output[0].provider_data["openrouter_reasoning_details"] == [
+        {"type": "reasoning.text", "text": "first detail", "signature": "first-signature"}
+    ]
+    assert second.raw_responses[0].output[0].provider_data["openrouter_reasoning_details"] == [
+        {"type": "reasoning.text", "text": "second detail", "signature": "second-signature"}
+    ]
+
+
 def _reasoning_details() -> list[dict[str, object]]:
     return [
         {
@@ -385,6 +427,29 @@ async def _encrypted_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
 
 
+async def _multi_choice_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
+    first = ChoiceDelta()
+    first.reasoning_details = [
+        {"type": "reasoning.summary", "summary": "choice zero"},
+        {"type": "reasoning.text", "text": "zero text", "signature": "zero-signature"},
+    ]
+    second = ChoiceDelta()
+    second.reasoning_details = [
+        {"type": "reasoning.summary", "summary": "choice one"},
+        {"type": "reasoning.text", "text": "one text", "signature": "one-signature"},
+    ]
+    yield ChatCompletionChunk(
+        id="chunk_multi",
+        choices=[
+            ChunkChoice(delta=first, finish_reason=None, index=0, logprobs=None),
+            ChunkChoice(delta=second, finish_reason=None, index=1, logprobs=None),
+        ],
+        created=0,
+        model="anthropic/claude-sonnet-4.5",
+        object="chat.completion.chunk",
+    )
+
+
 def _chunk(chunk_id: str, delta: ChoiceDelta) -> ChatCompletionChunk:
     return ChatCompletionChunk(
         id=chunk_id,
@@ -400,3 +465,57 @@ def _chunk(chunk_id: str, delta: ChoiceDelta) -> ChatCompletionChunk:
         model="anthropic/claude-sonnet-4.5",
         object="chat.completion.chunk",
     )
+
+
+class _ParallelCompletions:
+    async def create(self, **kwargs: Any) -> ChatCompletion:
+        text = _last_user_text(kwargs["messages"])
+        await asyncio.sleep(0)
+        message = ChatCompletionMessage(role="assistant", content=f"{text} answer")
+        message.reasoning_details = [
+            {
+                "type": "reasoning.text",
+                "text": f"{text} detail",
+                "signature": f"{text}-signature",
+            }
+        ]
+        return ChatCompletion(
+            id=f"chatcmpl_{text}",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=message,
+                )
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _ParallelChat:
+    def __init__(self) -> None:
+        self.completions = _ParallelCompletions()
+
+
+class _ParallelClient:
+    def __init__(self) -> None:
+        self.chat = _ParallelChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+def _last_user_text(messages: list[dict[str, Any]]) -> str:
+    for message in reversed(messages):
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text = next((item.get("text") for item in content if isinstance(item, dict)), None)
+            if isinstance(text, str):
+                return text
+    raise AssertionError("missing user message")

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -276,6 +276,36 @@ class _ThinkingBlocksClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _SplitReasoningCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.reasoning_details = [
+            {"type": "reasoning.summary", "summary": "first summary"},
+            {"type": "reasoning.summary", "summary": "second summary"},
+            {"type": "reasoning.text", "text": "first text"},
+            {"type": "reasoning.text", "text": "second text"},
+        ]
+        return ChatCompletion(
+            id="chatcmpl_split_reasoning",
+            choices=[Choice(finish_reason="stop", index=0, logprobs=None, message=message)],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _SplitReasoningChat:
+    def __init__(self) -> None:
+        self.completions = _SplitReasoningCompletions()
+
+
+class _SplitReasoningClient:
+    def __init__(self) -> None:
+        self.chat = _SplitReasoningChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 class _MutationCompletions:
     def __init__(self) -> None:
         self.messages: list[dict[str, Any]] | None = None
@@ -506,7 +536,7 @@ async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None
         "openrouter/anthropic/claude-sonnet-4.5",
         openai_client=cast(Any, client),
     )
-    messages = [{"role": "assistant", "content": "previous"}]
+    messages = [{"role": "assistant", "content": "previous", "reasoning_content": "documented summary"}]
     token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details()])
     try:
         await model._get_client().chat.completions.create(messages=messages)
@@ -520,6 +550,25 @@ async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None
 
 
 @pytest.mark.asyncio
+async def test_openrouter_replay_details_respect_sdk_replay_policy() -> None:
+    """Replay enrichment should not add details when the SDK did not mark replay."""
+    client = _MutationClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    messages = [{"role": "assistant", "content": "previous"}]
+    token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details()])
+    try:
+        await model._get_client().chat.completions.create(messages=messages)
+    finally:
+        _OPENROUTER_REPLAY_DETAILS.reset(token)
+
+    assert client.chat.completions.messages is not None
+    assert "reasoning_details" not in client.chat.completions.messages[0]
+
+
+@pytest.mark.asyncio
 async def test_openrouter_replay_details_attach_to_latest_assistant_message() -> None:
     """Replay enrichment should not attach current reasoning to older assistant turns."""
     client = _MutationClient()
@@ -530,7 +579,7 @@ async def test_openrouter_replay_details_attach_to_latest_assistant_message() ->
     messages = [
         {"role": "assistant", "content": "older"},
         {"role": "user", "content": "next"},
-        {"role": "assistant", "content": "current"},
+        {"role": "assistant", "content": "current", "reasoning_content": "documented summary"},
     ]
     token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details()])
     try:
@@ -558,6 +607,23 @@ def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
         {"type": "reasoning.encrypted", "data": "encrypted-data"},
         {"type": "reasoning.text", "text": "real text", "signature": "text-signature"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_reasoning_fragments_preserve_boundaries() -> None:
+    """Multiple reasoning fragments should keep readable separators."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _SplitReasoningClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.summary[0].text == "first summary\nsecond summary"
+    assert [content.text for content in reasoning.content] == ["first text", "second text"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -151,6 +151,43 @@ class _EncryptedStreamClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _ReplayCompletions:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> ChatCompletion:
+        self.requests.append(kwargs)
+        message = ChatCompletionMessage(role="assistant", content=f"turn {len(self.requests)}")
+        if len(self.requests) == 1:
+            message.reasoning_details = _reasoning_details()
+        return ChatCompletion(
+            id=f"chatcmpl_test_{len(self.requests)}",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=message,
+                )
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _ReplayChat:
+    def __init__(self) -> None:
+        self.completions = _ReplayCompletions()
+
+
+class _ReplayClient:
+    def __init__(self) -> None:
+        self.chat = _ReplayChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 @pytest.mark.asyncio
 async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
     """Runner output should include OpenRouter reasoning from OpenAI-compatible chat."""
@@ -263,6 +300,48 @@ async def test_openrouter_streamed_encrypted_only_reasoning_details_surface_thro
     assert reasoning.summary[0].text == "[REDACTED]"
     assert reasoning.content is None
     assert reasoning.encrypted_content == "encrypted-data"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
+    """A second turn should pass prior OpenRouter reasoning details back."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    await Runner.run(
+        agent,
+        [
+            *first.to_input_list(),
+            {
+                "role": "user",
+                "content": "again",
+            },
+        ],
+    )
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert assistant["reasoning_details"] == [
+        {
+            "type": "reasoning.summary",
+            "summary": "documented summary",
+        },
+        {
+            "type": "reasoning.encrypted",
+            "data": "encrypted-data",
+        },
+        {
+            "type": "reasoning.text",
+            "text": "documented text",
+            "signature": "text-signature",
+        },
+    ]
 
 
 def _reasoning_details() -> list[dict[str, object]]:

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -1,0 +1,70 @@
+from typing import Any, cast
+
+import pytest
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage
+
+from agency_swarm import Agent, Runner, set_tracing_disabled
+from agency_swarm.utils.openrouter import build_openrouter_chat_model
+
+
+class _Completions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.reasoning = "provider reasoning"
+        message.reasoning_details = [
+            {
+                "type": "reasoning.text",
+                "text": "provider detail",
+                "signature": "reasoning-signature",
+            }
+        ]
+        return ChatCompletion(
+            id="chatcmpl_test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=message,
+                )
+            ],
+            created=0,
+            model="openai/gpt-5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _Chat:
+    def __init__(self) -> None:
+        self.completions = _Completions()
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.chat = _Chat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
+    """Runner output should include OpenRouter reasoning from OpenAI-compatible chat."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/openai/gpt-5",
+        openai_client=cast(Any, _Client()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    items = result.raw_responses[0].output
+    assert [item.type for item in items] == ["reasoning", "message"]
+
+    reasoning = items[0]
+    assert reasoning.summary[0].text == "provider reasoning"
+    assert reasoning.content[0].text == "provider detail"
+    assert reasoning.encrypted_content == "reasoning-signature"
+    assert result.final_output == "final answer"

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -550,6 +550,36 @@ async def test_openrouter_replay_accepts_trailing_slash_base_url() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openrouter_replay_accepts_legacy_reasoning_without_detail_marker() -> None:
+    """Older OpenRouter reasoning items without detail markers should still replay."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    items = first.to_input_list()
+    for item in items:
+        if isinstance(item, dict) and item.get("type") == "reasoning":
+            provider = item.get("provider_data")
+            if isinstance(provider, dict):
+                provider.pop("openrouter_reasoning_details", None)
+
+    await Runner.run(agent, [*items, {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert assistant["reasoning_details"] == [
+        {"type": "reasoning.summary", "summary": "documented summary"},
+        {"type": "reasoning.encrypted", "data": "encrypted-data"},
+        {"type": "reasoning.text", "text": "documented text", "signature": "text-signature"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_openrouter_replay_details_can_be_disabled() -> None:
     """A caller-provided replay policy should be able to block OpenRouter detail replay."""
     set_tracing_disabled(True)

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -157,6 +157,24 @@ class _EncryptedStreamClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _TextOnlyStreamCompletions:
+    async def create(self, **kwargs: Any) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if kwargs.get("stream"):
+            return _text_only_stream_chunks()
+        raise AssertionError("streaming test must request stream=True")
+
+
+class _TextOnlyStreamChat:
+    def __init__(self) -> None:
+        self.completions = _TextOnlyStreamCompletions()
+
+
+class _TextOnlyStreamClient:
+    def __init__(self) -> None:
+        self.chat = _TextOnlyStreamChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 class _ReplayCompletions:
     def __init__(self) -> None:
         self.requests: list[dict[str, Any]] = []
@@ -482,6 +500,26 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openrouter_replay_details_can_be_disabled() -> None:
+    """A caller-provided replay policy should be able to block OpenRouter detail replay."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+        should_replay_reasoning_content=lambda _context: False,
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert "reasoning_details" not in assistant
+
+
+@pytest.mark.asyncio
 async def test_openrouter_runner_surfaces_non_stream_reasoning_content() -> None:
     """OpenRouter sync responses can provide reasoning_content without details."""
     set_tracing_disabled(True)
@@ -652,6 +690,32 @@ async def test_openrouter_stream_without_details_keeps_litellm_reasoning_fallbac
 
 
 @pytest.mark.asyncio
+async def test_openrouter_streamed_text_only_reasoning_details_surface_through_runner() -> None:
+    """Streaming text-only reasoning_details should still create reasoning output."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _TextOnlyStreamClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = Runner.run_streamed(agent, "hello")
+    events = [event async for event in result.stream_events()]
+    raw = [event.data for event in events if isinstance(event, RawResponsesStreamEvent)]
+
+    summary_deltas = [event.delta for event in raw if event.type == "response.reasoning_summary_text.delta"]
+    text_deltas = [event.delta for event in raw if event.type == "response.reasoning_text.delta"]
+    completed = next(event.response for event in raw if event.type == "response.completed")
+    reasoning = completed.output[0]
+
+    assert summary_deltas == ["text-only detail"]
+    assert text_deltas == ["text-only detail"]
+    assert reasoning.type == "reasoning"
+    assert reasoning.summary[0].text == "text-only detail"
+    assert reasoning.content[0].text == "text-only detail"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_parallel_runs_keep_provider_data_separate() -> None:
     """Overlapping runs on one model should attach their own reasoning_details."""
     set_tracing_disabled(True)
@@ -727,6 +791,13 @@ async def _encrypted_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     delta = ChoiceDelta()
     delta.reasoning_details = [_encrypted_reasoning_detail()]
     yield _chunk("chunk_encrypted", delta)
+    yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
+
+
+async def _text_only_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
+    delta = ChoiceDelta()
+    delta.reasoning_details = [{"type": "reasoning.text", "text": "text-only detail"}]
+    yield _chunk("chunk_text_only", delta)
     yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
 
 

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -101,6 +101,56 @@ class _StreamClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _EncryptedCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        message = ChatCompletionMessage(role="assistant", content="final answer")
+        message.reasoning_details = [_encrypted_reasoning_detail()]
+        return ChatCompletion(
+            id="chatcmpl_test",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=message,
+                )
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _EncryptedChat:
+    def __init__(self) -> None:
+        self.completions = _EncryptedCompletions()
+
+
+class _EncryptedClient:
+    def __init__(self) -> None:
+        self.chat = _EncryptedChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+class _EncryptedStreamCompletions:
+    async def create(self, **kwargs: Any) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if kwargs.get("stream"):
+            return _encrypted_stream_chunks()
+        raise AssertionError("streaming test must request stream=True")
+
+
+class _EncryptedStreamChat:
+    def __init__(self) -> None:
+        self.completions = _EncryptedStreamCompletions()
+
+
+class _EncryptedStreamClient:
+    def __init__(self) -> None:
+        self.chat = _EncryptedStreamChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 @pytest.mark.asyncio
 async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
     """Runner output should include OpenRouter reasoning from OpenAI-compatible chat."""
@@ -170,6 +220,51 @@ async def test_openrouter_streamed_reasoning_details_surface_through_runner() ->
     assert reasoning.encrypted_content == "encrypted-data\ntext-signature"
 
 
+@pytest.mark.asyncio
+async def test_openrouter_runner_preserves_encrypted_only_reasoning_details() -> None:
+    """Encrypted-only details should still create a reasoning item."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _EncryptedClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.type == "reasoning"
+    assert reasoning.summary[0].text == "[REDACTED]"
+    assert reasoning.content == []
+    assert reasoning.encrypted_content == "encrypted-data"
+    assert result.final_output == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_streamed_encrypted_only_reasoning_details_surface_through_runner() -> None:
+    """Streaming encrypted-only details should still create a reasoning item."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _EncryptedStreamClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = Runner.run_streamed(agent, "hello")
+    events = [event async for event in result.stream_events()]
+    raw = [event.data for event in events if isinstance(event, RawResponsesStreamEvent)]
+
+    summary_deltas = [event.delta for event in raw if event.type == "response.reasoning_summary_text.delta"]
+    completed = next(event.response for event in raw if event.type == "response.completed")
+    reasoning = completed.output[0]
+
+    assert summary_deltas == ["[REDACTED]"]
+    assert reasoning.type == "reasoning"
+    assert reasoning.summary[0].text == "[REDACTED]"
+    assert reasoning.content is None
+    assert reasoning.encrypted_content == "encrypted-data"
+
+
 def _reasoning_details() -> list[dict[str, object]]:
     return [
         {
@@ -197,11 +292,28 @@ def _reasoning_details() -> list[dict[str, object]]:
     ]
 
 
+def _encrypted_reasoning_detail() -> dict[str, object]:
+    return {
+        "type": "reasoning.encrypted",
+        "data": "encrypted-data",
+        "id": "reasoning-encrypted-1",
+        "format": "anthropic-claude-v1",
+        "index": 0,
+    }
+
+
 async def _stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     for index, detail in enumerate(_reasoning_details()):
         delta = ChoiceDelta()
         delta.reasoning_details = [detail]
         yield _chunk(f"chunk_{index}", delta)
+    yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
+
+
+async def _encrypted_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
+    delta = ChoiceDelta()
+    delta.reasoning_details = [_encrypted_reasoning_detail()]
+    yield _chunk("chunk_encrypted", delta)
     yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
 
 

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -403,7 +403,7 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
 
 @pytest.mark.asyncio
 async def test_openrouter_details_from_second_choice_do_not_attach_to_first_choice() -> None:
-    """Runner converts the first chat choice, so provider details must follow that choice."""
+    """OpenRouter reasoning does not silently drop later chat choices."""
     set_tracing_disabled(True)
     model = build_openrouter_chat_model(
         "openrouter/anthropic/claude-sonnet-4.5",
@@ -411,11 +411,8 @@ async def test_openrouter_details_from_second_choice_do_not_attach_to_first_choi
     )
     agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
 
-    result = await Runner.run(agent, "hello")
-
-    reasoning = result.raw_responses[0].output[0]
-    assert reasoning.summary[0].text == "first summary"
-    assert "openrouter_reasoning_details" not in reasoning.provider_data
+    with pytest.raises(ValueError, match="single-choice"):
+        await Runner.run(agent, "hello")
 
 
 @pytest.mark.asyncio
@@ -458,19 +455,11 @@ def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
 
 @pytest.mark.asyncio
 async def test_openrouter_streamed_reasoning_details_stay_separate_by_choice() -> None:
-    """Multi-choice streams should not mix reasoning metadata across choices."""
+    """Multi-choice streams should not silently mix reasoning metadata across choices."""
     stream = _normalize_openrouter_reasoning_stream(_multi_choice_stream_chunks())
 
-    chunks = [chunk async for chunk in stream]
-
-    first = chunks[0].choices[0].delta
-    second = chunks[0].choices[1].delta
-    assert first.reasoning_content == "choice zero"
-    assert first.reasoning == "zero text"
-    assert first.thinking_blocks == [{"signature": "zero-signature"}]
-    assert second.reasoning_content == "choice one"
-    assert second.reasoning == "one text"
-    assert second.thinking_blocks == [{"signature": "one-signature"}]
+    with pytest.raises(ValueError, match="single-choice"):
+        _ = [chunk async for chunk in stream]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -12,6 +12,7 @@ from openai.types.completion_usage import CompletionUsage
 from agency_swarm import Agent, Runner, set_tracing_disabled
 from agency_swarm.utils.openrouter import (
     _OPENROUTER_REPLAY_DETAILS,
+    _details_from_reasoning_item,
     _normalize_openrouter_reasoning_stream,
     build_openrouter_chat_model,
 )
@@ -436,6 +437,23 @@ async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None
     assert client.chat.completions.messages is not messages
     assert client.chat.completions.messages is not None
     assert client.chat.completions.messages[0]["reasoning_details"] == _reasoning_details()
+
+
+def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
+    """A local display placeholder should not be sent back as provider reasoning."""
+    details = _details_from_reasoning_item(
+        {
+            "type": "reasoning",
+            "summary": [{"text": "[REDACTED]"}],
+            "content": [{"text": "real text"}],
+            "encrypted_content": "encrypted-data\ntext-signature",
+        }
+    )
+
+    assert details == [
+        {"type": "reasoning.encrypted", "data": "encrypted-data"},
+        {"type": "reasoning.text", "text": "real text", "signature": "text-signature"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -12,8 +12,10 @@ from openai.types.completion_usage import CompletionUsage
 from agency_swarm import Agent, Runner, set_tracing_disabled
 from agency_swarm.utils.openrouter import (
     _OPENROUTER_REPLAY_DETAILS,
+    OPENROUTER_REASONING_DETAILS_KEY,
     _details_from_reasoning_item,
     _normalize_openrouter_reasoning_stream,
+    _openrouter_replay_details,
     build_openrouter_chat_model,
 )
 
@@ -172,6 +174,24 @@ class _TextOnlyStreamChat:
 class _TextOnlyStreamClient:
     def __init__(self) -> None:
         self.chat = _TextOnlyStreamChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+class _SplitReasoningStreamCompletions:
+    async def create(self, **kwargs: Any) -> ChatCompletion | AsyncIterator[ChatCompletionChunk]:
+        if kwargs.get("stream"):
+            return _split_reasoning_stream_chunks()
+        raise AssertionError("streaming test must request stream=True")
+
+
+class _SplitReasoningStreamChat:
+    def __init__(self) -> None:
+        self.completions = _SplitReasoningStreamCompletions()
+
+
+class _SplitReasoningStreamClient:
+    def __init__(self) -> None:
+        self.chat = _SplitReasoningStreamChat()
         self.base_url = "https://openrouter.ai/api/v1"
 
 
@@ -498,7 +518,7 @@ async def test_openrouter_streamed_encrypted_only_reasoning_details_surface_thro
     assert reasoning.type == "reasoning"
     assert reasoning.summary[0].text == "[REDACTED]"
     assert reasoning.content is None
-    assert reasoning.encrypted_content == "encrypted-data"
+    assert reasoning.encrypted_content == "encrypted-data\nsecond-encrypted-data"
 
 
 @pytest.mark.asyncio
@@ -624,6 +644,30 @@ async def test_openrouter_default_replay_blocks_cross_family_reasoning() -> None
 
 
 @pytest.mark.asyncio
+async def test_openrouter_default_replay_blocks_same_provider_different_model() -> None:
+    """OpenRouter reasoning replay should match the exact normalized model."""
+    set_tracing_disabled(True)
+    client = _ReplayClient()
+    source = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=source)
+
+    first = await Runner.run(agent, "hello")
+    target = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-opus-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent.model = target
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert "reasoning_details" not in assistant
+
+
+@pytest.mark.asyncio
 async def test_openrouter_default_replay_blocks_proxy_endpoint() -> None:
     """OpenRouter details should not replay through non-OpenRouter gateways by default."""
     set_tracing_disabled(True)
@@ -659,9 +703,7 @@ async def test_openrouter_replays_synthesized_reasoning_content() -> None:
 
     messages = client.chat.completions.requests[1]["messages"]
     assistant = next(message for message in messages if message["role"] == "assistant")
-    assert assistant["reasoning_details"] == [
-        {"type": "reasoning.summary", "summary": "content reasoning"}
-    ]
+    assert assistant["reasoning_details"] == [{"type": "reasoning.summary", "summary": "content reasoning"}]
 
 
 @pytest.mark.asyncio
@@ -733,8 +775,8 @@ async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None
 
 
 @pytest.mark.asyncio
-async def test_openrouter_replay_details_respect_sdk_replay_policy() -> None:
-    """Replay enrichment should not add details when the SDK did not mark replay."""
+async def test_openrouter_replay_details_attach_to_plain_assistant_message() -> None:
+    """Replay enrichment should add details to ordinary assistant turns."""
     client = _MutationClient()
     model = build_openrouter_chat_model(
         "openrouter/anthropic/claude-sonnet-4.5",
@@ -748,7 +790,7 @@ async def test_openrouter_replay_details_respect_sdk_replay_policy() -> None:
         _OPENROUTER_REPLAY_DETAILS.reset(token)
 
     assert client.chat.completions.messages is not None
-    assert "reasoning_details" not in client.chat.completions.messages[0]
+    assert client.chat.completions.messages[0]["reasoning_details"] == _reasoning_details()
 
 
 @pytest.mark.asyncio
@@ -775,6 +817,30 @@ async def test_openrouter_replay_details_attach_to_latest_assistant_message() ->
     assert client.chat.completions.messages[2]["reasoning_details"] == _reasoning_details()
 
 
+@pytest.mark.asyncio
+async def test_openrouter_replay_details_attach_to_matching_assistant_message() -> None:
+    """Replay enrichment should follow assistant-turn slots, not newest suffix."""
+    client = _MutationClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    messages = [
+        {"role": "assistant", "content": "older"},
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "content": "current"},
+    ]
+    token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details(), []])
+    try:
+        await model._get_client().chat.completions.create(messages=messages)
+    finally:
+        _OPENROUTER_REPLAY_DETAILS.reset(token)
+
+    assert client.chat.completions.messages is not None
+    assert client.chat.completions.messages[0]["reasoning_details"] == _reasoning_details()
+    assert "reasoning_details" not in client.chat.completions.messages[2]
+
+
 def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
     """A local display placeholder should not be sent back as provider reasoning."""
     details = _details_from_reasoning_item(
@@ -790,6 +856,29 @@ def test_openrouter_replay_fallback_drops_redaction_placeholder() -> None:
         {"type": "reasoning.encrypted", "data": "encrypted-data"},
         {"type": "reasoning.text", "text": "real text", "signature": "text-signature"},
     ]
+
+
+def test_openrouter_replay_details_keep_assistant_turn_slots() -> None:
+    """Replay collection should align details with assistant turn order."""
+    replay = _openrouter_replay_details(
+        [
+            {
+                "type": "reasoning",
+                "provider_data": {
+                    "model": "anthropic/claude-sonnet-4.5",
+                    OPENROUTER_REASONING_DETAILS_KEY: _reasoning_details(),
+                },
+            },
+            {"type": "message", "role": "assistant", "content": "older"},
+            {"role": "user", "content": "next"},
+            {"role": "assistant", "content": "current"},
+        ],
+        model="anthropic/claude-sonnet-4.5",
+        base_url="https://openrouter.ai/api/v1",
+        should_replay=lambda _context: True,
+    )
+
+    assert replay == [_reasoning_details(), []]
 
 
 @pytest.mark.asyncio
@@ -829,9 +918,7 @@ async def test_openrouter_stream_without_details_keeps_litellm_reasoning_fallbac
 
     normalized = chunks[0].choices[0].delta
     assert not getattr(normalized, "_agency_swarm_skip_reasoning_content_copy", False)
-    assert normalized.thinking_blocks == [
-        {"thinking": "fallback reasoning", "signature": "fallback-signature"}
-    ]
+    assert normalized.thinking_blocks == [{"thinking": "fallback reasoning", "signature": "fallback-signature"}]
 
 
 @pytest.mark.asyncio
@@ -858,6 +945,31 @@ async def test_openrouter_streamed_text_only_reasoning_details_surface_through_r
     assert reasoning.type == "reasoning"
     assert reasoning.summary[0].text == "text-only detail"
     assert reasoning.content[0].text == "text-only detail"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_streamed_reasoning_fragments_preserve_boundaries() -> None:
+    """Streaming reasoning fragments should preserve newline boundaries."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _SplitReasoningStreamClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = Runner.run_streamed(agent, "hello")
+    events = [event async for event in result.stream_events()]
+    raw = [event.data for event in events if isinstance(event, RawResponsesStreamEvent)]
+
+    summary_deltas = [event.delta for event in raw if event.type == "response.reasoning_summary_text.delta"]
+    text_deltas = [event.delta for event in raw if event.type == "response.reasoning_text.delta"]
+    completed = next(event.response for event in raw if event.type == "response.completed")
+    reasoning = completed.output[0]
+
+    assert summary_deltas == ["first summary", "\nsecond summary"]
+    assert text_deltas == ["first text", "\nsecond text"]
+    assert reasoning.summary[0].text == "first summary\nsecond summary"
+    assert [content.text for content in reasoning.content] == ["first text\nsecond text"]
 
 
 @pytest.mark.asyncio
@@ -924,6 +1036,16 @@ def _encrypted_reasoning_detail() -> dict[str, object]:
     }
 
 
+def _second_encrypted_reasoning_detail() -> dict[str, object]:
+    return {
+        "type": "reasoning.encrypted",
+        "data": "second-encrypted-data",
+        "id": "reasoning-encrypted-2",
+        "format": "anthropic-claude-v1",
+        "index": 1,
+    }
+
+
 async def _stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     for index, detail in enumerate(_reasoning_details()):
         delta = ChoiceDelta()
@@ -936,6 +1058,9 @@ async def _encrypted_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     delta = ChoiceDelta()
     delta.reasoning_details = [_encrypted_reasoning_detail()]
     yield _chunk("chunk_encrypted", delta)
+    second = ChoiceDelta()
+    second.reasoning_details = [_second_encrypted_reasoning_detail()]
+    yield _chunk("chunk_encrypted_second", second)
     yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
 
 
@@ -943,6 +1068,21 @@ async def _text_only_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
     delta = ChoiceDelta()
     delta.reasoning_details = [{"type": "reasoning.text", "text": "text-only detail"}]
     yield _chunk("chunk_text_only", delta)
+    yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
+
+
+async def _split_reasoning_stream_chunks() -> AsyncIterator[ChatCompletionChunk]:
+    for index, detail in enumerate(
+        [
+            {"type": "reasoning.summary", "summary": "first summary"},
+            {"type": "reasoning.summary", "summary": "second summary"},
+            {"type": "reasoning.text", "text": "first text"},
+            {"type": "reasoning.text", "text": "second text"},
+        ]
+    ):
+        delta = ChoiceDelta()
+        delta.reasoning_details = [detail]
+        yield _chunk(f"chunk_split_{index}", delta)
     yield _chunk("chunk_content", ChoiceDelta(content="final answer"))
 
 

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -269,6 +269,36 @@ class _ReasoningContentClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _ReasoningContentReplayCompletions:
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> ChatCompletion:
+        self.requests.append(kwargs)
+        message = ChatCompletionMessage(role="assistant", content=f"turn {len(self.requests)}")
+        if len(self.requests) == 1:
+            message.reasoning_content = "content reasoning"
+        return ChatCompletion(
+            id=f"chatcmpl_content_replay_{len(self.requests)}",
+            choices=[Choice(finish_reason="stop", index=0, logprobs=None, message=message)],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _ReasoningContentReplayChat:
+    def __init__(self) -> None:
+        self.completions = _ReasoningContentReplayCompletions()
+
+
+class _ReasoningContentReplayClient:
+    def __init__(self) -> None:
+        self.chat = _ReasoningContentReplayChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 class _ThinkingBlocksCompletions:
     async def create(self, **_kwargs: Any) -> ChatCompletion:
         message = ChatCompletionMessage(role="assistant", content="final answer")
@@ -517,6 +547,27 @@ async def test_openrouter_replay_details_can_be_disabled() -> None:
     messages = client.chat.completions.requests[1]["messages"]
     assistant = next(message for message in messages if message["role"] == "assistant")
     assert "reasoning_details" not in assistant
+
+
+@pytest.mark.asyncio
+async def test_openrouter_replays_synthesized_reasoning_content() -> None:
+    """Reasoning_content-only responses should keep replay metadata for the next turn."""
+    set_tracing_disabled(True)
+    client = _ReasoningContentReplayClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    first = await Runner.run(agent, "hello")
+    await Runner.run(agent, [*first.to_input_list(), {"role": "user", "content": "again"}])
+
+    messages = client.chat.completions.requests[1]["messages"]
+    assistant = next(message for message in messages if message["role"] == "assistant")
+    assert assistant["reasoning_details"] == [
+        {"type": "reasoning.summary", "summary": "content reasoning"}
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_modules/test_openrouter_reasoning.py
+++ b/tests/test_agent_modules/test_openrouter_reasoning.py
@@ -10,7 +10,11 @@ from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, Choic
 from openai.types.completion_usage import CompletionUsage
 
 from agency_swarm import Agent, Runner, set_tracing_disabled
-from agency_swarm.utils.openrouter import _normalize_openrouter_reasoning_stream, build_openrouter_chat_model
+from agency_swarm.utils.openrouter import (
+    _OPENROUTER_REPLAY_DETAILS,
+    _normalize_openrouter_reasoning_stream,
+    build_openrouter_chat_model,
+)
 
 
 class _Completions:
@@ -189,6 +193,71 @@ class _ReplayClient:
         self.base_url = "https://openrouter.ai/api/v1"
 
 
+class _MixedChoiceCompletions:
+    async def create(self, **_kwargs: Any) -> ChatCompletion:
+        first = ChatCompletionMessage(role="assistant", content="first answer")
+        first.reasoning = "first summary"
+        second = ChatCompletionMessage(role="assistant", content="second answer")
+        second.reasoning_details = [
+            {"type": "reasoning.text", "text": "second detail", "signature": "second-signature"}
+        ]
+        return ChatCompletion(
+            id="chatcmpl_mixed",
+            choices=[
+                Choice(finish_reason="stop", index=0, logprobs=None, message=first),
+                Choice(finish_reason="stop", index=1, logprobs=None, message=second),
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+            usage=CompletionUsage(completion_tokens=2, prompt_tokens=1, total_tokens=3),
+        )
+
+
+class _MixedChoiceChat:
+    def __init__(self) -> None:
+        self.completions = _MixedChoiceCompletions()
+
+
+class _MixedChoiceClient:
+    def __init__(self) -> None:
+        self.chat = _MixedChoiceChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
+class _MutationCompletions:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] | None = None
+
+    async def create(self, **kwargs: Any) -> ChatCompletion:
+        self.messages = kwargs["messages"]
+        return ChatCompletion(
+            id="chatcmpl_mutation",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    logprobs=None,
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                )
+            ],
+            created=0,
+            model="anthropic/claude-sonnet-4.5",
+            object="chat.completion",
+        )
+
+
+class _MutationChat:
+    def __init__(self) -> None:
+        self.completions = _MutationCompletions()
+
+
+class _MutationClient:
+    def __init__(self) -> None:
+        self.chat = _MutationChat()
+        self.base_url = "https://openrouter.ai/api/v1"
+
+
 @pytest.mark.asyncio
 async def test_openrouter_runner_surfaces_reasoning_metadata() -> None:
     """Runner output should include OpenRouter reasoning from OpenAI-compatible chat."""
@@ -329,6 +398,44 @@ async def test_openrouter_replays_reasoning_details_on_next_request() -> None:
     messages = client.chat.completions.requests[1]["messages"]
     assistant = next(message for message in messages if message["role"] == "assistant")
     assert assistant["reasoning_details"] == _reasoning_details()
+
+
+@pytest.mark.asyncio
+async def test_openrouter_details_from_second_choice_do_not_attach_to_first_choice() -> None:
+    """Runner converts the first chat choice, so provider details must follow that choice."""
+    set_tracing_disabled(True)
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, _MixedChoiceClient()),
+    )
+    agent = Agent(name="OpenRouterAgent", instructions="Reply briefly.", model=model)
+
+    result = await Runner.run(agent, "hello")
+
+    reasoning = result.raw_responses[0].output[0]
+    assert reasoning.summary[0].text == "first summary"
+    assert "openrouter_reasoning_details" not in reasoning.provider_data
+
+
+@pytest.mark.asyncio
+async def test_openrouter_replay_details_do_not_mutate_caller_messages() -> None:
+    """Replay enrichment should copy request messages before adding OpenRouter fields."""
+    client = _MutationClient()
+    model = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=cast(Any, client),
+    )
+    messages = [{"role": "assistant", "content": "previous"}]
+    token = _OPENROUTER_REPLAY_DETAILS.set([_reasoning_details()])
+    try:
+        await model._get_client().chat.completions.create(messages=messages)
+    finally:
+        _OPENROUTER_REPLAY_DETAILS.reset(token)
+
+    assert "reasoning_details" not in messages[0]
+    assert client.chat.completions.messages is not messages
+    assert client.chat.completions.messages is not None
+    assert client.chat.completions.messages[0]["reasoning_details"] == _reasoning_details()
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -1578,6 +1578,97 @@ def test_openrouter_override_reuses_non_default_source_openai_client(
     assert agent.model.should_replay_reasoning_content is replay
 
 
+def test_openrouter_override_preserves_official_source_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter swaps should keep headers, not OpenAI auth, from official-base wrappers."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import get_openrouter_model_name
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-env")
+    client = AsyncOpenAI(
+        api_key="sk-source",
+        base_url="https://api.openai.com/v1",
+        default_headers={"x-source": "kept"},
+        timeout=12,
+        max_retries=3,
+    )
+
+    def replay(_context):
+        return False
+
+    source = OpenAIChatCompletionsModel(
+        model="gpt-4o-mini",
+        openai_client=client,
+        should_replay_reasoning_content=replay,
+    )
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4.5"
+    assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
+    assert agent.model._client is not client
+    assert agent.model._client.api_key == "sk-openrouter-env"
+    assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
+    assert agent.model._client.timeout == 12
+    assert agent.model._client.max_retries == 3
+    assert dict(agent.model._client.default_headers)["x-source"] == "kept"
+    assert agent.model.should_replay_reasoning_content is replay
+
+
+def test_openrouter_override_request_key_copies_official_source_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Request OpenRouter credentials should copy source client settings."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-source",
+        base_url="https://api.openai.com/v1",
+        default_headers={"x-source": "old"},
+        timeout=12,
+        max_retries=3,
+    )
+    source = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(
+        agency,
+        ClientConfig(
+            model="openrouter/anthropic/claude-sonnet-4.5",
+            api_key="sk-openrouter-request",
+            default_headers={"x-source": "new"},
+        ),
+    )
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model._client is not client
+    assert agent.model._client.api_key == "sk-openrouter-request"
+    assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
+    assert agent.model._client.timeout == 12
+    assert agent.model._client.max_retries == 3
+    assert dict(agent.model._client.default_headers)["x-source"] == "new"
+
+
 def test_configured_openrouter_agent_openai_override_drops_openrouter_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -1520,6 +1520,7 @@ def test_configured_openrouter_model_override_preserves_replay_policy(
         api_key="sk-injected",
         base_url="https://openrouter-proxy.test/v1",
     )
+
     def replay(_context):
         return False
 
@@ -1537,10 +1538,10 @@ def test_configured_openrouter_model_override_preserves_replay_policy(
     assert agent.model.should_replay_reasoning_content is replay
 
 
-def test_openrouter_override_reuses_non_default_source_openai_client(
+def test_openrouter_override_does_not_reuse_custom_gateway_source_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """OpenRouter swaps should keep an existing gateway client from normal OpenAI wrappers."""
+    """OpenRouter swaps should not send OpenRouter models to a custom gateway."""
     pytest.importorskip("agents")
 
     from agents import OpenAIChatCompletionsModel
@@ -1551,7 +1552,7 @@ def test_openrouter_override_reuses_non_default_source_openai_client(
     from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
     from agency_swarm.utils.openrouter import get_openrouter_model_name
 
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-env")
     client = AsyncOpenAI(
         api_key="sk-gateway",
         base_url="https://gateway.test/v1",
@@ -1574,7 +1575,9 @@ def test_openrouter_override_reuses_non_default_source_openai_client(
     assert isinstance(agent.model, OpenAIChatCompletionsModel)
     assert agent.model.model == "anthropic/claude-sonnet-4.5"
     assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
-    assert agent.model._client is client
+    assert agent.model._client is not client
+    assert agent.model._client.api_key == "sk-openrouter-env"
+    assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
     assert agent.model.should_replay_reasoning_content is replay
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -1501,6 +1501,42 @@ def test_configured_openrouter_model_override_preserves_injected_client_without_
     assert dict(agent.model._client.default_headers)["x-client"] == "kept"
 
 
+def test_configured_openrouter_model_override_preserves_replay_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter model swaps should keep custom reasoning replay policy."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import build_openrouter_chat_model
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-injected",
+        base_url="https://openrouter-proxy.test/v1",
+    )
+    def replay(_context):
+        return False
+
+    source = build_openrouter_chat_model(
+        "openrouter/anthropic/claude-sonnet-4.5",
+        openai_client=client,
+        should_replay_reasoning_content=replay,
+    )
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/openai/gpt-5"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.should_replay_reasoning_content is replay
+
+
 def test_configured_openrouter_agent_openai_override_drops_openrouter_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -1537,6 +1537,47 @@ def test_configured_openrouter_model_override_preserves_replay_policy(
     assert agent.model.should_replay_reasoning_content is replay
 
 
+def test_openrouter_override_reuses_non_default_source_openai_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter swaps should keep an existing gateway client from normal OpenAI wrappers."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import get_openrouter_model_name
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-gateway",
+        base_url="https://gateway.test/v1",
+        default_headers={"x-source": "kept"},
+    )
+
+    def replay(_context):
+        return False
+
+    source = OpenAIChatCompletionsModel(
+        model="gpt-4o-mini",
+        openai_client=client,
+        should_replay_reasoning_content=replay,
+    )
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4.5"
+    assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
+    assert agent.model._client is client
+    assert agent.model.should_replay_reasoning_content is replay
+
+
 def test_configured_openrouter_agent_openai_override_drops_openrouter_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
+++ b/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
@@ -1,0 +1,40 @@
+"""Focused OpenRouter client override regressions."""
+
+import pytest
+
+
+def test_model_only_openrouter_override_copies_custom_official_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A model-only OpenRouter swap should keep a source key when no OpenRouter env key exists."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+    from agency_swarm.utils.openrouter import get_openrouter_model_name
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-source-openrouter",
+        base_url="https://api.openai.com/v1",
+        default_headers={"x-source": "kept"},
+        timeout=12,
+        max_retries=3,
+    )
+    source = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
+
+    assert isinstance(agent.model, OpenAIChatCompletionsModel)
+    assert agent.model.model == "anthropic/claude-sonnet-4.5"
+    assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
+    assert agent.model._client is not client
+    assert agent.model._client.api_key == "sk-source-openrouter"
+    assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
+    assert agent.model._client.timeout == 12
+    assert agent.model._client.max_retries == 3
+    assert dict(agent.model._client.default_headers)["x-source"] == "kept"

--- a/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
+++ b/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
@@ -3,8 +3,39 @@
 import pytest
 
 
-def test_model_only_openrouter_override_copies_custom_official_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A model-only OpenRouter swap should keep a source key when no OpenRouter env key exists."""
+def test_model_only_openrouter_override_requires_openrouter_key_with_official_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An injected OpenAI key must not become an OpenRouter credential."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    client = AsyncOpenAI(
+        api_key="sk-source-openai",
+        base_url="https://api.openai.com/v1",
+        default_headers={"x-source": "kept"},
+        timeout=12,
+        max_retries=3,
+    )
+    source = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY is required"):
+        apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
+
+
+def test_model_only_openrouter_override_does_not_reuse_custom_gateway_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model-only OpenRouter swap must route through the OpenRouter endpoint."""
     pytest.importorskip("agents")
 
     from agents import OpenAIChatCompletionsModel
@@ -15,13 +46,11 @@ def test_model_only_openrouter_override_copies_custom_official_client(monkeypatc
     from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
     from agency_swarm.utils.openrouter import get_openrouter_model_name
 
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-env")
     client = AsyncOpenAI(
-        api_key="sk-source-openrouter",
-        base_url="https://api.openai.com/v1",
-        default_headers={"x-source": "kept"},
-        timeout=12,
-        max_retries=3,
+        api_key="sk-gateway",
+        base_url="https://gateway.test/v1",
+        default_headers={"x-source": "gateway"},
     )
     source = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
     agent = Agent(name="A", instructions="x", model=source)
@@ -30,11 +59,7 @@ def test_model_only_openrouter_override_copies_custom_official_client(monkeypatc
     apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
 
     assert isinstance(agent.model, OpenAIChatCompletionsModel)
-    assert agent.model.model == "anthropic/claude-sonnet-4.5"
     assert get_openrouter_model_name(agent.model) == "openrouter/anthropic/claude-sonnet-4.5"
     assert agent.model._client is not client
-    assert agent.model._client.api_key == "sk-source-openrouter"
+    assert agent.model._client.api_key == "sk-openrouter-env"
     assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
-    assert agent.model._client.timeout == 12
-    assert agent.model._client.max_retries == 3
-    assert dict(agent.model._client.default_headers)["x-source"] == "kept"


### PR DESCRIPTION
This pull request fixes OpenRouter reasoning handling so `openrouter/...` models preserve provider reasoning metadata across non-streaming, streaming, and multi-turn runs.

- Normalizes OpenRouter `reasoning_details` into Agents reasoning output, including summaries, text, signatures, and encrypted-only reasoning.
- Replays preserved OpenRouter reasoning details on later requests so provider reasoning continuity is kept.
- Prevents already-normalized OpenRouter chunks from being copied again by the LiteLLM reasoning patch.

The included tests cover non-streaming runner output, streamed reasoning events, encrypted-only reasoning, replaying details on the next request, and the LiteLLM skip path.
