### PR TITLE
fix: stop concurrent runs from dropping AfterEveryUserMessage reminders

### DIFF
--- a/src/agency_swarm/agent/system_reminders.py
+++ b/src/agency_swarm/agent/system_reminders.py
@@ -470,13 +470,15 @@ def restore_serialized_direct_run(direct_run: _DirectReminderRun, run_state: Run
 
 
 def _has_current_top_level_user_message(context: MasterContext, agent_name: str, run_id: str) -> bool:
+    # Walk the full thread history, newest first, ignoring messages that belong to any
+    # *other* run (including concurrent runs interleaved into the same thread). A message
+    # tagged with a different run_id never bounds this run's own messages, so it must be
+    # skipped rather than treated as an early-exit boundary.
     for message in reversed(context.thread_manager.get_all_messages()):
         if not isinstance(message, dict):
             continue
         message_run_id = message.get("agent_run_id")
         if message_run_id != run_id:
-            if message_run_id is not None:
-                break
             continue
         if message.get("role") == "user":
             return message.get("agent") == agent_name and message.get("callerAgent") is None

--- a/tests/test_agent_modules/test_system_reminders_review_regressions.py
+++ b/tests/test_agent_modules/test_system_reminders_review_regressions.py
@@ -449,3 +449,28 @@ async def test_agent_clone_replaces_internal_reminder_hooks() -> None:
     assert not _contains(disabled_model.inputs[0], "old reminder")
     assert _contains(replacement_model.inputs[0], "new reminder")
     assert not _contains(replacement_model.inputs[0], "old reminder")
+
+
+@pytest.mark.asyncio
+async def test_user_message_reminder_survives_concurrent_runs_on_shared_thread() -> None:
+    """Two `get_response` calls racing on the same Agency must each keep their own reminder.
+
+    `_has_current_top_level_user_message` scans thread history in reverse looking for the
+    user message that started *this* run. When two runs interleave on one thread, the
+    newest message can belong to the other run; the scan must skip past it and keep
+    looking, not abort early and report the reminder missing.
+    """
+    model = _ReminderEchoModel()
+    agent = Agent(name="Concurrent", instructions="x", model=model, system_reminders="reminder!")
+    agency = Agency(agent)
+
+    first_result, second_result = await asyncio.gather(
+        agency.get_response("message one"),
+        agency.get_response("message two"),
+    )
+
+    assert model.calls == 2
+    assert _contains(model.inputs[0], "reminder!")
+    assert _contains(model.inputs[1], "reminder!")
+    assert first_result.final_output == "reminder!"
+    assert second_result.final_output == "reminder!"


### PR DESCRIPTION
### Summary

`_has_current_top_level_user_message` (added in #732) scans thread history in reverse looking for the user message that started the current run, keyed by `agent_run_id`. It `break`s the scan as soon as it sees a message tagged with a *different* run's id.

Two concurrent `get_response` calls on one `Agency` share a `ThreadManager`, so their messages interleave in history. The run that started first sees the other run's newer message as the top of history, hits the `break`, and returns `False` — its `AfterEveryUserMessage` reminder is silently never staged. No error, no log.

Fix: change that `break` to `continue`. The scan still terminates correctly — it already returns as soon as it finds *any* message tagged with the current run's `agent_run_id` whose role is `user`, so it never walks past a matching message. Skipping non-matching runs' messages instead of aborting on them cannot surface a stale earlier message from the same run.

With two separate `Agency` instances (no shared thread) both runs already got their reminder correctly before this fix, confirming this was the shared-thread scan logic, not general state sharing.

### Test plan

- Added `test_user_message_reminder_survives_concurrent_runs_on_shared_thread` to `tests/test_agent_modules/test_system_reminders_review_regressions.py`: runs two `agency.get_response(...)` calls concurrently via `asyncio.gather` on one `Agency`/thread and asserts both model calls receive the reminder. Confirmed it fails deterministically (20/20 manual trials, and via `git checkout -- src/agency_swarm/agent/system_reminders.py` + rerun) against the pre-fix code and passes after the fix.
- `uv run pytest tests/ --ignore=tests/integration`: 1153 passed, 2 skipped (baseline 1152 passed, 2 skipped; +1 for the new test).
- `make format` and `make check` (ruff + mypy): clean.

### Issue number

Closes #745

### Checks

- [x] I've added new tests
- [ ] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass