### PR TITLE
test(integration): refresh Anthropic live model

### DIFF
--- a/tests/integration/communication/test_streaming_order_consistency.py
+++ b/tests/integration/communication/test_streaming_order_consistency.py
@@ -108,7 +108,7 @@ EXPECTED_FLOW_DEFAULT: list[tuple[str, str, str | None]] = [
     ("message_output_item", "MainAgent", None),
 ]
 
-ANTHROPIC_MODEL_NAME = "anthropic/claude-sonnet-4-5-20250929"
+ANTHROPIC_MODEL_NAME = "anthropic/claude-sonnet-5"
 
 EXPECTED_FLOW_ANTHROPIC: list[tuple[str, str, str | None]] = [
     ("tool_call_item", "MainAgent", "get_market_data"),

--- a/tests/integration/communication/test_streaming_order_consistency.py
+++ b/tests/integration/communication/test_streaming_order_consistency.py
@@ -108,7 +108,7 @@ EXPECTED_FLOW_DEFAULT: list[tuple[str, str, str | None]] = [
     ("message_output_item", "MainAgent", None),
 ]
 
-ANTHROPIC_MODEL_NAME = "anthropic/claude-sonnet-4-20250514"
+ANTHROPIC_MODEL_NAME = "anthropic/claude-sonnet-4-5-20250929"
 
 EXPECTED_FLOW_ANTHROPIC: list[tuple[str, str, str | None]] = [
     ("tool_call_item", "MainAgent", "get_market_data"),

--- a/tests/integration/litellm_integration/test_litellm_anthropic_message_ordering.py
+++ b/tests/integration/litellm_integration/test_litellm_anthropic_message_ordering.py
@@ -41,6 +41,7 @@ def _assert_valid_tool_call_pairs(messages: list[dict[str, object]]) -> None:
     function_calls = [msg for msg in messages if msg.get("type") == "function_call"]
     function_outputs = [msg for msg in messages if msg.get("type") == "function_call_output"]
 
+    assert function_calls, "Expected at least one function call in Anthropic/LiteLLM history"
     call_ids = [msg.get("call_id") for msg in function_calls]
     assert all(isinstance(call_id, str) and call_id for call_id in call_ids)
     assert len(call_ids) == len(set(call_ids))
@@ -59,7 +60,7 @@ def litellm_anthropic_agency():
         name="Coordinator",
         instructions="You are a coordinator agent.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
         tools=[get_user_id],
     )
 
@@ -67,7 +68,7 @@ def litellm_anthropic_agency():
         name="Worker",
         instructions="You perform tasks.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
     )
 
     return Agency(
@@ -86,8 +87,8 @@ class TestLitellmAnthropicMessageOrdering:
         """Verify tool usage with streaming followed by second turn."""
         litellm.modify_params = True
 
-        async for _ in litellm_anthropic_agency.get_response_stream(message="get my id"):
-            pass
+        first_events = [event async for event in litellm_anthropic_agency.get_response_stream(message="get my id")]
+        assert first_events, "Expected Anthropic/LiteLLM to emit stream events for tool usage"
 
         # Verify message structure
         messages = litellm_anthropic_agency.thread_manager.get_all_messages()
@@ -117,8 +118,8 @@ class TestLitellmAnthropicMessageOrdering:
                 )
 
         # Second turn should succeed
-        async for _ in litellm_anthropic_agency.get_response_stream(message="hi"):
-            pass
+        second_events = [event async for event in litellm_anthropic_agency.get_response_stream(message="hi")]
+        assert second_events, "Expected Anthropic/LiteLLM to emit stream events for the follow-up turn"
 
     @pytest.mark.asyncio
     async def test_handoff_no_intermediate_messages(self, litellm_anthropic_agency: Agency):
@@ -126,10 +127,13 @@ class TestLitellmAnthropicMessageOrdering:
         litellm.modify_params = True
 
         # First turn with handoff
-        async for _ in litellm_anthropic_agency.get_response_stream(
-            message="transfer to worker", recipient_agent="Coordinator"
-        ):
-            pass
+        first_events = [
+            event
+            async for event in litellm_anthropic_agency.get_response_stream(
+                message="transfer to worker", recipient_agent="Coordinator"
+            )
+        ]
+        assert first_events, "Expected Anthropic/LiteLLM to emit stream events for handoff"
 
         # Verify no intermediate assistant messages between tool calls and outputs
         messages = litellm_anthropic_agency.thread_manager.get_all_messages()
@@ -166,5 +170,5 @@ class TestLitellmAnthropicMessageOrdering:
                     )
 
         # Second turn should succeed
