### PR TITLE
chore: prepare 1.10.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.10.0"
+version = "1.10.2"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -5,11 +5,10 @@ import logging
 import os
 import threading
 import warnings
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from agents import RunConfig, RunHooks, RunResult, Tool, TResponseInputItem
 
-from agency_swarm.agent.agent_flow import AgentFlow
 from agency_swarm.agent.core import AgencyContext, Agent
 from agency_swarm.agent.execution_streaming import StreamingRunResponse
 from agency_swarm.hooks import PersistenceHooks
@@ -19,6 +18,10 @@ from agency_swarm.tools.mcp_manager import attach_persistent_mcp_servers, defaul
 from agency_swarm.utils.files import get_external_caller_directory
 from agency_swarm.utils.thread import ThreadLoadCallback, ThreadManager, ThreadSaveCallback
 
+from .flow_compat import (
+    CommunicationFlowEntry,
+    normalize_parse_agent_flows_result as _normalize_parse_agent_flows_result,
+)
 from .helpers import read_instructions, run_fastapi as run_fastapi_helper
 from .setup import (
     apply_shared_resources,
@@ -32,47 +35,6 @@ if TYPE_CHECKING:
     from agency_swarm.agent.context_types import AgentRuntimeState
 
 logger = logging.getLogger(__name__)
-
-ParseAgentFlowsResult = tuple[
-    list[tuple[Agent, Agent]],
-    dict[tuple[str, str], list[type]],
-    set[tuple[str, str]],
-]
-
-CommunicationFlowEntry = (
-    tuple[Agent, Agent]  # Basic (sender, receiver) pair
-    | tuple[AgentFlow, type]  # Agent flow with tool class
-    | tuple[Agent, Agent, type]  # Individual (sender, receiver, tool_class)
-    | tuple[Agent, Agent, list[type] | tuple[type, ...]]  # Individual pair with multiple tool classes
-    | AgentFlow  # Standalone agent flow (uses default tool)
-)
-
-
-def _normalize_parse_agent_flows_result(result: object) -> ParseAgentFlowsResult:
-    """Accept legacy local patches that still return the old two-value shape."""
-    if not isinstance(result, tuple):
-        raise TypeError("parse_agent_flows must return a tuple.")
-
-    if len(result) == 3:
-        flows, mapping, defaults = result
-        return (
-            cast(list[tuple[Agent, Agent]], flows),
-            cast(dict[tuple[str, str], list[type]], mapping),
-            cast(set[tuple[str, str]], defaults),
-        )
-
-    if len(result) == 2:
-        flows, raw_mapping = result
-        normalized: dict[tuple[str, str], list[type]] = {}
-        legacy_mapping = cast(
-            dict[tuple[str, str], type | list[type] | tuple[type, ...]],
-            raw_mapping,
-        )
-        for pair, tool_classes in legacy_mapping.items():
-            normalized[pair] = list(tool_classes) if isinstance(tool_classes, (list, tuple)) else [tool_classes]
-        return cast(list[tuple[Agent, Agent]], flows), normalized, set()
-
-    raise ValueError("parse_agent_flows must return 2 or 3 values.")
 
 
 class Agency:

--- a/src/agency_swarm/agency/core.py
+++ b/src/agency_swarm/agency/core.py
@@ -5,7 +5,7 @@ import logging
 import os
 import threading
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agents import RunConfig, RunHooks, RunResult, Tool, TResponseInputItem
 
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+ParseAgentFlowsResult = tuple[
+    list[tuple[Agent, Agent]],
+    dict[tuple[str, str], list[type]],
+    set[tuple[str, str]],
+]
+
 CommunicationFlowEntry = (
     tuple[Agent, Agent]  # Basic (sender, receiver) pair
     | tuple[AgentFlow, type]  # Agent flow with tool class
@@ -40,6 +46,33 @@ CommunicationFlowEntry = (
     | tuple[Agent, Agent, list[type] | tuple[type, ...]]  # Individual pair with multiple tool classes
     | AgentFlow  # Standalone agent flow (uses default tool)
 )
+
+
+def _normalize_parse_agent_flows_result(result: object) -> ParseAgentFlowsResult:
+    """Accept legacy local patches that still return the old two-value shape."""
+    if not isinstance(result, tuple):
+        raise TypeError("parse_agent_flows must return a tuple.")
+
+    if len(result) == 3:
+        flows, mapping, defaults = result
+        return (
+            cast(list[tuple[Agent, Agent]], flows),
+            cast(dict[tuple[str, str], list[type]], mapping),
+            cast(set[tuple[str, str]], defaults),
+        )
+
+    if len(result) == 2:
+        flows, raw_mapping = result
+        normalized: dict[tuple[str, str], list[type]] = {}
+        legacy_mapping = cast(
+            dict[tuple[str, str], type | list[type] | tuple[type, ...]],
+            raw_mapping,
+        )
+        for pair, tool_classes in legacy_mapping.items():
+            normalized[pair] = list(tool_classes) if isinstance(tool_classes, (list, tuple)) else [tool_classes]
+        return cast(list[tuple[Agent, Agent]], flows), normalized, set()
+
+    raise ValueError("parse_agent_flows must return 2 or 3 values.")
 
 
 class Agency:
@@ -146,7 +179,7 @@ class Agency:
                 _derived_communication_flows,
                 _communication_tool_classes,
                 _default_communication_tool_pairs,
-            ) = parse_agent_flows(self, communication_flows or [])
+            ) = _normalize_parse_agent_flows_result(parse_agent_flows(self, communication_flows or []))
         else:
             raise ValueError(
                 "Agency structure not defined. Provide entry point agents as positional arguments and/or "

--- a/src/agency_swarm/agency/flow_compat.py
+++ b/src/agency_swarm/agency/flow_compat.py
@@ -1,0 +1,47 @@
+"""Compatibility helpers for agency flow parsing."""
+
+from typing import cast
+
+from agency_swarm.agent.agent_flow import AgentFlow
+from agency_swarm.agent.core import Agent
+
+CommunicationFlowEntry = (
+    tuple[Agent, Agent]  # Basic (sender, receiver) pair
+    | tuple[AgentFlow, type]  # Agent flow with tool class
+    | tuple[Agent, Agent, type]  # Individual (sender, receiver, tool_class)
+    | tuple[Agent, Agent, list[type] | tuple[type, ...]]  # Individual pair with multiple tool classes
+    | AgentFlow  # Standalone agent flow (uses default tool)
+)
+
+ParseAgentFlowsResult = tuple[
+    list[tuple[Agent, Agent]],
+    dict[tuple[str, str], list[type]],
+    set[tuple[str, str]],
+]
+
+
+def normalize_parse_agent_flows_result(result: object) -> ParseAgentFlowsResult:
+    """Accept legacy local patches that still return the old two-value shape."""
+    if not isinstance(result, tuple):
+        raise TypeError("parse_agent_flows must return a tuple.")
+
+    if len(result) == 3:
+        flows, mapping, defaults = result
+        return (
+            cast(list[tuple[Agent, Agent]], flows),
+            cast(dict[tuple[str, str], list[type]], mapping),
+            cast(set[tuple[str, str]], defaults),
+        )
+
+    if len(result) == 2:
+        flows, raw_mapping = result
+        normalized: dict[tuple[str, str], list[type]] = {}
+        legacy_mapping = cast(
+            dict[tuple[str, str], type | list[type] | tuple[type, ...]],
+            raw_mapping,
+        )
+        for pair, tool_classes in legacy_mapping.items():
+            normalized[pair] = list(tool_classes) if isinstance(tool_classes, (list, tuple)) else [tool_classes]
+        return cast(list[tuple[Agent, Agent]], flows), normalized, set()
+
+    raise ValueError("parse_agent_flows must return 2 or 3 values.")

--- a/tests/test_agency_modules/test_agent_flow_integration.py
+++ b/tests/test_agency_modules/test_agent_flow_integration.py
@@ -134,6 +134,25 @@ def test_agent_pair_can_use_send_message_and_handoff():
     assert "transfer_to_Agent2" in handoff_names
 
 
+@pytest.mark.parametrize("tool_mapping", ([Handoff], Handoff))
+def test_legacy_two_value_flow_parser_patch_still_initializes_agency(monkeypatch, tool_mapping):
+    """Test compatibility with OpenSwarm projects that patch parse_agent_flows."""
+    agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")
+    agent2 = Agent(name="Agent2", instructions="Test agent 2", model="gpt-5.4-mini")
+
+    def parse_agent_flows_legacy(_agency: Agency, _flows: list[Any]):
+        return [(agent1, agent2)], {("Agent1", "Agent2"): tool_mapping}
+
+    monkeypatch.setattr("agency_swarm.agency.core.parse_agent_flows", parse_agent_flows_legacy)
+
+    agency = Agency(agent1, communication_flows=[(agent1 > agent2, Handoff)])
+
+    assert agency._communication_tool_classes[("Agent1", "Agent2")] == [Handoff]
+    assert agency._default_communication_tool_pairs == set()
+    handoff_names = [handoff.tool_name for handoff in agency.get_agent_runtime_state("Agent1").handoffs]
+    assert handoff_names == ["transfer_to_Agent2"]
+
+
 def test_runtime_registration_keeps_multiple_send_message_tool_classes() -> None:
     """Test runtime registration creates each requested SendMessage class for one recipient."""
     agent1 = Agent(name="Agent1", instructions="Test agent 1", model="gpt-5.4-mini")

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.10.0"
+version = "1.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
### Summary

Prepares the 1.10.2 release branch from main.

This restores compatibility for projects that still patch `parse_agent_flows` with the legacy two-value return shape, while preserving the current three-value flow parser contract. The compatibility normalization now lives in `agency.flow_compat` so `core.py` stays within the repository file-size policy.

It also bumps package metadata to `1.10.2` and keeps the hosted-tool/OpenRouter fix already on main in the 1.10.2 release line.

### Test plan

- Built and installed the candidate package, then ran the FastAPI/OpenRouter request path end to end.
- Ran a live OpenRouter call against the installed candidate package.
- Ran `make lint` and `make format`.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation (not relevant for this release metadata/compatibility patch)
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
