### PR TITLE
fix: cascade orphaned-reasoning removal across consecutive reasoning items

### DIFF
--- a/src/agency_swarm/messages/message_filter.py
+++ b/src/agency_swarm/messages/message_filter.py
@@ -215,14 +215,21 @@ class MessageFilter:
 
         # Pattern 3: reasoning items must be followed by their original next item,
         # AND items following a reasoning must have that reasoning present.
-        # First pass: identify which reasoning items to remove (missing follower)
+        # First pass: identify which reasoning items to remove (missing follower).
+        # Process in reverse so that removing a reasoning item's follower (which may
+        # itself be a reasoning item) cascades to the preceding reasoning item.
         kept_index_set = {idx for idx, _ in kept_entries}
         removed_reasoning_indices: set[int] = set()
 
-        for idx, msg in kept_entries:
+        for idx, msg in sorted(kept_entries, key=lambda entry: entry[0], reverse=True):
             if msg.get("type") == "reasoning":
                 required_idx = idx + 1
-                if required_idx >= len(messages) or required_idx not in kept_index_set:
+                follower_dropped = (
+                    required_idx >= len(messages)
+                    or required_idx not in kept_index_set
+                    or required_idx in removed_reasoning_indices
+                )
+                if follower_dropped:
                     logger.info(
                         "Removing reasoning item %s because its required following item was dropped",
                         msg.get("id"),

--- a/tests/test_agent_modules/test_message_filter_fake_id.py
+++ b/tests/test_agent_modules/test_message_filter_fake_id.py
@@ -44,3 +44,31 @@ def test_remove_duplicates_still_dedupes_real_ids() -> None:
     result = MessageFilter.remove_duplicates(messages)
 
     assert result == [messages[0], messages[2]]
+
+
+def test_remove_orphaned_messages_cascades_consecutive_reasoning() -> None:
+    # rs_B's follower (the orphaned function_call) is dropped, so rs_B is dropped;
+    # rs_A's follower is then rs_B, which was just removed, so rs_A must also be
+    # dropped. A reasoning item left without its required follower is rejected by
+    # the Responses API.
+    messages = [
+        {"type": "reasoning", "id": "rs_A"},
+        {"type": "reasoning", "id": "rs_B"},
+        {"type": "function_call", "id": "fc_1", "call_id": "c1", "name": "f", "arguments": "{}"},
+    ]
+
+    result = MessageFilter.remove_orphaned_messages(messages)
+
+    assert result == []
+
+
+def test_remove_orphaned_messages_keeps_valid_consecutive_reasoning() -> None:
+    messages = [
+        {"type": "reasoning", "id": "rs_A"},
+        {"type": "reasoning", "id": "rs_B"},
+        {"id": "msg_1", "type": "message", "role": "assistant", "content": "ok"},
+    ]
+
+    result = MessageFilter.remove_orphaned_messages(messages)
+
+    assert result == messages


### PR DESCRIPTION
## Problem

`MessageFilter.remove_orphaned_messages` (Pattern 3) enforces that every `reasoning` item must be followed by its originally-adjacent item. The first pass that decides which reasoning items to drop ran a **single forward pass** that only checked whether the follower's index was still in the kept set.

When `reasoning_A` is followed by `reasoning_B`, and `reasoning_B`'s own follower (e.g. an orphaned `function_call` already stripped by Pattern 1) is gone:
- `reasoning_B` is correctly dropped, but
- `reasoning_A` **survives**, because its follower `reasoning_B` was still in the kept-index set during the forward pass.

That leaves a `reasoning` item whose required follower is gone — a history the OpenAI Responses API rejects.

## Reproduction

```python
MessageFilter.remove_orphaned_messages([
    {"type": "reasoning", "id": "rs_A"},
    {"type": "reasoning", "id": "rs_B"},
    {"type": "function_call", "id": "fc_1", "call_id": "c1", "name": "f", "arguments": "{}"},
])
# before: [{'type': 'reasoning', 'id': 'rs_A'}]   (dangling)
# after:  []
```

## Fix

Run the first pass in **reverse** index order and treat an already-removed follower as dropped, so removal cascades to the preceding reasoning item. Valid consecutive reasoning (followed by a real item) is preserved.

## Tests

Adds two tests to `tests/test_agent_modules/test_message_filter_fake_id.py` (cascade removal; valid-chain preservation). Verified RED→GREEN on the real filter; the existing MessageFilter suite still passes.