### PR TITLE
chore(release): bump Agency Swarm to 1.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.10.2"
+version = "1.10.3"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.10.2"
+version = "1.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
### Summary

Prepare Agency Swarm 1.10.3 for publication with the compatibility constraint merged in #720: `openai>=2.2,<2.45` alongside `openai-agents==0.14.8`. This version ensures fresh installs avoid the incompatible OpenAI 2.45 release.

This release commit changes only the package version from 1.10.2 to 1.10.3 in `pyproject.toml` and `uv.lock`.

### Test plan

- `uv lock --check` passed.
- The focused dependency-constraint test passed.
- Wheel and sdist metadata were verified.
- A fresh wheel install resolved `openai==2.44.0` and `openai-agents==0.14.8`, and `Usage` construction succeeded.
- `make check` and `git diff --check` passed.
- An exact-commit Codex review completed without findings.
- Before the metadata-only version bump, the full local suite passed on the merged #720 content: 1,303 passed, 2 skipped, 0 failed. The full suite was not rerun after the version bump.
- Hosted lint and typecheck are green. Hosted test jobs are red during provider authentication because configured repository secrets are invalid or empty.

### Issue number

Follow-up to #720.

### Checks

- [x] I've added new tests (if relevant) — no new test was needed for this metadata-only version bump; the existing focused dependency test passed.
- [ ] I've added/updated the relevant documentation — no documentation change is needed for this metadata-only version bump.
- [ ] I've run `make lint` and `make format` — `make check` ran lint and typecheck; `make format` was not run separately.
- [ ] I've made sure tests pass — focused and pre-bump local proof passed, but hosted provider-authentication test jobs remain red.
