### PR TITLE
fix: strip source auth headers for OpenRouter swaps

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -213,7 +213,7 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
             elif source_client is not None and _should_copy_source_openai_client_for_openrouter(source_client):
                 openrouter_client = _copy_source_openai_client_for_openrouter(source_client, config)
             elif source_client is not None and _should_preserve_source_openai_headers(source_client):
-                source_default_headers = cast(dict[str, str], dict(source_client.default_headers or {})) or None
+                source_default_headers = _copyable_source_openai_headers(source_client)
         agent.model = build_openrouter_chat_model(
             model_name,
             api_key=None if openrouter_client is not None or config is None else config.api_key,
@@ -301,7 +301,7 @@ def _should_preserve_source_openai_headers(client: AsyncOpenAI | None) -> bool:
     base_url = str(client.base_url).rstrip("/")
     if base_url != "https://api.openai.com/v1":
         return False
-    return bool(client.default_headers)
+    return bool(_copyable_source_openai_headers(client))
 
 
 def _should_copy_source_openai_client_for_openrouter(
@@ -325,10 +325,20 @@ def _copy_source_openai_client_for_openrouter(
     return client.copy(
         api_key=(None if config is None else config.api_key) or os.getenv(OPENROUTER_API_KEY_ENV),
         base_url=(None if config is None else config.base_url) or OPENROUTER_BASE_URL,
-        default_headers=(None if config is None else config.default_headers)
-        or cast(dict[str, str], dict(client.default_headers or {}))
-        or None,
+        default_headers=(None if config is None else config.default_headers) or _copyable_source_openai_headers(client),
     )
+
+
+_OPENAI_CREDENTIAL_HEADER_NAMES = frozenset({"authorization", "openai-organization", "openai-project"})
+
+
+def _copyable_source_openai_headers(client: AsyncOpenAI) -> dict[str, str] | None:
+    headers = {
+        key: value
+        for key, value in cast(dict[str, str], dict(client.default_headers or {})).items()
+        if key.lower() not in _OPENAI_CREDENTIAL_HEADER_NAMES
+    }
+    return headers or None
 
 
 def _openrouter_override_default_headers(

--- a/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
+++ b/tests/test_fastapi_utils_modules/test_openrouter_client_override.py
@@ -63,3 +63,33 @@ def test_model_only_openrouter_override_does_not_reuse_custom_gateway_client(
     assert agent.model._client is not client
     assert agent.model._client.api_key == "sk-openrouter-env"
     assert str(agent.model._client.base_url).startswith("https://openrouter.ai/api/v1")
+
+
+def test_model_only_openrouter_override_strips_source_auth_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Copied official clients must not send stale OpenAI auth to OpenRouter."""
+    pytest.importorskip("agents")
+
+    from agents import OpenAIChatCompletionsModel
+    from openai import AsyncOpenAI
+
+    from agency_swarm import Agent
+    from agency_swarm.integrations.fastapi_utils.endpoint_handlers import apply_openai_client_config
+    from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-env")
+    client = AsyncOpenAI(
+        api_key="sk-source-openai",
+        base_url="https://api.openai.com/v1",
+        default_headers={"x-source": "kept"},
+    )
+    source = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
+    agent = Agent(name="A", instructions="x", model=source)
+    agency = type("Agency", (), {"agents": {"A": agent}})()
+
+    apply_openai_client_config(agency, ClientConfig(model="openrouter/anthropic/claude-sonnet-4.5"))
+
+    headers = dict(agent.model._client.default_headers)
+    assert headers["x-source"] == "kept"
+    assert headers.get("Authorization") != "Bearer sk-source-openai"


### PR DESCRIPTION
## Summary

Fixes a release-review blocker in OpenRouter model-only swaps.

When Agency Swarm copied an official-base `AsyncOpenAI` client into a new OpenRouter client, it could also copy generated OpenAI credential headers. That risked sending the old OpenAI `Authorization` header to OpenRouter and overriding the OpenRouter API key selected from `OPENROUTER_API_KEY` or `client_config.api_key`.

This keeps custom source headers, but strips generated OpenAI credential headers before building the OpenRouter client.

## Tests

- `UV_PYTHON=3.13 uv run pytest -q tests/test_fastapi_utils_modules/test_openrouter_client_override.py tests/test_fastapi_utils_modules/test_openai_client_config_models.py -k openrouter` -> 23 passed, 57 deselected
- `UV_PYTHON=3.13 uv run pytest -q tests/test_agent_modules/test_openrouter_reasoning.py tests/test_fastapi_utils_modules/test_openrouter_client_override.py tests/test_fastapi_utils_modules/test_openai_client_config_models.py -k openrouter` -> 51 passed, 57 deselected
- `UV_PYTHON=3.13 uv run ruff check src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py tests/test_fastapi_utils_modules/test_openrouter_client_override.py`
- `UV_PYTHON=3.13 uv run ruff format --check src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py tests/test_fastapi_utils_modules/test_openrouter_client_override.py`
- `UV_PYTHON=3.13 uv run mypy src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py`

## Issue number

Release-review blocker for `v1.10.0`.

## Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass

Docs are not needed because this is a credential-routing bug fix. I ran the equivalent focused lint and format checks on the touched files rather than repo-wide `make lint` / `make format`.
