### PR TITLE
docs: correct default model and feature guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Define tools using the modern `@function_tool` decorator (recommended), or exten
         files_folder="./files", # files to be uploaded to OpenAI
         schemas_folder="./schemas", # OpenAPI schemas to be converted into tools
         tools=[my_custom_tool],  # FunctionTool returned by @function_tool (or adapt BaseTool via ToolFactory)
-        model="gpt-5.4-mini",
+        model="gpt-5.6-luna",
         model_settings=ModelSettings(
             max_tokens=25000,
         ),

--- a/docs/additional-features/azure-openai.mdx
+++ b/docs/additional-features/azure-openai.mdx
@@ -53,7 +53,7 @@ azure_agent = Agent(
     name="AzureAgent",
     instructions="You are a helpful assistant",
     model=OpenAIChatCompletionsModel(
-        model="gpt-5.4-mini",
+        model="gpt-5.6-luna",
         openai_client=azure_agent,
     ),
 )

--- a/docs/additional-features/fastapi-integration.mdx
+++ b/docs/additional-features/fastapi-integration.mdx
@@ -253,12 +253,11 @@ run_fastapi(
     },
     tools=[example_tool, test_tool],
     enable_realtime=True,
-    realtime_options={"provider": "openai", "model": "gpt-realtime-mini"},
+    realtime_options={"provider": "openai", "model": "gpt-realtime-2.1-mini"},
 )
 ```
 
 Endpoints follow the reference above; tool schemas mirror the definitions of `example_tool` and `test_tool`.
-
 </Accordion>
 
 ---

--- a/docs/additional-features/guardrails/input-guardrails.mdx
+++ b/docs/additional-features/guardrails/input-guardrails.mdx
@@ -112,7 +112,7 @@ guardrail_agent = Agent(
         "Treat questions about account access, billing, and troubleshooting as relevant. "
         "Flag any unrelated requests as irrelevant."
     ),
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     model_settings=ModelSettings(reasoning=Reasoning(effort="low")),
     output_type=RelevanceDecision,
 )
@@ -135,7 +135,7 @@ async def require_support_topic(
 support_agent = Agent(
     name="CustomerSupportAgent",
     instructions="You help customers resolve account, billing, and troubleshooting issues.",
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     input_guardrails=[require_support_topic],
     raise_input_guardrail_error=False,  # Non-strict mode: guidance returned as assistant message
 )

--- a/docs/additional-features/guardrails/output-guardrails.mdx
+++ b/docs/additional-features/guardrails/output-guardrails.mdx
@@ -73,7 +73,7 @@ async def forbid_sensitive_email(
 support_agent = Agent(
     name="SupportPilot",
     instructions="You handle customer support. Official email: support@example.com.",
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     output_guardrails=[forbid_sensitive_email],
     validation_attempts=1,
 )

--- a/docs/additional-features/observability.mdx
+++ b/docs/additional-features/observability.mdx
@@ -48,10 +48,10 @@ Agency Swarm supports three main observability approaches:
   <Card title="OpenAI Tracing" icon="chart-line" href="#openai-tracing">
     Built-in tracing using OpenAI's native tools
   </Card>
-  <Card title="Langfuse" icon="gauge-high" href="#langfuse-tracing">
+  <Card title="Langfuse" icon="gauge-high" href="#langfuse">
     Advanced tracing and debugging platform
   </Card>
-  <Card title="AgentOps" icon="database" href="#agentops-tracing">
+  <Card title="AgentOps" icon="database" href="#agentops">
     Specialized agent monitoring and analytics
   </Card>
 </CardGroup>

--- a/docs/additional-features/voice-agents/deployment.mdx
+++ b/docs/additional-features/voice-agents/deployment.mdx
@@ -102,5 +102,5 @@ Deployment checklist:
 For a lower-level implementation (custom playback tracking, fine-grained buffering), see the [Twilio demo README](https://github.com/VRSEN/agency-swarm/blob/main/src/agency_swarm/ui/demos/realtime/twilio/README.md).
 
 <Note>
-Store your Twilio account SID and auth token in a local `.env`, export them before launching the demo, and keep `OPENAI_API_KEY` alongside them. The packaged server reads standard environment variables; no credentials live in source control.
+Set `OPENAI_API_KEY` or `XAI_API_KEY` for the realtime provider you selected. You configure the phone number and webhook in the Twilio Console, so this bridge does not read a Twilio account SID or auth token. Keep provider keys out of source control.
 </Note>

--- a/docs/additional-features/voice-agents/overview.mdx
+++ b/docs/additional-features/voice-agents/overview.mdx
@@ -15,12 +15,12 @@ Agency Swarm reuses your existing `Agent` definitions for voice. This page shows
 ## Prerequisites
 
 - Access to a supported realtime provider:
-  - OpenAI (`gpt-realtime-2` by default, or the cheaper `gpt-realtime-mini`)
-  - xAI (`grok-voice-think-fast-1.0`; legacy `grok-voice-fast-1.0` remains available for older deployments)
-- The standard install—no extras needed:
+  - OpenAI (`gpt-realtime-2` is the Agency Swarm default; see [OpenAI's realtime model catalog](https://developers.openai.com/api/docs/models/all#realtime-and-audio) for other models and current pricing)
+  - xAI (`grok-voice-think-fast-1.0` is the Agency Swarm default; see [xAI's Speech to Speech guide](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech#model-selection) for current model availability)
+- The voice extra:
 
 ```bash
