### PR TITLE
feat: harden Ollama TUI bridge support

### DIFF
--- a/src/agency_swarm/agency/setup.py
+++ b/src/agency_swarm/agency/setup.py
@@ -27,8 +27,7 @@ _warned_deprecated_send_message_handoff = False
 def _validate_communication_tool_class(tool_class: type) -> None:
     if not issubclass(tool_class, SendMessage | Handoff):
         raise TypeError(
-            f"Invalid communication tool class: {tool_class.__name__}. "
-            "Expected a SendMessage or Handoff subclass."
+            f"Invalid communication tool class: {tool_class.__name__}. Expected a SendMessage or Handoff subclass."
         )
 
 

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -547,7 +547,10 @@ def _resolve_stream_client_config(http_request: Request, config: ClientConfig | 
             return config.model_copy(update={"base_url": None})
     if config.model != _AGENCY_SWARM_DEFAULT_MODEL:
         return config
-    return config.model_copy(update={"model": None})
+    update: dict[str, str | None] = {"model": None}
+    if config.base_url is not None and _is_request_base_url(http_request, config.base_url):
+        update["base_url"] = None
+    return config.model_copy(update=update)
 
 
 def _is_request_base_url(http_request: Request, base_url: str) -> bool:

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -537,6 +537,10 @@ def _resolve_stream_client_config(http_request: Request, config: ClientConfig | 
     app_state = getattr(getattr(http_request, "app", None), "state", None)
     if not bool(getattr(app_state, "agency_swarm_tui_bridge", False)):
         return config
+    if config.model is not None and _is_litellm_model(config.model):
+        provider = _get_litellm_provider(config.model)
+        if config.base_url is not None and _is_local_litellm_provider(provider):
+            return config.model_copy(update={"base_url": None})
     if config.model != _AGENCY_SWARM_DEFAULT_MODEL:
         return config
     return config.model_copy(update={"model": None})
@@ -2306,11 +2310,6 @@ def _resolve_litellm_base_url(
     provider = _get_litellm_provider(model_name)
 
     if config.base_url is None:
-        return existing_base_url
-
-    # Local providers resolve their own endpoint from LiteLLM/env configuration.
-    # Inheriting the Agent Swarm bridge URL here points those models at the wrong server.
-    if _is_local_litellm_provider(provider):
         return existing_base_url
 
     # Preserve main's Codex browser-auth guard for non-OpenAI providers, while

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -193,9 +193,6 @@ def _apply_request_model_override(agent: Agent, model_name: str, config: ClientC
     Returns ``True`` when the OpenAI gateway client has already been applied
     during the swap so the caller can skip the downstream client-apply step.
     """
-    if model_name == _AGENCY_SWARM_DEFAULT_MODEL:
-        return False
-
     model = agent.model
 
     if is_openrouter_model_name(model_name):
@@ -490,7 +487,7 @@ def apply_openai_client_config(agency: Agency, config: ClientConfig) -> None:
     # Apply to all agents in the agency
     for agent in agency.agents.values():
         gateway_applied = False
-        if config.model is not None and config.model != _AGENCY_SWARM_DEFAULT_MODEL:
+        if config.model is not None:
             gateway_applied = _apply_request_model_override(agent, config.model, config)
             _refresh_framework_defaults_after_model_swap(agent)
         _apply_request_model_settings_extra_args(agent, config)

--- a/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
+++ b/src/agency_swarm/integrations/fastapi_utils/endpoint_handlers.py
@@ -539,11 +539,22 @@ def _resolve_stream_client_config(http_request: Request, config: ClientConfig | 
         return config
     if config.model is not None and _is_litellm_model(config.model):
         provider = _get_litellm_provider(config.model)
-        if config.base_url is not None and _is_local_litellm_provider(provider):
+        if (
+            config.base_url is not None
+            and _is_local_litellm_provider(provider)
+            and _is_request_base_url(http_request, config.base_url)
+        ):
             return config.model_copy(update={"base_url": None})
     if config.model != _AGENCY_SWARM_DEFAULT_MODEL:
         return config
     return config.model_copy(update={"model": None})
+
+
+def _is_request_base_url(http_request: Request, base_url: str) -> bool:
+    request_base_url = getattr(http_request, "base_url", None)
+    if request_base_url is None:
+        return False
+    return str(request_base_url).rstrip("/") == base_url.rstrip("/")
 
 
 @dataclass

--- a/src/agency_swarm/integrations/fastapi_utils/override_policy.py
+++ b/src/agency_swarm/integrations/fastapi_utils/override_policy.py
@@ -9,8 +9,6 @@ from agency_swarm import Agency, Agent
 from agency_swarm.integrations.fastapi_utils.request_models import ClientConfig
 from agency_swarm.utils.openrouter import get_openrouter_model_name, is_openrouter_model_name
 
-_AGENCY_SWARM_DEFAULT_MODEL = "agency-swarm/default"
-
 
 def get_allowed_dirs_for_metadata(allowed_local_dirs: Sequence[str | Path]) -> list[str]:
     """Return all configured allowlist entries as resolved absolute paths."""
@@ -30,10 +28,7 @@ class RequestOverridePolicy:
             or self.config.api_key is not None
             or self.config.default_headers is not None
             or self.config.litellm_keys is not None
-            or (
-                getattr(self.config, "model", None) is not None
-                and getattr(self.config, "model", None) != _AGENCY_SWARM_DEFAULT_MODEL
-            )
+            or getattr(self.config, "model", None) is not None
             or getattr(self.config, "model_settings_extra_args", None) is not None
         )
 

--- a/src/agency_swarm/ui/demos/agentswarm_cli.py
+++ b/src/agency_swarm/ui/demos/agentswarm_cli.py
@@ -154,10 +154,7 @@ def _env(port: int, agency_id: str) -> dict[str, str]:
                         "agency": agency_id,
                         "discoveryTimeoutMs": 2000,
                     },
-                },
-                "ollama": {
-                    "name": "Ollama",
-                },
+                }
             },
         }
     )

--- a/tests/test_agency_modules/test_agentswarm_cli_tui.py
+++ b/tests/test_agency_modules/test_agentswarm_cli_tui.py
@@ -57,7 +57,7 @@ def test_agentswarm_cli_tui_launches_agent_swarm_cli(monkeypatch):
     assert config["model"] == agentswarm_cli_demo._MODEL
     assert config["provider"]["agency-swarm"]["options"]["baseURL"] == "http://127.0.0.1:43121"
     assert config["provider"]["agency-swarm"]["options"]["agency"] == "My_Agency"
-    assert config["provider"]["ollama"]["name"] == "Ollama"
+    assert "ollama" not in config["provider"]
     assert server.stopped is True
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -100,6 +100,27 @@ def test_tui_bridge_stream_config_ignores_default_model_sentinel() -> None:
     assert resolved.default_headers == {"x-test": "1"}
 
 
+def test_tui_bridge_stream_config_strips_default_model_bridge_base_url() -> None:
+    """The default sentinel should not point local LiteLLM agency models back at the bridge."""
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)),
+        base_url="http://127.0.0.1:54321/",
+    )
+    config = ClientConfig(
+        model="agency-swarm/default",
+        api_key="sk-test",
+        base_url="http://127.0.0.1:54321",
+    )
+
+    resolved = endpoint_handlers._resolve_stream_client_config(request, config)
+
+    assert resolved is not None
+    assert resolved.model is None
+    assert resolved.base_url is None
+    assert resolved.api_key == "sk-test"
+    assert config.base_url == "http://127.0.0.1:54321"
+
+
 def test_tui_bridge_stream_config_keeps_explicit_openai_model() -> None:
     """TUI-selected OpenAI models should replace the agency's configured model."""
     request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)))

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -157,7 +157,10 @@ def test_tui_bridge_stream_config_keeps_explicit_litellm_model() -> None:
 
 def test_tui_bridge_stream_config_strips_local_litellm_gateway_base_url() -> None:
     """TUI-selected local LiteLLM models should not inherit the bridge server URL."""
-    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)))
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)),
+        base_url="http://127.0.0.1:54321/",
+    )
     config = ClientConfig(
         model="litellm/ollama_chat/gemma4:e4b",
         api_key="sk-openai-gateway",
@@ -172,6 +175,24 @@ def test_tui_bridge_stream_config_strips_local_litellm_gateway_base_url() -> Non
     assert resolved.base_url is None
     assert resolved.api_key == "sk-openai-gateway"
     assert config.base_url == "http://127.0.0.1:54321"
+
+
+def test_tui_bridge_stream_config_preserves_explicit_local_litellm_base_url() -> None:
+    """Remote Ollama/LM Studio base URLs must survive the TUI bridge rewrite."""
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)),
+        base_url="http://127.0.0.1:54321/",
+    )
+    config = ClientConfig(
+        model="litellm/ollama_chat/gemma4:e4b",
+        api_key="sk-openai-gateway",
+        base_url="http://remote-ollama.test",
+    )
+
+    resolved = endpoint_handlers._resolve_stream_client_config(request, config)
+
+    assert resolved is config
+    assert resolved.base_url == "http://remote-ollama.test"
 
 
 def test_request_api_key_allows_client_build_without_env(monkeypatch) -> None:

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -155,6 +155,25 @@ def test_tui_bridge_stream_config_keeps_explicit_litellm_model() -> None:
     assert resolved.model == "litellm/ollama_chat/gemma4:e4b"
 
 
