### PR TITLE
fix: skip test files when loading tools from folder

### DIFF
--- a/src/agency_swarm/agent/tools.py
+++ b/src/agency_swarm/agent/tools.py
@@ -62,6 +62,8 @@ def load_tools_from_folder(agent: "Agent") -> None:
 
     Supports both ``BaseTool`` subclasses and ``FunctionTool``
     instances created via the ``@function_tool`` decorator.
+    Files prefixed with ``_`` or ``.`` and pytest files
+    (``test_*.py``, ``*_test.py``, ``conftest.py``) are skipped.
 
     Args:
         agent: The agent to load tools for
@@ -78,7 +80,11 @@ def load_tools_from_folder(agent: "Agent") -> None:
         return
 
     for file in folder_path.iterdir():
-        if not file.is_file() or file.suffix != ".py" or file.name.startswith("_"):
+        if not file.is_file() or file.suffix != ".py" or file.name.startswith(("_", ".")):
+            continue
+
+        if file.stem.startswith("test_") or file.stem.endswith("_test") or file.name == "conftest.py":
+            logger.debug("Skipping test file in tools folder: %s", file)
             continue
 
         tools = ToolFactory.from_file(file)

--- a/tests/test_tools_modules/test_tool_system.py
+++ b/tests/test_tools_modules/test_tool_system.py
@@ -316,7 +316,13 @@ def test_tools_folder_edge_cases(tmp_path):
     (tools_dir / "_private_tool.py").write_text("# Should be ignored")
     (tools_dir / "readme.txt").write_text("Not a Python file")
     (tools_dir / "invalid_tool.py").write_text("invalid python syntax !")
-
+    ignored_tool_template = (
+        "from agents import function_tool\n\n@function_tool\ndef {name}() -> str:\n    return 'ignored'\n"
+    )
+    (tools_dir / "test_valid_tool.py").write_text(ignored_tool_template.format(name="tool_from_test_prefix"))
+    (tools_dir / "valid_tool_test.py").write_text(ignored_tool_template.format(name="tool_from_test_suffix"))
+    (tools_dir / "conftest.py").write_text(ignored_tool_template.format(name="tool_from_conftest"))
+    (tools_dir / ".hidden_tool.py").write_text(ignored_tool_template.format(name="tool_from_hidden_file"))
     # Create valid tool
     (tools_dir / "valid_tool.py").write_text("""
 from agents import function_tool


### PR DESCRIPTION
## Problem

`load_tools_from_folder` imports every `.py` file in `tools_folder` except `_`-prefixed ones. Users who keep pytest files (`test_*.py`, `*_test.py`, `conftest.py`) next to their tools get those files imported and executed as tool modules, producing import errors, warnings, and unwanted side effects.

## What changed

- `load_tools_from_folder` now skips `test_*.py`, `*_test.py`, `conftest.py`, and `.`-prefixed files, in addition to the existing `_` prefix skip. Skipped test files are logged at debug level.
- Extended the existing `tools_folder` edge-case test to prove tools defined in these files are not loaded.

Revives #311 by @sreyemnayr (original targeted `release/v1.0.0-beta`).