-pip install agency-swarm
+pip install "agency-swarm[voice]"
 ```
 
 ## Define your agent (same API)

--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -111,7 +111,7 @@ from agency_swarm import Agent
 agent = Agent(
     name="SupportAgent",
     instructions="You are helpful.",
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     conversation_starters=["Support: I need help with billing"],
     cache_conversation_starters=True,
 )

--- a/docs/core-framework/agents/advanced-configuration.mdx
+++ b/docs/core-framework/agents/advanced-configuration.mdx
@@ -45,7 +45,7 @@ Set `include_web_search_sources=False` to skip this.
 
 ### System Reminders
 
-Use `system_reminders` when you want the agent to see a short reminder before model calls, without writing hooks.
+Use `system_reminders` when you want the agent to see a short reminder at a supported trigger, without writing hooks.
 
 ```python
 from agency_swarm import Agent
@@ -57,7 +57,7 @@ agent = Agent(
 )
 ```
 
-This reminder is added only to the model input. It is **not saved** in the thread history.
+A plain string or callable is added before the first model call of each top-level user turn. It appears only in the model input and is **not saved** in the thread history.
 
 For tool-heavy agents, add a checkpoint reminder:
 

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -57,8 +57,8 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Name *(required)* | `name` | The name of the agent. |
 | Instructions *(optional)* | `instructions` | The instructions for the agent. Will be used as the "system prompt" when this agent is invoked. Can be a string or a function that dynamically generates instructions. Default: `None` |
 | Description *(optional)* | `description` | A description of the agent's role or purpose, used to convey agent's role to other agents. Default: `None` |
-| Model *(optional)* | `model` | The model implementation to use when invoking the LLM. If not provided, uses agents SDK default model. Current default model can be [found here](https://openai.github.io/openai-agents-python/models). Default: `None` |
-| Model Settings *(optional)* | `model_settings` | Configures model-specific tuning parameters (e.g. temperature, top_p). See [ModelSettings documentation](https://openai.github.io/openai-agents-python/ref/model_settings/) for details. Default: SDK defaults with Agency Swarm applying `truncation="auto"` when unset. |
+| Model *(optional)* | `model` | The model implementation to use when invoking the LLM. Omitting it or passing `model=None` selects Agency Swarm's `gpt-5.6-luna` default. To keep a different model, pass its name or model object explicitly, such as `model="gpt-5.4-mini"`. |
+| Model Settings *(optional)* | `model_settings` | Configures model-specific tuning parameters (e.g. temperature, top_p). See [ModelSettings documentation](https://openai.github.io/openai-agents-python/ref/model_settings/) for details. Agency Swarm applies the model-specific SDK defaults, then fills unset fields with `truncation="auto"` and `include_usage=True`. The default `gpt-5.6-luna` reasoning effort is `"none"`. |
 | Tools *(optional)* | `tools` | A list of tools that the agent can use. Default: `[]` |
 | Tools Folder *(optional)* | `tools_folder` | Path to a directory containing tool definitions. Tools are automatically discovered and loaded from this directory. Supports both BaseTool subclasses and modern FunctionTool instances. Default: `None` |
 | Files Folder *(optional)* | `files_folder` | Path to a local folder for managing files associated with this agent. If the folder name follows the pattern `*_vs_<vector_store_id>`, files uploaded via `upload_file` will also be added to the specified OpenAI Vector Store, and a `FileSearchTool` will be automatically added. Default: `None` |
@@ -76,7 +76,7 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Schemas Folder *(optional)* | `schemas_folder` | Path to a directory containing openapi schema files in .json format. Schemas are automatically converted into FunctionTools. Default: `None` |
 | Validation Attempts *(optional)* | `validation_attempts` | Number of retries when an output guardrail trips. Default: `1` |
 | Raise Input Guardrail Error *(optional)* | `raise_input_guardrail_error` | If set to `True`, input guardrail errors raise an exception. If set to `False`, the guardrail message is returned as the agent's response. Default: `False` |
-| System Reminders *(optional)* | `system_reminders` | Transient reminders shown to the model before model calls. Start with `system_reminders="..."`; use `EveryNToolCalls(...)` for tool checkpoints. Default: `None` |
+| System Reminders *(optional)* | `system_reminders` | Transient reminders shown to the model at supported triggers. A string runs before the first model call of each top-level user turn; use `EveryNToolCalls(...)` for tool checkpoints. Default: `None` |
 | Handoff Reminder *(optional)* | `handoff_reminder` | Replaces the default handoff reminder system message with a given string. Default: "Transfer completed. You are [recipient_agent_name]. Please continue the task." |
 | Include Search Results *(optional)* | `include_search_results` | Include search results in FileSearchTool output for citation extraction. Default: `False` |
 | Include Web Search Sources *(optional)* | `include_web_search_sources` | Include source URLs from WebSearchTool calls. Default: `True` |
@@ -94,7 +94,7 @@ Please note that agent handoff parameters are not supported. To enable handoffs,
 </Note>
 
 <Warning>
-To start receiving reasoning events for reasoning models, you need to explicitly specify `reasoning` parameter inside `ModelSettings`
+Agency Swarm runs the default `gpt-5.6-luna` model with reasoning effort set to `"none"`. To enable reasoning and receive reasoning events, pass `reasoning=Reasoning(effort="low")` (or another supported effort) inside `ModelSettings`.
 </Warning>
 
 ## Agent Template

--- a/docs/core-framework/agents/overview.mdx
+++ b/docs/core-framework/agents/overview.mdx
@@ -57,7 +57,7 @@ In agency swarm, to create an agent, you need to instantiate the `Agent` class.
 | Name *(required)* | `name` | The name of the agent. |
 | Instructions *(optional)* | `instructions` | The instructions for the agent. Will be used as the "system prompt" when this agent is invoked. Can be a string or a function that dynamically generates instructions. Default: `None` |
 | Description *(optional)* | `description` | A description of the agent's role or purpose, used to convey agent's role to other agents. Default: `None` |
-| Model *(optional)* | `model` | The model implementation to use when invoking the LLM. Omitting it or passing `model=None` selects Agency Swarm's `gpt-5.6-luna` default. To keep a different model, pass its name or model object explicitly, such as `model="gpt-5.4-mini"`. |
+| Model *(optional)* | `model` | The model implementation to use when invoking the LLM. Omitting it or passing `model=None` selects Agency Swarm's `gpt-5.6-luna` default. To use a different supported model, pass its name or model object explicitly. |
 | Model Settings *(optional)* | `model_settings` | Configures model-specific tuning parameters (e.g. temperature, top_p). See [ModelSettings documentation](https://openai.github.io/openai-agents-python/ref/model_settings/) for details. Agency Swarm applies the model-specific SDK defaults, then fills unset fields with `truncation="auto"` and `include_usage=True`. The default `gpt-5.6-luna` reasoning effort is `"none"`. |
 | Tools *(optional)* | `tools` | A list of tools that the agent can use. Default: `[]` |
 | Tools Folder *(optional)* | `tools_folder` | Path to a directory containing tool definitions. Tools are automatically discovered and loaded from this directory. Supports both BaseTool subclasses and modern FunctionTool instances. Default: `None` |
@@ -107,7 +107,7 @@ from agency_swarm import Agent, ModelSettings, Reasoning
 example_agent = Agent(
     name="agent_name",
     description="agent_description",
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
     instructions="./instructions.md",
     files_folder="./files",
     tools_folder="./tools",

--- a/docs/core-framework/third-party-agents/openclaw-agent.mdx
+++ b/docs/core-framework/third-party-agents/openclaw-agent.mdx
@@ -23,7 +23,7 @@ coordinator = Agent(
     name="Coordinator",
     description="Routes work to the right specialist.",
     instructions="Delegate OpenClaw-specific tasks to OpenClawWorker.",
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
 )
 
 openclaw_worker = OpenClawAgent(
@@ -146,7 +146,7 @@ Use OpenClaw plugins or MCP when you need to extend OpenClaw itself.
           name="Coordinator",
           description="Routes work to the OpenClaw worker.",
           instructions="Delegate OpenClaw-specific work to OpenClawWorker.",
-          model="gpt-5.4-mini",
+          model="gpt-5.6-luna",
       )
       openclaw_worker = OpenClawAgent(
           name="OpenClawWorker",

--- a/docs/core-framework/tools/custom-tools/step-by-step-guide.mdx
+++ b/docs/core-framework/tools/custom-tools/step-by-step-guide.mdx
@@ -251,7 +251,7 @@ if __name__ == "__main__":
         name="MathAgent",
         instructions="You are a helpful math assistant",
         tools=[calculator_tool],  # Pass function directly
-        model="gpt-5.4-mini"
+        model="gpt-5.6-luna"
     )
     ```
   </Step>