-        async for _ in litellm_anthropic_agency.get_response_stream(message="hi"):
-            pass
+        second_events = [event async for event in litellm_anthropic_agency.get_response_stream(message="hi")]
+        assert second_events, "Expected Anthropic/LiteLLM to emit stream events for the follow-up turn"

--- a/tests/integration/litellm_integration/test_litellm_anthropic_message_ordering.py
+++ b/tests/integration/litellm_integration/test_litellm_anthropic_message_ordering.py
@@ -59,16 +59,16 @@ def litellm_anthropic_agency():
     coordinator = Agent(
         name="Coordinator",
         instructions="You are a coordinator agent.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
         tools=[get_user_id],
     )
 
     worker = Agent(
         name="Worker",
         instructions="You perform tasks.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
     )
 
     return Agency(

--- a/tests/integration/litellm_integration/test_litellm_anthropic_nonstreaming.py
+++ b/tests/integration/litellm_integration/test_litellm_anthropic_nonstreaming.py
@@ -50,16 +50,16 @@ def litellm_anthropic_agency():
     coordinator = Agent(
         name="Coordinator",
         instructions="You are a coordinator agent.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
         tools=[get_user_id],
     )
 
     worker = Agent(
         name="Worker",
         instructions="You perform tasks.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
     )
 
     return Agency(

--- a/tests/integration/litellm_integration/test_litellm_anthropic_nonstreaming.py
+++ b/tests/integration/litellm_integration/test_litellm_anthropic_nonstreaming.py
@@ -51,7 +51,7 @@ def litellm_anthropic_agency():
         name="Coordinator",
         instructions="You are a coordinator agent.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
         tools=[get_user_id],
     )
 
@@ -59,7 +59,7 @@ def litellm_anthropic_agency():
         name="Worker",
         instructions="You perform tasks.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
     )
 
     return Agency(

--- a/tests/integration/litellm_integration/test_litellm_placeholder_ids_integration.py
+++ b/tests/integration/litellm_integration/test_litellm_placeholder_ids_integration.py
@@ -36,16 +36,16 @@ def _build_agency() -> Agency:
             "task details in your message. "
             "When delegating, only relay the exact task text and never include unrelated user information."
         ),
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
         tools=[get_user_id],
     )
 
     worker_agent = Agent(
         name="Worker",
         instructions="You perform tasks.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
     )
 
     data_agent = Agent(
@@ -53,8 +53,8 @@ def _build_agency() -> Agency:
         instructions="You are a DataAgent that provides information about the user. \
         User name is John Doe. User age is 30.",
         description="Has information about the user.",
-        model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
+        model_settings=ModelSettings(),
+        model=LitellmModel(model="anthropic/claude-sonnet-5"),
     )
 
     return Agency(

--- a/tests/integration/litellm_integration/test_litellm_placeholder_ids_integration.py
+++ b/tests/integration/litellm_integration/test_litellm_placeholder_ids_integration.py
@@ -37,7 +37,7 @@ def _build_agency() -> Agency:
             "When delegating, only relay the exact task text and never include unrelated user information."
         ),
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
         tools=[get_user_id],
     )
 
@@ -45,7 +45,7 @@ def _build_agency() -> Agency:
         name="Worker",
         instructions="You perform tasks.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
     )
 
     data_agent = Agent(
@@ -54,7 +54,7 @@ def _build_agency() -> Agency:
         User name is John Doe. User age is 30.",
         description="Has information about the user.",
         model_settings=ModelSettings(temperature=0.0),
-        model=LitellmModel(model="anthropic/claude-sonnet-4-20250514"),
+        model=LitellmModel(model="anthropic/claude-sonnet-4-5-20250929"),
     )
 
     return Agency(


### PR DESCRIPTION
### Summary

Replace the retired Anthropic model in the four live integration modules with Sonnet 5 and remove the non-default temperature per Anthropic guidance. The streaming message-ordering tests now also reject empty provider streams and histories instead of passing without exercising their intended protocol assertions.

Production behavior and dependency constraints are unchanged.

### Test plan

- All 10 credentialed Anthropic integration nodes passed on Python 3.13
- `UV_FROZEN=1 uv run --python 3.13 pytest -q tests/test_messages_modules/test_message_formatter_history_protocol.py`
- `uv run ruff format --check` on the four changed modules
- `uv run ruff check` on the four changed modules

### Issue number

Closes #721

### Checks

- [x] I've added new tests — strengthened existing live assertions
- [ ] I've added/updated the relevant documentation — not applicable to test-only maintenance
- [x] I've run `make lint` and `make format` equivalents on the changed files
- [x] I've made sure the relevant tests pass