+def test_tui_bridge_stream_config_strips_local_litellm_gateway_base_url() -> None:
+    """TUI-selected local LiteLLM models should not inherit the bridge server URL."""
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)))
+    config = ClientConfig(
+        model="litellm/ollama_chat/gemma4:e4b",
+        api_key="sk-openai-gateway",
+        base_url="http://127.0.0.1:54321",
+    )
+
+    resolved = endpoint_handlers._resolve_stream_client_config(request, config)
+
+    assert resolved is not None
+    assert resolved is not config
+    assert resolved.model == "litellm/ollama_chat/gemma4:e4b"
+    assert resolved.base_url is None
+    assert resolved.api_key == "sk-openai-gateway"
+    assert config.base_url == "http://127.0.0.1:54321"
+
+
 def test_request_api_key_allows_client_build_without_env(monkeypatch) -> None:
     """Request api_key should work even if server has no OPENAI_API_KEY."""
     pytest.importorskip("agents")
@@ -355,8 +374,8 @@ def test_litellm_google_wrapper_uses_gemini_request_proxy_base_url() -> None:
     assert agent.model.base_url == "http://litellm-proxy.local"
 
 
-def test_litellm_ollama_does_not_use_request_base_url_fallback() -> None:
-    """Request gateway base_url must not override Ollama's provider-native endpoint."""
+def test_litellm_ollama_uses_explicit_request_base_url() -> None:
+    """Non-TUI callers may route local LiteLLM providers to a remote Ollama endpoint."""
     pytest.importorskip("agents")
     pytest.importorskip("agents.extensions.models.litellm_model")
 