--- a/docs/core-framework/tools/mcp-integration.mdx
+++ b/docs/core-framework/tools/mcp-integration.mdx
@@ -160,7 +160,7 @@ local_agent = Agent(
     description="An agent that can use local MCP tools.",
     instructions="Use the available MCP tools to help users.",
     mcp_servers=[stdio_server],  # Local servers go here
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
 )
 
 # For hosted MCP servers, use tools parameter
@@ -169,7 +169,7 @@ hosted_agent = Agent(
     description="An agent that can use hosted MCP tools.",
     instructions="Use the available hosted MCP tools to help users.",
     tools=[hosted_tool],  # Hosted tools go here
-    model="gpt-5.4-mini",
+    model="gpt-5.6-luna",
 )
 ```
 </Accordion>

--- a/docs/core-framework/tools/mcp-integration.mdx
+++ b/docs/core-framework/tools/mcp-integration.mdx
@@ -103,7 +103,7 @@ Server specified in the HostedMCPTool should be publicly accessible for the agen
 </Note>
 
 <Note>
-If the remote MCP server is **OAuth-protected**, pass the user's OAuth access token via `tool_config.authorization` (not via headers). See [OAuth for MCP Servers](/core-framework/tools/mcp-oauth).
+If the remote MCP server is **OAuth-protected**, direct `HostedMCPTool` usage requires the user's access token in `tool_config.authorization`, not in headers. With `run_fastapi`, leave `authorization` empty and wrap the protected tool with `enable_hosted_mcp_tool_oauth(...)` so Agency Swarm obtains and injects the token. See [OAuth for MCP Servers](/core-framework/tools/mcp-oauth).
 </Note>
 </Accordion>
 

--- a/docs/core-framework/tools/mcp-oauth.mdx
+++ b/docs/core-framework/tools/mcp-oauth.mdx
@@ -8,7 +8,7 @@ icon: "key"
 
 This feature lets **your users** connect their personal accounts to AI agents you build. When a user wants your agent to access their Gmail, GitHub, or Notion, they simply click "Authorize" in their browser—just like signing into any app. The agent then stores their credentials and can access their data on their behalf.
 
-**Example:** You build a productivity agent. A user asks it to "summarize my unread emails." The agent prompts the user to authorize Gmail access. They click approve, and the agent can now read their inbox. Next time, it just works—no login required until the token expires.
+**Example:** You build a productivity agent. A user asks it to "summarize my unread emails." The agent prompts the user to authorize Gmail access. They click approve, and the agent can now read their inbox. Next time, the stored token is reused or refreshed automatically. The user signs in again only when the token can no longer be refreshed.
 
 ## Why use this?
 
@@ -27,7 +27,7 @@ Use this when your agency runs on a server and users authenticate from a web/mob
 - **Mode:** `saas_stream`
 - **Hosted MCP** (Notion): Configure `MCPServerOAuth(url=..., name=...)` and deploy your agency.
 - **Self-hosted MCP** (GitHub/Google): Run your OAuth-enabled MCP server + deploy your agency.
-- **HostedMCPTool (remote MCP)**: If you use `HostedMCPTool`, OAuth tokens must be provided via `tool_config.authorization`. In FastAPI, wrap only the OAuth-protected hosted tool with `enable_hosted_mcp_tool_oauth(...)`. Agency Swarm creates an in-memory callback-state registry by default. For multiple workers, an external `oauth_registry` shares callback state only; configure `oauth_token_path` on shared persistent storage as well, or use sticky routing or a single worker. Agency Swarm surfaces the auth URL via `event: oauth_redirect` and injects the access token once authorized. Public hosted MCP servers should stay unwrapped.
+- **HostedMCPTool (remote MCP)**: Outside FastAPI, provide the OAuth token through `tool_config.authorization`. In FastAPI, leave `authorization` empty and wrap only the OAuth-protected hosted tool with `enable_hosted_mcp_tool_oauth(...)`. Agency Swarm creates an in-memory callback-state registry by default. For multiple workers, an external `oauth_registry` shares callback state only; configure `oauth_token_path` on shared persistent storage as well, or use sticky routing or a single worker. Agency Swarm surfaces the auth URL via `event: oauth_redirect` and injects the access token once authorized. Public hosted MCP servers should stay unwrapped.
 - **Deferred auth trigger (all modes):** Startup never forces OAuth discovery. The model gets an `authenticate_mcp_server(server_name)` tool and OAuth starts only when that tool is invoked for a specific authenticated MCP server.
 - **Tool parameter contract:** `server_name` is constrained to the configured authenticated MCP server names for that agent.
 - **Streaming is required**: OAuth authorization is delivered via `event: oauth_redirect`, so use `POST /{agency}/get_response_stream`. The non-streaming `POST /{agency}/get_response` endpoint is not compatible with OAuth-enabled MCP servers.
@@ -85,7 +85,7 @@ agency.get_response_sync("List my repositories")  # Local run: browser opens for
 ```
 
 <Note>
