### PR TITLE
fix: persist EveryNToolCalls counters across run boundaries in the same thread

### DIFF
--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -76,6 +76,12 @@ agent = Agent(
 
 `EveryNToolCalls` counts local function tools and hosted tools (such as `WebSearchTool` and `FileSearchTool`) toward the same threshold.
 
+The count accumulates across turns of the same conversation thread, not just within one
+`get_response()` call. A `15`-call threshold can be crossed by 7 tool calls in one turn and
+8 in the next; the reminder fires on the model call right after the 15th. A new conversation
+(a new `Agency`, or any run that doesn't share a `ThreadManager` with a prior run) starts its
+count at zero.
+
 If the reminder needs agency context, pass a callable:
 
 ```python

--- a/src/agency_swarm/agent/system_reminder_state.py
+++ b/src/agency_swarm/agent/system_reminder_state.py
@@ -12,7 +12,7 @@ from agents import Agent as SDKAgent, RunContextWrapper, TResponseInputItem
 from agents.handoffs import Handoff as SDKHandoff
 
 from agency_swarm.context import MasterContext
-from agency_swarm.reminders import SystemReminder
+from agency_swarm.reminders import EveryNToolCalls, SystemReminder
 
 if TYPE_CHECKING:
     from agents.run_state import RunState
@@ -231,6 +231,46 @@ def build_system_message(
 ) -> TResponseInputItem:
     """Build one transient reminder input item."""
     return {"role": role, "content": text}
+
+
+def thread_key(context: RunContextWrapper[MasterContext]) -> object | None:
+    """Return the object identifying the conversation thread, if one exists.
+
+    A stable ``ThreadManager`` is what makes a run part of the same conversation
+    thread as an earlier run: Agency-managed runs and any direct run explicitly
+    given a shared ``MasterContext`` reuse the same instance across turns, while
+    every other run (no context, or a fresh minimal context) has no persistent
+    thread and its counters stay run-scoped.
+    """
+    master_context = context.context
+    if isinstance(master_context, MasterContext):
+        return master_context.thread_manager
+    return None
+
+
+def clamped_tool_call_counts(
+    raw_counts: object,
+    tool_call_reminders: Sequence[EveryNToolCalls],
+) -> dict[int, int]:
+    """Bound deserialized tool-call counts to each reminder's valid ``[0, n)`` range.
+
+    The advance logic that produces these counts never yields a value outside that
+    range, but decoded JSON from a ``RunState`` payload is untrusted input: a huge or
+    negative value would otherwise force-fire or permanently suppress a reminder, and
+    could now also be written into cross-run thread-persisted counts.
+    """
+    if not isinstance(raw_counts, dict):
+        return {}
+    clamped: dict[int, int] = {}
+    for index, count in raw_counts.items():
+        if not (str(index).isdigit() and isinstance(count, int) and not isinstance(count, bool)):
+            continue
+        reminder_index = int(index)
+        if reminder_index >= len(tool_call_reminders):
+            continue
+        reminder_n = tool_call_reminders[reminder_index].n
+        clamped[reminder_index] = max(0, min(count, reminder_n - 1))
+    return clamped
 
 
 _SUSPENDED_DIRECT_RUNS: WeakKeyDictionary[

--- a/src/agency_swarm/agent/system_reminders.py
+++ b/src/agency_swarm/agent/system_reminders.py
@@ -117,6 +117,12 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
         ]
         self._tool_call_reminders = [reminder for reminder in reminders if isinstance(reminder, EveryNToolCalls)]
         self._run_state: dict[tuple[int, str], _RunReminderState] = {}
+        # EveryNToolCalls counts must survive run boundaries within the same conversation
+        # thread (see _thread_key), unlike everything else in `_run_state`, which is
+        # per-run only. Keying by the live `ThreadManager` and using a weak dictionary
+        # means counts disappear on their own once the owning Agency/thread is gone,
+        # without needing an explicit clear on every run boundary.
+        self._thread_tool_call_counts: weakref.WeakKeyDictionary[object, dict[int, int]] = weakref.WeakKeyDictionary()
 
     async def on_start(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any]) -> None:
         self._discard_stale_context_states(context)
@@ -209,6 +215,24 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
             else:
                 state.tool_call_counts[index] = current_count
 
+        thread_key = self._thread_key(context)
+        if thread_key is not None:
+            self._thread_tool_call_counts[thread_key] = dict(state.tool_call_counts)
+
+    def _thread_key(self, context: RunContextWrapper[MasterContext]) -> object | None:
+        """Return the object identifying the conversation thread, if one exists.
+
+        A stable ``ThreadManager`` is what makes a run part of the same conversation
+        thread as an earlier run: Agency-managed runs and any direct run explicitly
+        given a shared ``MasterContext`` reuse the same instance across turns, while
+        every other run (no context, or a fresh minimal context) has no persistent
+        thread and its counters stay run-scoped, exactly as before.
+        """
+        master_context = context.context
+        if isinstance(master_context, MasterContext):
+            return master_context.thread_manager
+        return None
+
     def _get_state(
         self,
         context: RunContextWrapper[MasterContext],
@@ -220,6 +244,11 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
         state = self._run_state.get(run_key)
         if state is None:
             state = _RunReminderState()
+            thread_key = self._thread_key(context)
+            if thread_key is not None:
+                persisted_counts = self._thread_tool_call_counts.get(thread_key)
+                if persisted_counts:
+                    state.tool_call_counts = dict(persisted_counts)
             self._run_state[run_key] = state
             if not is_active_agency_run(context.context):
                 weakref.finalize(context.usage, self._run_state.pop, run_key, None)
@@ -256,19 +285,7 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
     def _state_from_payload(self, payload: dict[str, object]) -> _RunReminderState:
         user_indexes = int_values(payload.get("pending_user_message_indexes"))
         tool_indexes = set(int_values(payload.get("pending_tool_reminder_indexes")))
-        raw_counts = payload.get("tool_call_counts")
-        tool_call_counts = (
-            {
-                int(index): count
-                for index, count in raw_counts.items()
-                if str(index).isdigit()
-                and int(index) < len(self._tool_call_reminders)
-                and isinstance(count, int)
-                and not isinstance(count, bool)
-            }
-            if isinstance(raw_counts, dict)
-            else {}
-        )
+        tool_call_counts = self._clamped_tool_call_counts(payload.get("tool_call_counts"))
         raw_agent_name = payload.get("agent_name")
         agent_name = raw_agent_name if isinstance(raw_agent_name, str) else None
         return _RunReminderState(
@@ -281,6 +298,29 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
             user_message_reminders_staged=payload.get("user_message_reminders_staged") is True,
             agent_name=agent_name,
         )
+
+    def _clamped_tool_call_counts(self, raw_counts: object) -> dict[int, int]:
+        """Bound deserialized tool-call counts to each reminder's valid ``[0, n)`` range.
+
+        ``_advance_tool_call_counters`` only ever produces counts in that range, but a
+        hand-crafted ``RunState`` payload is untrusted input: a huge or negative value
+        would otherwise force-fire or permanently suppress a reminder. Now that a
+        restored count can also be written into ``_thread_tool_call_counts`` and outlive
+        this one run (see ``_advance_tool_call_counters``), clamping here keeps a
+        hostile value from corrupting the whole thread instead of just one run.
+        """
+        if not isinstance(raw_counts, dict):
+            return {}
+        clamped: dict[int, int] = {}
+        for index, count in raw_counts.items():
+            if not (str(index).isdigit() and isinstance(count, int) and not isinstance(count, bool)):
+                continue
+            reminder_index = int(index)
+            if reminder_index >= len(self._tool_call_reminders):
+                continue
+            reminder_n = self._tool_call_reminders[reminder_index].n
+            clamped[reminder_index] = max(0, min(count, reminder_n - 1))
+        return clamped
 
     def _render_context(
         self,

--- a/src/agency_swarm/agent/system_reminders.py
+++ b/src/agency_swarm/agent/system_reminders.py
@@ -20,6 +20,7 @@ from .system_reminder_state import (
     _RunReminderState,
     active_agency_run,
     build_system_message,
+    clamped_tool_call_counts,
     has_user_message,
     int_values,
     is_active_agency_run,
@@ -27,6 +28,7 @@ from .system_reminder_state import (
     register_agency_run_hook,
     run_state_agents_by_name,
     suspend_agency_run_hooks,
+    thread_key,
 )
 
 if TYPE_CHECKING:
@@ -117,11 +119,8 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
         ]
         self._tool_call_reminders = [reminder for reminder in reminders if isinstance(reminder, EveryNToolCalls)]
         self._run_state: dict[tuple[int, str], _RunReminderState] = {}
-        # EveryNToolCalls counts must survive run boundaries within the same conversation
-        # thread (see _thread_key), unlike everything else in `_run_state`, which is
-        # per-run only. Keying by the live `ThreadManager` and using a weak dictionary
-        # means counts disappear on their own once the owning Agency/thread is gone,
-        # without needing an explicit clear on every run boundary.
+        # Unlike `_run_state`, these counts must survive run boundaries (see `thread_key`
+        # in system_reminder_state.py). The weak dictionary drops them once their thread does.
         self._thread_tool_call_counts: weakref.WeakKeyDictionary[object, dict[int, int]] = weakref.WeakKeyDictionary()
 
     async def on_start(self, context: AgentHookContext[MasterContext], agent: SDKAgent[Any]) -> None:
@@ -215,23 +214,9 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
             else:
                 state.tool_call_counts[index] = current_count
 
-        thread_key = self._thread_key(context)
-        if thread_key is not None:
-            self._thread_tool_call_counts[thread_key] = dict(state.tool_call_counts)
-
-    def _thread_key(self, context: RunContextWrapper[MasterContext]) -> object | None:
-        """Return the object identifying the conversation thread, if one exists.
-
-        A stable ``ThreadManager`` is what makes a run part of the same conversation
-        thread as an earlier run: Agency-managed runs and any direct run explicitly
-        given a shared ``MasterContext`` reuse the same instance across turns, while
-        every other run (no context, or a fresh minimal context) has no persistent
-        thread and its counters stay run-scoped, exactly as before.
-        """
-        master_context = context.context
-        if isinstance(master_context, MasterContext):
-            return master_context.thread_manager
-        return None
+        key = thread_key(context)
+        if key is not None:
+            self._thread_tool_call_counts[key] = dict(state.tool_call_counts)
 
     def _get_state(
         self,
@@ -244,9 +229,9 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
         state = self._run_state.get(run_key)
         if state is None:
             state = _RunReminderState()
-            thread_key = self._thread_key(context)
-            if thread_key is not None:
-                persisted_counts = self._thread_tool_call_counts.get(thread_key)
+            key = thread_key(context)
+            if key is not None:
+                persisted_counts = self._thread_tool_call_counts.get(key)
                 if persisted_counts:
                     state.tool_call_counts = dict(persisted_counts)
             self._run_state[run_key] = state
@@ -285,7 +270,7 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
     def _state_from_payload(self, payload: dict[str, object]) -> _RunReminderState:
         user_indexes = int_values(payload.get("pending_user_message_indexes"))
         tool_indexes = set(int_values(payload.get("pending_tool_reminder_indexes")))
-        tool_call_counts = self._clamped_tool_call_counts(payload.get("tool_call_counts"))
+        tool_call_counts = clamped_tool_call_counts(payload.get("tool_call_counts"), self._tool_call_reminders)
         raw_agent_name = payload.get("agent_name")
         agent_name = raw_agent_name if isinstance(raw_agent_name, str) else None
         return _RunReminderState(
@@ -298,29 +283,6 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
             user_message_reminders_staged=payload.get("user_message_reminders_staged") is True,
             agent_name=agent_name,
         )
-
-    def _clamped_tool_call_counts(self, raw_counts: object) -> dict[int, int]:
-        """Bound deserialized tool-call counts to each reminder's valid ``[0, n)`` range.
-
-        ``_advance_tool_call_counters`` only ever produces counts in that range, but a
-        hand-crafted ``RunState`` payload is untrusted input: a huge or negative value
-        would otherwise force-fire or permanently suppress a reminder. Now that a
-        restored count can also be written into ``_thread_tool_call_counts`` and outlive
-        this one run (see ``_advance_tool_call_counters``), clamping here keeps a
-        hostile value from corrupting the whole thread instead of just one run.
-        """
-        if not isinstance(raw_counts, dict):
-            return {}
-        clamped: dict[int, int] = {}
-        for index, count in raw_counts.items():
-            if not (str(index).isdigit() and isinstance(count, int) and not isinstance(count, bool)):
-                continue
-            reminder_index = int(index)
-            if reminder_index >= len(self._tool_call_reminders):
-                continue
-            reminder_n = self._tool_call_reminders[reminder_index].n
-            clamped[reminder_index] = max(0, min(count, reminder_n - 1))
-        return clamped
 
     def _render_context(
         self,

--- a/tests/test_agent_modules/test_system_reminders_thread_persistence.py
+++ b/tests/test_agent_modules/test_system_reminders_thread_persistence.py
@@ -1,0 +1,220 @@
+"""EveryNToolCalls counters must persist across run boundaries within one conversation
+thread: a normal multi-turn Agency conversation should accumulate tool-call counts across
+`get_response()` calls instead of restarting at zero on every turn, while a genuinely new
+conversation thread must still start at zero. See docs/core-framework/agents/advanced-configuration.mdx.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import AsyncIterator
+
+import pytest
+from agents import ModelSettings, Tool, TResponseInputItem
+from agents.agent_output import AgentOutputSchemaBase
+from agents.handoffs import Handoff as SDKHandoff
+from agents.items import ModelResponse, TResponseStreamEvent
+from agents.models.interface import Model, ModelTracing
+from openai.types.responses.response_prompt_param import ResponsePromptParam
+
+from agency_swarm import Agency, Agent, EveryNToolCalls
+from agency_swarm.agent.system_reminder_state import _RunReminderState
+from tests.deterministic_model import _build_message_response, _build_tool_call_response, _stream_text_events
+from tests.test_agent_modules.test_system_reminders_review_regressions import (
+    _contains,
+    _local_tool,
+    _reminder_hooks,
+    _run_context,
+    _ToolThenAnswerModel,
+)
+
+
+class _NToolCallsPerTurnModel(Model):
+    """Call the tool `threshold` times per top-level user turn, then answer.
+
+    Counts tool outputs seen since the most recent user message, mirroring how a real
+    tool-heavy agent works turn by turn.
+    """
+
+    def __init__(self, threshold: int) -> None:
+        self.model = "test-n-tool-calls-per-turn"
+        self.threshold = threshold
+        self.recorded_inputs: list[list[TResponseInputItem]] = []
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[SDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> ModelResponse:
+        if not isinstance(input, list):
+            raise TypeError("This test model expects structured input items.")
+
+        self.recorded_inputs.append(copy.deepcopy(input))
+        tool_outputs = 0
+        for item in reversed(input):
+            if isinstance(item, dict) and item.get("role") == "user":
+                break
+            if isinstance(item, dict) and item.get("type") in {"function_call_output", "tool_call_output_item"}:
+                tool_outputs += 1
+
+        if tool_outputs < self.threshold:
+            return _build_tool_call_response(tools[0].name, {})
+        return _build_message_response("done", self.model)
+
+    def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[TResponseInputItem],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: AgentOutputSchemaBase | None,
+        handoffs: list[SDKHandoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None,
+        conversation_id: str | None,
+        prompt: ResponsePromptParam | None,
+    ) -> AsyncIterator[TResponseStreamEvent]:
+        return _stream_text_events("done", self.model)
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_fires_from_cumulative_count_across_turns() -> None:
+    """The documented example: EveryNToolCalls(15, ...) with 7 tool calls per turn across
+    3 turns (21 total) must fire once cumulative tool calls reach 15, in the 3rd turn.
+
+    Before this fix, every turn restarted its count at zero, so 7 < 15 every time and the
+    reminder never fired for a normal multi-turn conversational agent.
+    """
+    model = _NToolCallsPerTurnModel(threshold=7)
+    agent = Agent(
+        name="ReminderAgent",
+        instructions="Use the tool until the task is done.",
+        model=model,
+        model_settings=ModelSettings(temperature=0.0),
+        tools=[_local_tool],
+        system_reminders=[EveryNToolCalls(15, "Checkpoint reminder")],
+    )
+    agency = Agency(agent)
+
+    await agency.get_response("Handle task-1")
+    await agency.get_response("Handle task-2")
+    await agency.get_response("Handle task-3")
+
+    # 3 turns x 8 model calls each (7 tool calls + 1 final answer) = 24 calls total.
+    assert len(model.recorded_inputs) == 24
+    fired_at = [index for index, items in enumerate(model.recorded_inputs) if _contains(items, "Checkpoint reminder")]
+
+    # Cumulative tool calls cross 15 right after the 1st tool call of turn 3 (7+7+1=15),
+    # which is model call index 17 (turn 3 starts at index 16; call 16 has 0 outputs
+    # so far this turn, call 17 sees the reminder injected after that tool call ran).
+    assert fired_at == [17]
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_new_agency_thread_starts_at_zero() -> None:
+    """A brand-new Agency (a genuinely new conversation thread) must not inherit another
+    thread's tool-call count, even when it wraps the exact same Agent instance."""
+    agent = Agent(
+        name="SharedAgent",
+        instructions="x",
+        tools=[_local_tool],
+        system_reminders=[EveryNToolCalls(2, "Checkpoint reminder")],
+    )
+
+    thread_a = Agency(agent)
+    model_a1 = _ToolThenAnswerModel()
+    agent.model = model_a1
+    await thread_a.get_response("Handle task-1")
+    # Thread A's count is now 1/2; not yet due.
+    assert not _contains(model_a1.inputs[-1], "Checkpoint reminder")
+
+    # A different Agency wrapping the same Agent is a different conversation thread.
+    # If the count leaked from thread A, this single tool call would push it to 2/2 and fire.
+    thread_b = Agency(agent)
+    model_b1 = _ToolThenAnswerModel()
+    agent.model = model_b1
+    await thread_b.get_response("Handle task-1")
+    assert not _contains(model_b1.inputs[-1], "Checkpoint reminder")
+
+    # Thread A's own count did genuinely persist: its second turn now crosses the threshold.
+    model_a2 = _ToolThenAnswerModel()
+    agent.model = model_a2
+    await thread_a.get_response("Handle task-2")
+    assert _contains(model_a2.inputs[-1], "Checkpoint reminder")
+
+
+def test_state_from_payload_clamps_hostile_tool_call_counts() -> None:
+    """A hand-crafted RunState payload must not seed a huge or negative count.
+
+    `_advance_tool_call_counters` never produces a count outside `[0, n)`, but decoded
+    JSON is untrusted input; the index was already bounds-checked, but the value was not.
+    """
+    agent = Agent(name="Hostile", instructions="x", system_reminders=[EveryNToolCalls(5, "Checkpoint")])
+    hooks = _reminder_hooks(agent)
+
+    huge_state = hooks._state_from_payload({"tool_call_counts": {"0": 10**9}})
+    negative_state = hooks._state_from_payload({"tool_call_counts": {"0": -(10**9)}})
+
+    assert huge_state.tool_call_counts == {0: 4}  # clamped to n - 1
+    assert negative_state.tool_call_counts == {0: 0}  # clamped to 0
+
+
+def test_state_payload_round_trips_legitimate_tool_call_counts() -> None:
+    """Clamping must not alter a count that was already inside the valid range."""
+    agent = Agent(name="Legit", instructions="x", system_reminders=[EveryNToolCalls(5, "Checkpoint")])
+    hooks = _reminder_hooks(agent)
+
+    original = _RunReminderState(tool_call_counts={0: 3})
+    payload = hooks._state_to_payload(original, hook_index=0)
+    restored = hooks._state_from_payload(payload)
+
+    assert restored.tool_call_counts == {0: 3}
+
+
+@pytest.mark.asyncio
+async def test_hostile_tool_call_count_does_not_corrupt_persistent_thread_state() -> None:
+    """A hostile restored count must not survive into cross-run thread persistence.
+
+    Persisting counts across runs means a value restored into one run's state can now
+    outlive that run: `_advance_tool_call_counters` writes it into the per-thread store
+    on every tool call. If the value weren't clamped first, a hostile huge or negative
+    count would corrupt the whole thread instead of just one run.
+    """
+    agent = Agent(
+        name="HostileThread",
+        instructions="x",
+        tools=[_local_tool],
+        system_reminders=[EveryNToolCalls(5, "Checkpoint reminder")],
+    )
+    hooks = _reminder_hooks(agent)
+
+    # A hostile negative count, already clamped by _state_from_payload, seeded into a run
+    # that carries a real (thread-identifying) MasterContext.
+    negative_context = _run_context(agent, "run-negative")
+    run_key = hooks._resolve_run_key(negative_context)
+    hooks._run_state[run_key] = hooks._state_from_payload({"tool_call_counts": {"0": -(10**9)}})
+
+    await hooks.on_tool_end(negative_context, agent, _local_tool, "ok")
+
+    thread_key = hooks._thread_key(negative_context)
+    assert hooks._thread_tool_call_counts[thread_key] == {0: 1}
+
+    # A hostile huge positive count behaves like a legitimate value at the threshold.
+    huge_context = _run_context(agent, "run-huge")
+    huge_run_key = hooks._resolve_run_key(huge_context)
+    hooks._run_state[huge_run_key] = hooks._state_from_payload({"tool_call_counts": {"0": 10**9}})
+
+    await hooks.on_tool_end(huge_context, agent, _local_tool, "ok")
+
+    huge_thread_key = hooks._thread_key(huge_context)
+    assert hooks._thread_tool_call_counts[huge_thread_key] == {0: 0}

--- a/tests/test_agent_modules/test_system_reminders_thread_persistence.py
+++ b/tests/test_agent_modules/test_system_reminders_thread_persistence.py
@@ -18,7 +18,7 @@ from agents.models.interface import Model, ModelTracing
 from openai.types.responses.response_prompt_param import ResponsePromptParam
 
 from agency_swarm import Agency, Agent, EveryNToolCalls
-from agency_swarm.agent.system_reminder_state import _RunReminderState
+from agency_swarm.agent.system_reminder_state import _RunReminderState, thread_key as resolve_thread_key
 from tests.deterministic_model import _build_message_response, _build_tool_call_response, _stream_text_events
 from tests.test_agent_modules.test_system_reminders_review_regressions import (
     _contains,
@@ -206,8 +206,8 @@ async def test_hostile_tool_call_count_does_not_corrupt_persistent_thread_state(
 
     await hooks.on_tool_end(negative_context, agent, _local_tool, "ok")
 
-    thread_key = hooks._thread_key(negative_context)
-    assert hooks._thread_tool_call_counts[thread_key] == {0: 1}
+    negative_thread_key = resolve_thread_key(negative_context)
+    assert hooks._thread_tool_call_counts[negative_thread_key] == {0: 1}
 
     # A hostile huge positive count behaves like a legitimate value at the threshold.
     huge_context = _run_context(agent, "run-huge")
@@ -216,5 +216,5 @@ async def test_hostile_tool_call_count_does_not_corrupt_persistent_thread_state(
 
     await hooks.on_tool_end(huge_context, agent, _local_tool, "ok")
 
-    huge_thread_key = hooks._thread_key(huge_context)
+    huge_thread_key = resolve_thread_key(huge_context)
     assert hooks._thread_tool_call_counts[huge_thread_key] == {0: 0}


### PR DESCRIPTION
### Summary

`EveryNToolCalls` counts were keyed per-run and wiped at every run boundary (`SystemReminderHooks.on_end` and `cleanup_execution`), so the documented checkpoint-reminder example could never fire for a normal multi-turn conversational agent: an agent making 7 tool calls per turn across 3 turns (21 total) with `EveryNToolCalls(15, ...)` never crossed the threshold, because every turn restarted at 0.

Tool-call counts now persist on the conversation's `ThreadManager` — the one piece of state that is genuinely stable across every run of the same Agency-managed (or explicitly-shared-context) conversation — for the lifetime of that thread. Everything else in per-run reminder state (pending reminder markers, hook indices) still resets on every run boundary exactly as before; only the cumulative counts move to a separate, weakly-referenced, thread-keyed store so they disappear on their own once the owning thread does. A run with no persistent thread (a bare `Runner.run(agent, "...")` call with no shared context) keeps the old run-scoped behavior, since there's nothing that identifies it as part of any earlier conversation.

Also hardened `_state_from_payload`: it already bounds-checked the reminder *index* in a deserialized `tool_call_counts` payload, but not the count *value*. A hand-crafted `RunState` payload could previously seed a huge or negative count; since a restored count can now also be written into the persistent per-thread store, that value is clamped into `[0, n)` so a hostile payload can't corrupt a whole thread instead of just one resumed run.

Docs updated: `docs/core-framework/agents/advanced-configuration.mdx` now says the count accumulates across turns of the same thread, not just within one `get_response()` call.

### Test plan

- New file `tests/test_agent_modules/test_system_reminders_thread_persistence.py` (5 tests):
  - `test_every_n_tool_calls_fires_from_cumulative_count_across_turns` — the documented case (15-threshold, 7 calls/turn x 3 turns) fires exactly once, in turn 3.
  - `test_every_n_tool_calls_new_agency_thread_starts_at_zero` — a new `Agency` (new thread) wrapping the *same* `Agent` instance does not inherit another thread's count, while the original thread's count does persist.
  - `test_state_from_payload_clamps_hostile_tool_call_counts` — a huge or negative deserialized count is clamped into `[0, n)`.
  - `test_state_payload_round_trips_legitimate_tool_call_counts` — a legitimate count round-trips unchanged.
  - `test_hostile_tool_call_count_does_not_corrupt_persistent_thread_state` — a hostile restored count, once clamped, still writes a safe value into the new per-thread store.
- Verified both new regression tests fail on the pre-fix code (reverted `system_reminders.py` locally) and pass after the fix, confirming they exercise the bug.
- Full suite: `uv run pytest tests/ --ignore=tests/integration` — 1157 passed, 2 skipped (baseline was 1152 passed, 2 skipped; the delta is exactly the 5 new tests).
- `make format` and `make check` (ruff + mypy): clean.
- Test-merged `origin/codex/fix-concurrent-run-reminder-scan` (PR #746, a one-line scan fix in a different function of the same file) locally to check for conflicts: clean auto-merge, no overlap (confirmed, then reverted — not pushed).

### Issue number

Closes #747

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