@@ -374,11 +393,11 @@ def test_litellm_ollama_does_not_use_request_base_url_fallback() -> None:
     agent = Agent(name="A", instructions="x", model=original_model)
     agency = _Agency(agent)
 
-    apply_openai_client_config(agency, ClientConfig(api_key="sk-openai-gateway", base_url="http://127.0.0.1:54321"))
+    apply_openai_client_config(agency, ClientConfig(api_key="sk-openai-gateway", base_url="http://remote-ollama.test"))
 
     assert isinstance(agent.model, LitellmModel)
     assert agent.model.model == "ollama_chat/gemma4:e4b"
-    assert agent.model.base_url is None
+    assert agent.model.base_url == "http://remote-ollama.test"
     assert agent.model.api_key is None
 
 

--- a/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
+++ b/tests/test_fastapi_utils_modules/test_openai_client_config_models.py
@@ -122,6 +122,28 @@ def test_regular_stream_config_keeps_request_model() -> None:
     assert resolved.model == "gpt-5.4"
 
 
+def test_regular_stream_config_keeps_default_model_sentinel_without_app() -> None:
+    """Non-TUI stream request doubles without ``.app`` should keep the sentinel."""
+    request = SimpleNamespace()
+    config = ClientConfig(model="agency-swarm/default", api_key="sk-test")
+
+    resolved = endpoint_handlers._resolve_stream_client_config(request, config)
+
+    assert resolved is config
+    assert resolved.model == "agency-swarm/default"
+
+
+def test_regular_stream_config_keeps_default_model_sentinel_without_tui_bridge() -> None:
+    """Only the TUI bridge should strip the default-model sentinel."""
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+    config = ClientConfig(model="agency-swarm/default", api_key="sk-test")
+
+    resolved = endpoint_handlers._resolve_stream_client_config(request, config)
+
+    assert resolved is config
+    assert resolved.model == "agency-swarm/default"
+
+
 def test_tui_bridge_stream_config_keeps_explicit_litellm_model() -> None:
     """TUI-selected LiteLLM models should replace the agency's configured model."""
     request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(agency_swarm_tui_bridge=True)))
