### PR TITLE
docs: add AI Gateway documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -190,7 +190,18 @@
           },
           {
             "group": "Additional Features",
-            "pages": ["platform/additional-instructions"]
+            "pages": [
+              "platform/additional-instructions",
+              {
+                "group": "AI Gateway",
+                "icon": "server",
+                "pages": [
+                  "platform/ai-gateway",
+                  "platform/ai-gateway/quickstart",
+                  "platform/ai-gateway/credits-and-pricing"
+                ]
+              }
+            ]
           }
         ],
         "openapi": {

--- a/docs/platform/ai-gateway.mdx
+++ b/docs/platform/ai-gateway.mdx
@@ -1,0 +1,93 @@
+---
+title: "AI Gateway"
+sidebarTitle: "Overview"
+icon: "info"
+description: "OpenAI-compatible Responses API proxy with Agencii auth."
+---
+
+Use a single endpoint to call OpenAI models with OpenAI Responses-compatible requests. Authenticate with your Agencii API key instead of a provider key.
+
+<CodeGroup>
+```python OpenAI Python SDK
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://ai-gateway.agencii.ai/openai",
+    api_key="unused",
+    default_headers={"X-Agencii-Api-Key": "sk-agencii-REPLACE_ME"},
+)
+
+resp = client.responses.create(
+    model="gpt-5.4-mini",
+    input="Tell me a three sentence bedtime story about a unicorn.",
+)
+
+print(resp.id)
+print(resp.output_text)
+```
+
+```ts OpenAI Node SDK
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://ai-gateway.agencii.ai/openai",
+  apiKey: "unused",
+  defaultHeaders: { "X-Agencii-Api-Key": "sk-agencii-REPLACE_ME" },
+});
+
+const resp = await client.responses.create({
+  model: "gpt-5.4-mini",
+  input: "Tell me a three sentence bedtime story about a unicorn.",
+});
+
+console.log(resp.id);
+console.log(resp.output_text);
+```
+</CodeGroup>
+
+## Model providers
+
+<CardGroup cols={2}>
+  <Card title="OpenAI" icon="sparkles">
+    https://ai-gateway.agencii.ai/openai
+  </Card>
+  <Card title="Claude" icon="clock">
+    Coming soon...
+  </Card>
+</CardGroup>
+
+## Base URL and endpoints
+
+Set your SDK's base URL to `https://ai-gateway.agencii.ai/openai`.
+
+If you use a raw HTTP client, send `POST` requests to any of these full URLs:
+
+- `https://ai-gateway.agencii.ai/openai/v1/responses`
+- `https://ai-gateway.agencii.ai/openai/responses`
+- `https://ai-gateway.agencii.ai/v1/responses`
+- `https://ai-gateway.agencii.ai/responses`
+
+## Authentication
+
+Preferred auth:
+
+- `X-Agencii-Api-Key: <your_agencii_api_key>`
+
+You can create and manage Agencii API keys in your [Agencii dashboard](https://agencii.ai/settings/?tab=apiKeys).
+
+For OpenAI SDK compatibility, the gateway also accepts:
+
+- `Authorization: Bearer <your_agencii_api_key>`
+
+<Note>
+If both headers are present, the gateway uses `X-Agencii-Api-Key` and ignores `Authorization`.
+When possible, keep platform auth on `X-Agencii-Api-Key` and reserve `Authorization` for frontend auth flows (e.g. App Check).
+</Note>
+
+## Streaming (SSE)
+
+Set `"stream": true` in the request payload. The gateway returns **SSE** (`Content-Type: text/event-stream`).
+
+## Response metadata
+
+- **Response header**: `X-Run-Id: <string>` (when available, used for log/usage correlation)

--- a/docs/platform/ai-gateway/credits-and-pricing.mdx
+++ b/docs/platform/ai-gateway/credits-and-pricing.mdx
@@ -1,0 +1,43 @@
+---
+title: "Credits and Pricing"
+description: "How AI Gateway usage is priced and deducted."
+icon: "circle-dollar"
+---
+
+```bash
+curl -sS \
+  -X POST "https://ai-gateway.agencii.ai/openai/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "X-Agencii-Api-Key: sk-agencii-REPLACE_ME" \
+  -d '{
+    "model": "gpt-5.4-mini",
+    "input": "Summarize this paragraph in one sentence."
+  }'
+```
+
+## How credits are calculated
+
+AI Gateway charges credits based on:
+
+- **Model pricing**
+- **Input and output token counts**
+
+Your usage is calculated from the response and deducted from your balance at cost.
+
+<Note>
+Credit deductions follow the same balance rules as the rest of the Agencii platform.
+See [How Credits Work](/platform/how-credits-work) for details.
+</Note>
+
+## Low balance behavior
+
+If your balance is too low to run a request, the gateway returns an error telling you to refill credits.
+
+## Track your usage
+
+Review AI Gateway usage and balance in your [Agencii dashboard billing page](https://agencii.ai/settings/?tab=billing).
+
+## Related pricing details
+
+- [Platform pricing](/platform/pricing)
+- [How credits work](/platform/how-credits-work)

--- a/docs/platform/ai-gateway/quickstart.mdx
+++ b/docs/platform/ai-gateway/quickstart.mdx
@@ -1,0 +1,82 @@
+---
+title: "Quickstart"
+description: "Send your first AI Gateway request in minutes."
+icon: "bolt"
+---
+
+<CodeGroup>
+```python OpenAI Python SDK
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://ai-gateway.agencii.ai/openai",
+    api_key="unused",
+    default_headers={"X-Agencii-Api-Key": "sk-agencii-REPLACE_ME"},
+)
+
+resp = client.responses.create(
+    model="gpt-5.4-mini",
+    input="Write a three sentence welcome message for a new user.",
+)
+
+print(resp.output_text)
+```
+
+```ts OpenAI Node SDK
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://ai-gateway.agencii.ai/openai",
+  apiKey: "unused",
+  defaultHeaders: { "X-Agencii-Api-Key": "sk-agencii-REPLACE_ME" },
+});
+
+const resp = await client.responses.create({
+  model: "gpt-5.4-mini",
+  input: "Write a three sentence welcome message for a new user.",
+});
+
+console.log(resp.output_text);
+```
+</CodeGroup>
+
+## Steps
+
+<Steps>
+  <Step title="Create an Agencii API key">
+    Get your key from [the Agencii dashboard](https://agencii.ai/settings/?tab=apiKeys) and keep it private.
+  </Step>
+  <Step title="Pick a model">
+    Use a model name your account has access to (OpenAI).
+  </Step>
+  <Step title="Send the request">
+    Use the OpenAI SDK or send a direct HTTP POST to `/v1/responses`.
+  </Step>
+</Steps>
+
+## Direct HTTP example
+
+```bash
+curl -sS \
+  -X POST "https://ai-gateway.agencii.ai/openai/v1/responses" \
+  -H "Content-Type: application/json" \
+  -H "X-Agencii-Api-Key: sk-agencii-REPLACE_ME" \
+  -d '{
+    "model": "gpt-5.4-mini",
+    "input": "Write a three sentence welcome message for a new user."
+  }'
+```
+
+## Auth options
+
+- **Preferred**: `X-Agencii-Api-Key: <your_agencii_api_key>`
+- **SDK compatibility**: `Authorization: Bearer <your_agencii_api_key>`
+- **If both are present**: `X-Agencii-Api-Key` is used.
+
+## Optional request headers
+
+- `X-Idempotency-Key: <string>` (helps dedupe repeat requests)
+
+## Streaming
+
+Set `"stream": true` in the request payload to receive SSE responses.


### PR DESCRIPTION
Adds Platform-tab documentation for the AI Gateway, an OpenAI-compatible Responses API proxy authenticated with the Agencii API key:

- **Overview** (`docs/platform/ai-gateway.mdx`): copy-paste Python/Node SDK snippets, base URL and accepted endpoint URLs, auth header precedence, streaming, and response metadata.
- **Quickstart** (`docs/platform/ai-gateway/quickstart.mdx`): first request via SDK or curl, key creation steps, auth options, optional headers.
- **Credits and Pricing** (`docs/platform/ai-gateway/credits-and-pricing.mdx`): how usage is priced and deducted, low-balance behavior, billing links.
- `docs/docs.json`: AI Gateway group under Platform → Additional Features.

Revives #506 by @dumitruPuggle; applies the review feedback from that PR:

- Auth header precedence documented explicitly (`X-Agencii-Api-Key` wins over `Authorization` when both are present).
- Dashboard links point to the exact URLs used elsewhere in platform docs (`https://agencii.ai/settings/?tab=apiKeys`, `https://agencii.ai/settings/?tab=billing`).
- Model examples use `gpt-5.4-mini`, matching the rest of the current docs (the old PR still had `gpt-5.1` in the quickstart).
- Endpoint list shows full URLs so nothing is ambiguous relative to the base URL.
- The latency-and-limits page stays removed.
- Per `.cursor/rules/writing-docs.mdc`, each page opens with the code snippet; the model-provider cards moved below it.

Opened as draft: the gateway hostname `ai-gateway.agencii.ai` does not currently resolve on public DNS, so the endpoint, header behavior, and pricing claims are carried over from #506 and still need confirmation against the live gateway.