### PR TITLE
fix: keep runtime handoffs available across mid-run agent switches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.10.4"
+version = "1.10.5"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/agency_swarm/agent/execution_helpers.py
+++ b/src/agency_swarm/agent/execution_helpers.py
@@ -379,21 +379,33 @@ def setup_execution(
             if combined is not None:
                 agent.instructions = combined
 
-    # Align handoffs with runtime state for this execution
-    runtime_state = None
-    if agency_context is not None and hasattr(agency_context, "runtime_state"):
-        runtime_state = agency_context.runtime_state
+    # Align handoffs with runtime state for this execution. The SDK run loop can
+    # switch to any agency agent mid-run via chained handoffs without re-entering
+    # setup_execution, so every agency agent needs its runtime handoffs attached
+    # before Runner.run starts.
+    agents_to_align: list[tuple[Agent, AgentRuntimeState | None]] = []
+    agency_instance = agency_context.agency_instance if agency_context is not None else None
+    if agency_instance is not None and getattr(agency_instance, "agents", None):
+        runtime_states = getattr(agency_instance, "_agent_runtime_state", {})
+        for agent_name, agency_agent in agency_instance.agents.items():
+            agents_to_align.append((agency_agent, runtime_states.get(agent_name)))
+    if all(aligned_agent is not agent for aligned_agent, _ in agents_to_align):
+        starting_runtime_state = getattr(agency_context, "runtime_state", None) if agency_context is not None else None
+        agents_to_align.append((agent, starting_runtime_state))
 
-    original_handoffs = list(agent.handoffs)
+    restore_entries: list[tuple[Agent, list[Any]]] = []
+    for target_agent, runtime_state in agents_to_align:
+        original_handoffs = list(target_agent.handoffs)
+        restore_entries.append((target_agent, original_handoffs))
+        if runtime_state and getattr(runtime_state, "handoffs", None):
+            existing = {_handoff_identity(h) for h in original_handoffs}
+            additional = [h for h in runtime_state.handoffs if _handoff_identity(h) not in existing]
+            target_agent.handoffs = original_handoffs + additional
+
     if agency_context is not None:
-        agency_context._handoffs_restore = original_handoffs  # type: ignore[attr-defined]
+        agency_context._handoffs_restore = restore_entries  # type: ignore[attr-defined]
     else:
-        agent._handoffs_restore = original_handoffs  # type: ignore[attr-defined]
-
-    if runtime_state and getattr(runtime_state, "handoffs", None):
-        existing = {_handoff_identity(h) for h in original_handoffs}
-        additional = [h for h in runtime_state.handoffs if _handoff_identity(h) not in existing]
-        agent.handoffs = original_handoffs + additional
+        agent._handoffs_restore = restore_entries  # type: ignore[attr-defined]
 
     # Log the conversation context
     logger.info(f"Agent '{agent.name}' handling {method_name} from sender: {sender_name}")
@@ -443,23 +455,24 @@ def cleanup_execution(
     # Always restore original instructions
     agent.instructions = original_instructions
 
-    restore_handoffs: list[Any] | None = None
+    restore_entries: list[tuple[Any, list[Any]]] | None = None
     if agency_context is not None:
         try:
-            restore_handoffs = agency_context._handoffs_restore  # type: ignore[attr-defined]
+            restore_entries = agency_context._handoffs_restore  # type: ignore[attr-defined]
             del agency_context._handoffs_restore  # type: ignore[attr-defined]
         except AttributeError:
-            restore_handoffs = None
+            restore_entries = None
     else:
         try:
-            restore_handoffs = agent._handoffs_restore  # type: ignore[attr-defined]
+            restore_entries = agent._handoffs_restore  # type: ignore[attr-defined]
             del agent._handoffs_restore  # type: ignore[attr-defined]
         except AttributeError:
-            restore_handoffs = None
+            restore_entries = None
 
-    if restore_handoffs is not None:
-        agent.handoffs.clear()
-        agent.handoffs.extend(restore_handoffs)
+    if restore_entries is not None:
+        for target_agent, original_handoffs in restore_entries:
+            target_agent.handoffs.clear()
+            target_agent.handoffs.extend(original_handoffs)
 
 
 def get_run_trace_id(run_config: RunConfig | None, agency_context: "AgencyContext | None" = None) -> str:

--- a/tests/test_agency_modules/test_chained_handoffs_runtime.py
+++ b/tests/test_agency_modules/test_chained_handoffs_runtime.py
@@ -1,0 +1,150 @@
+"""Chained handoffs within a single run must keep runtime handoffs available.
+
+Regression coverage for A -> B -> C handoff chains executed in one turn: the
+SDK run loop switches to the recipient agent without re-entering
+``setup_execution``, so runtime-state handoffs must be attached to every
+agency agent before ``Runner.run`` starts.
+"""
+
+from collections.abc import AsyncIterator
+
+import pytest
+from agents import Usage
+from agents.agent_output import AgentOutputSchemaBase
+from agents.handoffs import Handoff as SDKHandoff
+from agents.items import ModelResponse, TResponseInputItem, TResponseStreamEvent
+from agents.model_settings import ModelSettings
+from agents.models.interface import Model, ModelTracing
+from agents.tool import Tool
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from agency_swarm import Agency, Agent
+from agency_swarm.tools import Handoff
+
+
+class ScriptedHandoffModel(Model):
+    """Offline model that hands off when the target tool is offered.
+
+    Records the handoff tool names offered on every model call so tests can
+    assert which handoffs the run loop actually exposed to each agent.
+    """
+
+    def __init__(self, target_handoff: str | None, final_text: str) -> None:
+        self.model = "scripted-fake-model"
+        self.target_handoff = target_handoff
+        self.final_text = final_text
+        self.offered_handoffs: list[list[str]] = []
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[SDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> ModelResponse:
+        offered = [h.tool_name for h in handoffs]
+        self.offered_handoffs.append(offered)
+
+        usage = Usage(
+            requests=1,
+            input_tokens=1,
+            output_tokens=1,
+            total_tokens=2,
+            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        )
+
+        if self.target_handoff and self.target_handoff in offered:
+            recipient = self.target_handoff.removeprefix("transfer_to_")
+            call = ResponseFunctionToolCall(
+                id=f"fc_{recipient}",
+                call_id=f"call_{recipient}",
+                name=self.target_handoff,
+                arguments=f'{{"recipient_agent": "{recipient}"}}',
+                type="function_call",
+            )
+            return ModelResponse(output=[call], usage=usage, response_id=f"resp_{recipient}")
+
+        msg = ResponseOutputMessage(
+            id="msg_final",
+            content=[ResponseOutputText(text=self.final_text, type="output_text", annotations=[])],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+        return ModelResponse(output=[msg], usage=usage, response_id="resp_final")
+
+    def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[SDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        raise NotImplementedError("streaming is not exercised in this test")
+
+
+def _build_chained_agency() -> tuple[Agency, ScriptedHandoffModel, ScriptedHandoffModel, ScriptedHandoffModel]:
+    model_a = ScriptedHandoffModel("transfer_to_AgentB", "A done")
+    model_b = ScriptedHandoffModel("transfer_to_AgentC", "B stopped: no handoff tools")
+    model_c = ScriptedHandoffModel(None, "C done")
+
+    agent_a = Agent(name="AgentA", instructions="Hand off to AgentB.", model=model_a)
+    agent_b = Agent(name="AgentB", instructions="Hand off to AgentC.", model=model_b)
+    agent_c = Agent(name="AgentC", instructions="Finish the task.", model=model_c)
+
+    agency = Agency(
+        agent_a,
+        communication_flows=[
+            (agent_a > agent_b, Handoff),
+            (agent_b > agent_c, Handoff),
+        ],
+    )
+    return agency, model_a, model_b, model_c
+
+
+@pytest.mark.asyncio
+async def test_same_turn_chained_handoff_reaches_final_agent() -> None:
+    """A -> B -> C chained handoffs in one turn must reach AgentC."""
+    agency, model_a, model_b, model_c = _build_chained_agency()
+
+    result = await agency.get_response("Please chain to AgentC.")
+
+    assert model_a.offered_handoffs[0] == ["transfer_to_AgentB"]
+    assert model_b.offered_handoffs, "AgentB was never reached via handoff"
+    assert model_b.offered_handoffs[0] == ["transfer_to_AgentC"], (
+        "AgentB lost its runtime handoffs after the mid-run agent switch"
+    )
+    assert model_c.offered_handoffs, "AgentC was never reached via chained handoff"
+    assert result.final_output == "C done"
+
+
+@pytest.mark.asyncio
+async def test_runtime_handoffs_are_restored_after_run() -> None:
+    """Runtime handoffs must not leak onto agents once the run finishes."""
+    agency, _, _, _ = _build_chained_agency()
+
+    await agency.get_response("Please chain to AgentC.")
+
+    for name in ("AgentA", "AgentB", "AgentC"):
+        assert agency.agents[name].handoffs == [], f"{name} kept runtime handoffs after cleanup"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.10.4"
+version = "1.10.5"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
Chained same-turn handoffs (A→B→C, A→B→A) stalled at the first recipient because setup_execution merged runtime-state handoffs onto only the starting agent, while the Agents SDK run loop switches agents internally without re-entering agency-swarm. The recipient agent had no handoff tools until the next top-level message.

- Merge runtime-state handoffs (deduped) onto every registered agency agent before Runner.run, and restore all of them in cleanup_execution. Standalone agent behavior unchanged; nested SendMessage runs stay safe via dedupe.
- Add an offline scripted-model regression test for same-turn A→B→C chains (fails on 1.10.4, passes with the fix).
- Bump version to 1.10.5.

Verified: offline CI-equivalent suite 872 passed / 2 skipped; live-API run of tests/integration/agency/test_agent_handoffs.py plus the new chained tests: 15 passed. Hosted tests job fails only on the repository's invalid OPENAI_API_KEY secret (401s), as on previous releases.