### PR TITLE
fix: define EveryNToolCalls run contract

### DIFF
--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -59,14 +59,14 @@ agent = Agent(
 
 This reminder is added only to the model input. It is **not saved** in the thread history.
 
-For tool-heavy agents, add a checkpoint reminder:
+For a long autonomous run that may call many tools before it returns, add a checkpoint reminder:
 
 ```python
 from agency_swarm import Agent, EveryNToolCalls
 
 agent = Agent(
-    name="SupportAgent",
-    instructions="Answer clearly and keep the user moving forward.",
+    name="ResearchAgent",
+    instructions="Complete the full research task before replying. Use tools as needed.",
     system_reminders=[
         "Before replying, end with one clear next step.",
         EveryNToolCalls(15, "Pause and summarize progress before using more tools."),
@@ -74,7 +74,9 @@ agent = Agent(
 )
 ```
 
-`EveryNToolCalls` counts local function tools and hosted tools (such as `WebSearchTool` and `FileSearchTool`) toward the same threshold.
+`EveryNToolCalls` counts local function tools and hosted tools (such as `WebSearchTool` and `FileSearchTool`) separately for each agent within one logical run. A logical run starts with a user request to an agency or a direct `Runner` call. Handoffs and resumed interruptions stay in that run. The count resets when the run completes, fails, or is cancelled.
+
+For each configured `EveryNToolCalls`, if parallel tool calls cross several of its thresholds before the next model call, Agency Swarm produces exactly one reminder for that model call. It keeps the modulo remainder—the calls left after dividing by `n`—toward the next threshold.
 
 If the reminder needs agency context, pass a callable:
 

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -76,7 +76,7 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Schemas Folder *(optional)* | `schemas_folder` | Path to a directory containing openapi schema files in .json format. Schemas are automatically converted into FunctionTools. Default: `None` |
 | Validation Attempts *(optional)* | `validation_attempts` | Number of retries when an output guardrail trips. Default: `1` |
 | Raise Input Guardrail Error *(optional)* | `raise_input_guardrail_error` | If set to `True`, input guardrail errors raise an exception. If set to `False`, the guardrail message is returned as the agent's response. Default: `False` |
-| System Reminders *(optional)* | `system_reminders` | Transient reminders shown to the model before model calls. Start with `system_reminders="..."`; use `EveryNToolCalls(...)` for tool checkpoints. Default: `None` |
+| System Reminders *(optional)* | `system_reminders` | Transient reminders shown to the model before model calls. Start with `system_reminders="..."`; use `EveryNToolCalls(...)` for within-run tool checkpoints. Default: `None` |
 | Handoff Reminder *(optional)* | `handoff_reminder` | Replaces the default handoff reminder system message with a given string. Default: "Transfer completed. You are [recipient_agent_name]. Please continue the task." |
 | Include Search Results *(optional)* | `include_search_results` | Include search results in FileSearchTool output for citation extraction. Default: `False` |
 | Include Web Search Sources *(optional)* | `include_web_search_sources` | Include source URLs from WebSearchTool calls. Default: `True` |

--- a/src/agency_swarm/agent/core.py
+++ b/src/agency_swarm/agent/core.py
@@ -163,11 +163,11 @@ class Agent(BaseAgent[MasterContext]):
             voice (str | None): Realtime session voice used when this agent is the entry agent. A realtime
                 session keeps one voice from start to finish, so a voice set on any other agent is not heard.
             system_reminders (str | Callable | SystemReminder | list[str | Callable | SystemReminder] | None):
-                Transient system reminders injected before model calls. Plain strings and callables run after each
-                top-level user message.
+                Transient reminders precede model calls. Strings and callables run after top-level user messages.
+                EveryNToolCalls counts tool calls per agent and per logical run; resumed interruptions preserve
+                the count, while completed runs reset it.
             handoff_reminder (str | None): Custom reminder for handoffs.
                 Defaults to `Transfer completed. You are {recipient_agent_name}. Please continue the task.`
-
         ## OpenAI Agents SDK Parameters:
             prompt (Prompt | DynamicPromptFunction | None): Dynamic prompt configuration.
             model (str | Model | None): Model identifier (e.g., "gpt-5.4") or Model instance.

--- a/src/agency_swarm/agent/system_reminders.py
+++ b/src/agency_swarm/agent/system_reminders.py
@@ -263,8 +263,8 @@ class SystemReminderHooks(AgentHooks[MasterContext]):
                 for index, count in raw_counts.items()
                 if str(index).isdigit()
                 and int(index) < len(self._tool_call_reminders)
-                and isinstance(count, int)
-                and not isinstance(count, bool)
+                and type(count) is int
+                and 0 <= count < self._tool_call_reminders[int(index)].n
             }
             if isinstance(raw_counts, dict)
             else {}

