### PR TITLE
fix(deps): constrain OpenAI below 2.45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Vrsen AI Solutions", email = "me@vrsen.ai" }]
 dependencies = [
-    "openai>=2.2,<3",
+    "openai>=2.2,<2.45",
     "openai-agents==0.14.8",
     "datamodel-code-generator>=0.56.0,<0.67.0",
     "docstring-parser>=0.16,<1.0.0",

--- a/tests/test_build_modules/test_dependency_constraints.py
+++ b/tests/test_build_modules/test_dependency_constraints.py
@@ -1,0 +1,18 @@
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+
+def test_openai_constraint_excludes_incompatible_release() -> None:
+    """Keep fresh installs on the last OpenAI version supported by Agents SDK 0.14.8."""
+    project = tomllib.loads((Path(__file__).parents[2] / "pyproject.toml").read_text())
+    requirements = {item.name: item for item in map(Requirement, project["project"]["dependencies"])}
+    openai = requirements["openai"]
+    agents = requirements["openai-agents"]
+
+    assert Version("2.44.0") in openai.specifier
+    assert Version("2.45.0") not in openai.specifier
+    assert agents.specifier == SpecifierSet("==0.14.8")

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.23.0,<2.0.0" },
     { name = "nest-asyncio", marker = "extra == 'jupyter'", specifier = ">=1.6.0,<2.0.0" },
     { name = "numpy", marker = "python_full_version >= '3.10' and extra == 'voice'", specifier = ">=2.2.0,<3" },
-    { name = "openai", specifier = ">=2.2,<3" },
+    { name = "openai", specifier = ">=2.2,<2.45" },
     { name = "openai-agents", specifier = "==0.14.8" },
     { name = "prompt-toolkit", specifier = ">=3.0.0,<4.0.0" },
     { name = "pydantic", specifier = ">=2.11,<3" },
@@ -2375,7 +2375,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.43.0"
+version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2387,9 +2387,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

This pull request prevents fresh Agency Swarm environments from resolving the incompatible OpenAI 2.45.0 release while `openai-agents==0.14.8` remains pinned.

OpenAI 2.45.0 made `InputTokensDetails.cache_write_tokens` required. Agents SDK 0.14.8 constructs that type without the field, causing `Usage()` to fail before any model request. This change temporarily constrains OpenAI to `>=2.2,<2.45`, refreshes the lock to 2.44.0, and adds semantic regression coverage for both dependency constraints.

PR #718 is insufficient because it updates only `uv.lock`. That protects the repository lock but does not change package metadata used by fresh installations, which would still permit OpenAI 2.45.0.

### Test plan

- `uv run pytest tests/test_build_modules/test_dependency_constraints.py`
- `make format`
- `make check`
- `make lint`
- Built wheel and verified `Requires-Dist` metadata
- Fresh wheel install selected OpenAI 2.44.0 and initialized `Usage()`
- Forcing OpenAI 2.45.0 failed dependency resolution

### Issue number

Closes #719

### Checks

- [x] I've added new tests
- [ ] I've added/updated the relevant documentation — not applicable to this dependency-only fix
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass