### PR TITLE
[codex] Reject path separators in remote upload filenames

### DIFF
--- a/src/agency_swarm/integrations/fastapi_utils/file_handler.py
+++ b/src/agency_swarm/integrations/fastapi_utils/file_handler.py
@@ -195,9 +195,16 @@ def get_extension_from_filetype(file_path: Path) -> str | None:
     return f".{kind.extension}" if kind else None
 
 
+def _validate_download_name(name: str) -> str:
+    if "/" in name or "\\" in name:
+        raise ValueError("Remote filename must not contain path separators")
+    return name
+
+
 async def download_file(url: str, name: str, save_dir: str) -> str:
-    ext = get_extension_from_name(name) or get_extension_from_url(url)
-    base = os.path.splitext(name)[0]
+    validated_name = _validate_download_name(name)
+    ext = get_extension_from_name(validated_name) or get_extension_from_url(url)
+    base = os.path.splitext(validated_name)[0]
 
     # Truncate prefix to avoid exceeding the 255-byte filename limit on most
     # filesystems (mkstemp appends a random suffix + ".tmp" on top of the prefix).

--- a/src/agency_swarm/integrations/fastapi_utils/file_handler.py
+++ b/src/agency_swarm/integrations/fastapi_utils/file_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import ntpath
 import os
 import shutil
 import sys
@@ -196,8 +197,8 @@ def get_extension_from_filetype(file_path: Path) -> str | None:
 
 
 def _validate_download_name(name: str) -> str:
-    if "/" in name or "\\" in name:
-        raise ValueError("Remote filename must not contain path separators")
+    if "/" in name or "\\" in name or ntpath.splitdrive(name)[0]:
+        raise ValueError("Remote filename must not contain path components")
     return name
 
 

--- a/tests/test_fastapi_utils_modules/test_file_handler_downloads.py
+++ b/tests/test_fastapi_utils_modules/test_file_handler_downloads.py
@@ -66,7 +66,8 @@ def _fd_points_to_dir(fd: int, directory: str) -> bool:
 
 
 @pytest.mark.asyncio
-async def test_download_file_rejects_traversal_names(tmp_path: Path) -> None:
+@pytest.mark.parametrize("name", ["../escape/proof.txt", r"..\escape\proof.txt", "D:proof.txt"])
+async def test_download_file_rejects_traversal_names(name: str, tmp_path: Path) -> None:
     """Remote download filenames should not be allowed to escape the save directory."""
     import agency_swarm.integrations.fastapi_utils.file_handler as fh
 
@@ -95,8 +96,8 @@ async def test_download_file_rejects_traversal_names(tmp_path: Path) -> None:
     try:
         url = f"http://127.0.0.1:{server.server_port}/payload.txt"
 
-        with pytest.raises(ValueError, match="path separators"):
-            await fh.download_file(url, "../escape/proof.txt", str(save_dir))
+        with pytest.raises(ValueError, match="path components"):
+            await fh.download_file(url, name, str(save_dir))
 
         assert not list(save_dir.iterdir())
         assert not list(escape_dir.iterdir())

--- a/tests/test_fastapi_utils_modules/test_file_handler_downloads.py
+++ b/tests/test_fastapi_utils_modules/test_file_handler_downloads.py
@@ -1,6 +1,8 @@
 """Unit tests for fastapi_utils download_file behavior."""
 
 import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -61,6 +63,46 @@ def _fd_points_to_dir(fd: int, directory: str) -> bool:
     except OSError:
         pass
     return False
+
+
+@pytest.mark.asyncio
+async def test_download_file_rejects_traversal_names(tmp_path: Path) -> None:
+    """Remote download filenames should not be allowed to escape the save directory."""
+    import agency_swarm.integrations.fastapi_utils.file_handler as fh
+
+    payload = b"downloaded data\n"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return None
+
+    save_dir = tmp_path / "downloads"
+    save_dir.mkdir()
+    escape_dir = tmp_path / "escape"
+    escape_dir.mkdir()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/payload.txt"
+
+        with pytest.raises(ValueError, match="path separators"):
+            await fh.download_file(url, "../escape/proof.txt", str(save_dir))
+
+        assert not list(save_dir.iterdir())
+        assert not list(escape_dir.iterdir())
+    finally:
+        server.shutdown()
+        server.server_close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #704

## What changed
- Reject remote download filenames that contain path separators (`/` or `\`) or Windows drive qualifiers such as `D:proof.txt` before `download_file()` creates a temporary file or starts the HTTP request.
- Add a regression test proving traversal-style names are rejected and do not create files in either the intended download directory or an escaped sibling directory.

## Root cause
`download_file()` used the caller-provided `file_urls` key directly as the `tempfile.mkstemp(prefix=...)` prefix. `mkstemp()` does not sanitize path components in the prefix, so path components in the key could influence the resolved temporary file path.

## Checks run
- Red proof before fix: focused test failed because the actual result resolved outside the intended `downloads` directory.
- `uv run pytest tests/test_fastapi_utils_modules/test_file_handler_downloads.py::test_download_file_rejects_traversal_names -q`
- `uv run pytest tests/test_fastapi_utils_modules/test_file_handler.py tests/test_fastapi_utils_modules/test_file_handler_downloads.py -q`
- `uv run pytest tests/test_fastapi_utils_modules -q`
- `make format`
- `make check`
- `uv run pytest tests --ignore=tests/integration -q`
- `make tests` with only `OPENAI_API_KEY` loaded from `/Users/nick/Areas/Development/code/agency-swarm/.env`: `1292 passed, 8 skipped, 18 warnings`

I also ran `make tests` with the entire `.env` loaded. That run failed only in Anthropic/LiteLLM live integration tests because the configured Anthropic model `claude-sonnet-4-20250514` returned provider `not_found`; this PR does not touch that path.