--- a/src/agency_swarm/reminders.py
+++ b/src/agency_swarm/reminders.py
@@ -75,7 +75,11 @@ class AfterEveryUserMessage(SystemReminder):
 
 @dataclass(frozen=True, slots=True)
 class EveryNToolCalls(SystemReminder):
-    """Inject a transient reminder on the next model call after every N tool calls."""
+    """Inject a transient reminder on the next model call after every N tool calls.
+
+    EveryNToolCalls counts tool calls per agent and per logical run; resumed interruptions
+    preserve the count, while completed runs reset it.
+    """
 
     n: int
     message: ReminderMessage

--- a/tests/test_agent_modules/test_system_reminders.py
+++ b/tests/test_agent_modules/test_system_reminders.py
@@ -94,9 +94,10 @@ class _RecordingModel(DeterministicModel):
         )
 
 
-class _TwoToolCallsModel(Model):
-    def __init__(self) -> None:
-        self.model = "test-two-tool-calls"
+class _NToolCallsPerTurnModel(Model):
+    def __init__(self, tool_calls_per_turn: int = 2) -> None:
+        self.model = "test-n-tool-calls-per-turn"
+        self.tool_calls_per_turn = tool_calls_per_turn
         self.recorded_inputs: list[list[TResponseInputItem]] = []
 
     async def get_response(
@@ -124,9 +125,13 @@ class _TwoToolCallsModel(Model):
             if isinstance(item, dict) and item.get("type") in {"function_call_output", "tool_call_output_item"}:
                 tool_outputs += 1
 
-        if tool_outputs < 2:
+        await self._before_response(input, tool_outputs)
+        if tool_outputs < self.tool_calls_per_turn:
             return _build_tool_call_response(tools[0].name, {})
         return _build_message_response("done", self.model)
+
+    async def _before_response(self, input_items: list[TResponseInputItem], tool_outputs: int) -> None:
+        pass
 
     def stream_response(
         self,
@@ -308,7 +313,7 @@ async def test_after_every_user_message_is_transient_in_thread_history() -> None
 
 @pytest.mark.asyncio
 async def test_every_n_tool_calls_injects_on_next_llm_call_and_resets() -> None:
-    model = _TwoToolCallsModel()
+    model = _NToolCallsPerTurnModel()
     agent = Agent(
         name="ReminderAgent",
         instructions="Use the tool until the task is done.",

--- a/tests/test_agent_modules/test_system_reminders_run_contract.py
+++ b/tests/test_agent_modules/test_system_reminders_run_contract.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agents import TResponseInputItem
+
+from agency_swarm import Agency, Agent, EveryNToolCalls, MasterContext, Runner
+from agency_swarm.agent.system_reminders import SystemReminderHooks
+from agency_swarm.utils.thread import ThreadManager
+from tests.test_agent_modules.test_system_reminders import (
+    _contains_text,
+    _extract_text,
+    _NToolCallsPerTurnModel,
+    check_task_state,
+)
+
+
+def _latest_user_text(input_items: list[TResponseInputItem]) -> str:
+    for item in reversed(input_items):
+        if isinstance(item, dict) and item.get("role") == "user":
+            return _extract_text(item) or ""
+    return ""
+
+
+class _ConcurrentRunsModel(_NToolCallsPerTurnModel):
+    def __init__(self) -> None:
+        super().__init__(tool_calls_per_turn=2)
+        self.first_waiting = asyncio.Event()
+        self.second_started = asyncio.Event()
+        self.second_waiting = asyncio.Event()
+        self.allow_second = asyncio.Event()
+
+    async def _before_response(self, input_items: list[TResponseInputItem], tool_outputs: int) -> None:
+        user_text = _latest_user_text(input_items)
+        if user_text == "first concurrent run" and tool_outputs == 1:
+            self.first_waiting.set()
+            await self.second_started.wait()
+        elif user_text == "second concurrent run" and tool_outputs == 0:
+            self.second_started.set()
+        elif user_text == "second concurrent run" and tool_outputs == 1:
+            self.second_waiting.set()
+            await self.allow_second.wait()
+
+
+def _tool_call_agent(name: str, model: _NToolCallsPerTurnModel) -> Agent:
+    return Agent(
+        name=name,
+        instructions="Use the tool until the task is done.",
+        model=model,
+        tools=[check_task_state],
+        system_reminders=[EveryNToolCalls(15, "Checkpoint reminder")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_fires_in_long_single_run() -> None:
+    model = _NToolCallsPerTurnModel(tool_calls_per_turn=20)
+    agent = _tool_call_agent("LongRunAgent", model)
+
+    await Agency(agent).get_response("Handle the long task")
+
+    reminder_calls = [
+        index
+        for index, input_items in enumerate(model.recorded_inputs)
+        if _contains_text(input_items, "Checkpoint reminder")
+    ]
+    assert len(model.recorded_inputs) == 21
+    assert reminder_calls == [15]
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_resets_across_agency_runs() -> None:
+    model = _NToolCallsPerTurnModel(tool_calls_per_turn=7)
+    agent = _tool_call_agent("AgencyRunAgent", model)
+    agency = Agency(agent)
+
+    for turn in range(3):
+        await agency.get_response(f"Handle task {turn}")
+
+    assert len(model.recorded_inputs) == 24
+    assert not any(_contains_text(input_items, "Checkpoint reminder") for input_items in model.recorded_inputs)
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_resets_across_direct_runs_with_shared_context() -> None:
+    model = _NToolCallsPerTurnModel(tool_calls_per_turn=7)
+    agent = _tool_call_agent("DirectRunAgent", model)
+    context = MasterContext(
+        thread_manager=ThreadManager(),
+        agents={agent.name: agent},
+        current_agent_name=agent.name,
+    )
+
+    for turn in range(3):
+        await Runner.run(agent, f"Handle task {turn}", context=context)
+
+    assert len(model.recorded_inputs) == 24
+    assert not any(_contains_text(input_items, "Checkpoint reminder") for input_items in model.recorded_inputs)
+
+
+@pytest.mark.asyncio
+async def test_every_n_tool_calls_isolates_overlapping_agency_runs() -> None:
+    model = _ConcurrentRunsModel()
+    agent = Agent(
+        name="ConcurrentRunAgent",
+        instructions="Use the tool until the task is done.",
+        model=model,
+        tools=[check_task_state],
+        system_reminders=[EveryNToolCalls(2, "Checkpoint reminder")],
+    )
+    agency = Agency(agent)
+
+    first_task = asyncio.create_task(agency.get_response("first concurrent run"))
+    await asyncio.wait_for(model.first_waiting.wait(), timeout=2)
+    second_task = asyncio.create_task(agency.get_response("second concurrent run"))
+    await asyncio.wait_for(model.second_waiting.wait(), timeout=2)
+    await asyncio.wait_for(first_task, timeout=2)
+    model.allow_second.set()
+    await asyncio.wait_for(second_task, timeout=2)
+
+    reminder_runs = [
+        _latest_user_text(input_items)
+        for input_items in model.recorded_inputs
+        if _contains_text(input_items, "Checkpoint reminder")
+    ]
+    assert reminder_runs == ["first concurrent run", "second concurrent run"]
+
+
+def test_state_from_payload_ignores_out_of_range_tool_call_counts() -> None:
+    reminders = [EveryNToolCalls(5, f"Reminder {index}") for index in range(5)]
+    hooks = SystemReminderHooks(reminders)
+
+    state = hooks._state_from_payload(
+        {
+            "tool_call_counts": {
+                "0": -1,
+                "1": 5,
+                "2": 10**100,
+                "3": True,
+                "4": 4,
+            }
+        }
+    )
+
+    assert state.tool_call_counts == {4: 4}

--- a/tests/test_agent_modules/test_system_reminders_streaming.py
+++ b/tests/test_agent_modules/test_system_reminders_streaming.py
@@ -184,6 +184,30 @@ async def test_every_n_tool_calls_cadence_survives_streamed_handoff() -> None:
 
 
 @pytest.mark.asyncio
+async def test_every_n_tool_calls_resets_across_streamed_agency_runs() -> None:
+    script: list[ScriptStep] = []
+    for _turn in range(3):
+        script.extend([lambda tools, _handoffs: [_function_call(tools[0].name)] for _call in range(7)])
+        script.append(lambda _tools, _handoffs: [_message("done")])
+    model = _ScriptedStreamModel(script)
+    agent = Agent(
+        name="StreamedRunAgent",
+        instructions="Use the tool until the task is done.",
+        model=model,
+        tools=[_local_tool],
+        system_reminders=[EveryNToolCalls(15, "Checkpoint reminder")],
+    )
+    agency = Agency(agent)
+
+    for turn in range(3):
+        async for _event in agency.get_response_stream(f"Handle task {turn}"):
+            pass
+
+    assert len(model.inputs) == 24
+    assert not any(_contains(input_items, "Checkpoint reminder") for input_items in model.inputs)
+
+
+@pytest.mark.asyncio
 async def test_streamed_handoff_cadence_matches_non_streaming() -> None:
     """The streamed cadence above is the same one `get_response` already produces."""
     agency, coordinator_model = _handoff_back_agency()


### PR DESCRIPTION
### Summary

This pull request defines and locks the `EveryNToolCalls` contract:

- Counts are per agent and per logical run. Handoffs and interruption resumes keep the same run; completed runs reset it.
- The docs now use a long autonomous run and explain parallel threshold crossings and modulo remainders.
- Restored counts are accepted only when `type(count) is int` and `0 <= count < n`; invalid values restart at zero.
- Tests cover long, separate, streamed, direct shared-context, concurrent, and restored run boundaries.

### Test plan

- `make format`
- `make check`
- `uv run pytest tests/ --ignore=tests/integration` — 1,159 passed, 2 skipped
- Focused reminder tests — 40 passed

### Issue number

Closes #749

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