-First run opens the browser for consent. Tokens are cached under `~/.agency-swarm/mcp-tokens/` and reused automatically. Users only re-authorize when tokens expire.
+The first run opens the browser for consent. Tokens are cached under `~/.agency-swarm/mcp-tokens/`, reused, and refreshed automatically. Users re-authorize only when refresh is no longer possible.
 </Note>
 
 ## OAuth flow at a glance
@@ -100,7 +100,7 @@ sequenceDiagram
 
     User->>Agent: Prompt needs OAuth data
     Agent->>Agent: Load cached tokens
-    alt Missing/expired
+    alt Missing or no longer refreshable
         Agent->>Browser: Open auth_url
         Browser->>Provider: User approves scopes
         Provider-->>Browser: Redirect with code/state

--- a/docs/platform/marketplace/onboarding.mdx
+++ b/docs/platform/marketplace/onboarding.mdx
@@ -189,7 +189,7 @@ All that the user who wants to deploy your agency needs to do is simply fill out
     		# ...
         
         # Literal field - creates a dropdown with predefined options
-    		 model: Literal["gpt-4o", "gpt-5.4-mini"] = Field(
+        model: Literal["gpt-4o", "gpt-5.6-luna"] = Field(
             ...,
             description="Select the AI model to use for the agent."
         )

--- a/docs/references/api.mdx
+++ b/docs/references/api.mdx
@@ -305,9 +305,9 @@ class Agent(BaseAgent[MasterContext]):
             include_web_search_sources (bool): Include source URLs for WebSearchTool output (default True)
             validation_attempts (int): Number of retries when output guardrails trigger (default 1)
             raise_input_guardrail_error (bool): Controls input guardrail behavior—False enables non-strict mode (guidance as assistant message), True enables strict mode (raises exceptions). Default: False
-            system_reminders (str | Callable | SystemReminder | list[str | Callable | SystemReminder] | None): Transient reminders shown to the model before model calls
+            system_reminders (str | Callable | SystemReminder | list[str | Callable | SystemReminder] | None): Transient reminders injected before model calls. Plain strings and callables run before the first model call of each top-level user turn.
             handoff_reminder (str | None): Custom reminder text when handing off to another agent
-            model (str | Model | None): Model identifier; defaults to agents SDK configuration
+            model (str | Model | None): Model identifier. Omitting it or passing None selects "gpt-5.6-luna"; pass another model name or Model instance explicitly to use it.
             model_settings (ModelSettings | None): Model configuration overrides
             tools (list[Tool] | None): Explicit tool instances to register
             mcp_servers (list[MCPServer] | None): Model Context Protocol servers to attach
@@ -334,7 +334,7 @@ class Agent(BaseAgent[MasterContext]):
 - **`include_web_search_sources`** (bool): Whether WebSearchTool responses include source URLs
 - **`validation_attempts`** (int): Retry count for output guardrail enforcement
 - **`raise_input_guardrail_error`** (bool): Controls input guardrail mode—False for non-strict (guidance as assistant), True for strict (raises exceptions).
-- **`system_reminders`** (list[SystemReminder]): Transient reminders shown to the model before model calls
+- **`system_reminders`** (list[SystemReminder]): Transient reminders injected before model calls. Plain strings and callables run before the first model call of each top-level user turn.
 - **`handoff_reminder`** (str | None): Custom reminder appended to handoff prompts
 - **`tool_concurrency_manager`** (ToolConcurrencyManager): Coordinates concurrent tool execution
 - **`voice`** (str | None): Realtime session voice used when this agent is the entry agent. A session keeps one voice from start to finish, so a voice set on any other agent is not heard.

--- a/docs/welcome/getting-started/from-scratch.mdx
+++ b/docs/welcome/getting-started/from-scratch.mdx
@@ -143,7 +143,7 @@ Use this guide when you need to build everything manually. Otherwise, start from
         description="Responsible for executing tasks.",
         instructions="./instructions.md",
         tools=[my_custom_tool, MyCustomTool],  # Import tools directly
-        model="gpt-5.4-mini",
+        model="gpt-5.6-luna",
         model_settings=ModelSettings(
             temperature=0.3,
             max_tokens=25000,
@@ -162,7 +162,7 @@ Use this guide when you need to build everything manually. Otherwise, start from
       developer = Agent(
           name="Developer",
           description="Responsible for executing tasks.",
-          model="gpt-5.4-mini",
+          model="gpt-5.6-luna",
           instructions="./instructions.md",
           tools_folder="./tools",
           files_folder="./files",


### PR DESCRIPTION
### Summary

This pull request updates the public docs to match the shipped default model, voice, MCP OAuth, and system reminder behavior.

- Documents `gpt-5.6-luna` as the Agency Swarm default, including `model=None` normalization, explicit model overrides, and default reasoning effort `"none"`.
- Refreshes voice setup and provider model guidance without embedding token prices.
- Clarifies OAuth token refresh and hosted MCP token injection.
- States the exact system reminder trigger and persistence behavior.
- Sweeps remaining `gpt-5.4-mini` references from README and docs examples, using `gpt-5.6-luna` or model-neutral wording.

### Test plan

- `make format`
- `make lint`
- Parsed `docs/docs.json`
- Checked added links and confirmed the diff contains only docs files

The local Mintlify preview was not started because the machine resource safety check blocked new preview processes.

### Issue number

N/A

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [ ] I've made sure tests pass