@@ -360,8 +382,8 @@ def test_litellm_ollama_does_not_use_request_base_url_fallback() -> None:
     assert agent.model.api_key is None
 
 
-def test_agency_swarm_default_model_does_not_override_litellm_agent_model() -> None:
-    """The TUI sentinel model should preserve the agency's configured model."""
+def test_agency_swarm_default_model_override_reaches_litellm_agent_model() -> None:
+    """Outside the TUI stream bridge, the sentinel remains a normal model override."""
     pytest.importorskip("agents")
     pytest.importorskip("agents.extensions.models.litellm_model")
 
@@ -381,8 +403,9 @@ def test_agency_swarm_default_model_does_not_override_litellm_agent_model() -> N
 
     apply_openai_client_config(agency, ClientConfig(model="agency-swarm/default"))
 
-    assert agent.model is original_model
-    assert agent.model.model == "ollama_chat/gemma4:e4b"
+    assert isinstance(agent.model, LitellmModel)
+    assert agent.model is not original_model
+    assert agent.model.model == "agency-swarm/default"
     assert agent.model.base_url == "http://localhost:11434/"
 
 

--- a/tests/test_fastapi_utils_modules/test_override_policy.py
+++ b/tests/test_fastapi_utils_modules/test_override_policy.py
@@ -32,9 +32,9 @@ def test_request_override_policy_flags() -> None:
     assert settings_only.has_client_overrides is True
     assert settings_only.has_openai_overrides is False
 
-    tui_default_model = RequestOverridePolicy(ClientConfig(model="agency-swarm/default"))
-    assert tui_default_model.has_client_overrides is False
-    assert tui_default_model.has_openai_overrides is False
+    default_model = RequestOverridePolicy(ClientConfig(model="agency-swarm/default"))
+    assert default_model.has_client_overrides is True
+    assert default_model.has_openai_overrides is False
 
     litellm_cfg = cast(
         ClientConfig,


### PR DESCRIPTION
### Summary

Hardens the clean Ollama/LiteLLM TUI bridge branch with the follow-up fixes added during review.

This stacked PR preserves non-TUI LiteLLM base URLs, strips only the TUI bridge URL for local providers, avoids incomplete local provider config, and keeps the repository formatting clean.

Base PR: https://github.com/VRSEN/agency-swarm/pull/688. This PR is required before the Ollama bridge feature is complete.

### Test plan

- `make check` passed.
- `uv run python -m compileall -q src/agency_swarm` passed.
- Focused pytest passed with 108 tests.
- `git diff --check` passed.
- Live Ollama bridge E2E passed with the paired Agent Swarm CLI fixes branch after pulling `qwen2.5:0.5b`.
- Local Codex review found no actionable issues for this exact head against the clean Artemii rebuild branch.

### Issue number

N/A - draft branch update for local Ollama model support.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
