### PR TITLE
fix: preserve MCP OAuth errors and configured scopes

### DIFF
--- a/src/agency_swarm/mcp/oauth.py
+++ b/src/agency_swarm/mcp/oauth.py
@@ -40,6 +40,7 @@ from .oauth_flow import (
     default_callback_handler,
     default_redirect_handler,
 )
+from .oauth_provider import ErrorCapturingOAuthClientProvider
 from .oauth_user import build_oauth_cache_segment, build_oauth_user_segment
 
 # Contextvar for per-user token isolation
@@ -461,7 +462,7 @@ async def create_oauth_provider(
 
         callback_handler = _wrapped_callback_handler
 
-    provider = OAuthClientProvider(
+    provider = ErrorCapturingOAuthClientProvider(
         server_url=server.url,
         client_metadata=client_metadata,
         storage=storage,

--- a/src/agency_swarm/mcp/oauth_client.py
+++ b/src/agency_swarm/mcp/oauth_client.py
@@ -34,6 +34,7 @@ from .oauth import (
     OAuthRedirectHandler,
     create_oauth_provider,
 )
+from .oauth_provider import ErrorCapturingOAuthClientProvider
 
 logger = logging.getLogger(__name__)
 
@@ -180,9 +181,18 @@ class MCPServerOAuthClient(MCPServer):
             self._authenticated = True
             logger.info(f"Successfully authenticated to OAuth MCP server: {self.name}")
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
+            flow_error = (
+                self._oauth_provider.pop_last_flow_error()
+                if isinstance(self._oauth_provider, ErrorCapturingOAuthClientProvider)
+                else None
+            )
             logger.info("OAuth MCP client connect cancelled: %s", self.name)
             # Ensure we close any partially-opened async context managers even when cancelled.
+            if flow_error is not None:
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self.cleanup()
+                raise flow_error from exc
             await self.cleanup()
             raise
         except Exception:
@@ -346,6 +356,7 @@ class MCPServerOAuthClient(MCPServer):
         cleanup gracefully since connections may have been made from different tasks.
         """
         logger.info(f"Cleaning up OAuth MCP client: {self.name}")
+        cancellation: asyncio.CancelledError | None = None
 
         # Cleanup discovery session
         await self._cleanup_discovery()
@@ -354,6 +365,8 @@ class MCPServerOAuthClient(MCPServer):
         if self._session_context and self._session_entered:
             try:
                 await self._session_context.__aexit__(None, None, None)
+            except asyncio.CancelledError as exc:
+                cancellation = exc
             except RuntimeError as e:
                 if "cancel scope" in str(e).lower() or "different task" in str(e).lower():
                     logger.debug(f"Session cleanup skipped (different task) for {self.name}")
@@ -371,6 +384,8 @@ class MCPServerOAuthClient(MCPServer):
         if self._transport_context and self._transport_entered:
             try:
                 await self._transport_context.__aexit__(None, None, None)
+            except asyncio.CancelledError as exc:
+                cancellation = cancellation or exc
             except RuntimeError as e:
                 if "cancel scope" in str(e).lower() or "different task" in str(e).lower():
                     logger.debug(f"Transport cleanup skipped (different task) for {self.name}")
@@ -383,11 +398,17 @@ class MCPServerOAuthClient(MCPServer):
 
         self._transport_context = None
         if self._http_client is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await self._http_client.aclose()
+            except asyncio.CancelledError as exc:
+                cancellation = cancellation or exc
+            except Exception:
+                logger.exception(f"Error closing HTTP client for {self.name}")
         self._http_client = None
 
         logger.info(f"Cleaned up OAuth MCP client: {self.name}")
+        if cancellation is not None:
+            raise cancellation
 
     async def __aenter__(self):
         """Async context manager entry."""

--- a/src/agency_swarm/mcp/oauth_config.py
+++ b/src/agency_swarm/mcp/oauth_config.py
@@ -3,7 +3,7 @@
 import json
 import os
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
 from urllib.parse import urlsplit
@@ -20,6 +20,7 @@ from .oauth import (
     OAuthRedirectHandler,
     get_default_cache_dir,
 )
+from .oauth_provider import preserve_configured_scopes
 from .oauth_user import build_oauth_cache_segment
 
 
@@ -32,7 +33,7 @@ class MCPServerOAuth:
         name: Unique identifier for this server
         client_id: OAuth client ID (reads from env if None and use_env_credentials=True)
         client_secret: OAuth client secret (reads from env if None and use_env_credentials=True)
-        scopes: List of OAuth scopes to request
+        scopes: OAuth scopes to request. When omitted, discovery supplies the default.
         redirect_uri: OAuth redirect URI for callback
         cache_dir: Directory for token storage (uses default if None)
         storage: Custom token storage implementation (overrides cache_dir)
@@ -51,7 +52,7 @@ class MCPServerOAuth:
     name: str
     client_id: str | None = None
     client_secret: str | None = None
-    scopes: list[str] = field(default_factory=lambda: ["user"])
+    scopes: list[str] | None = None
     redirect_uri: str | None = None
     cache_dir: Path | None = None
     storage: TokenStorage | None = None
@@ -112,12 +113,12 @@ class MCPServerOAuth:
                 redirect_uris=[AnyUrl(self.get_redirect_uri())],
                 grant_types=["authorization_code", "refresh_token"],
                 response_types=["code"],
-                scope=" ".join(self.scopes),
+                scope=" ".join(self.scopes) if self.scopes is not None else None,
             )
 
         if self.get_client_secret() and metadata.token_endpoint_auth_method is None:
-            return metadata.model_copy(update={"token_endpoint_auth_method": "client_secret_basic"})
-        return metadata
+            metadata = metadata.model_copy(update={"token_endpoint_auth_method": "client_secret_basic"})
+        return preserve_configured_scopes(metadata, self.scopes)
 
     def get_client_id_optional(self) -> str | None:
         """Return the resolved client_id without raising."""

--- a/src/agency_swarm/mcp/oauth_provider.py
+++ b/src/agency_swarm/mcp/oauth_provider.py
@@ -1,0 +1,94 @@
+"""Agency Swarm adaptations for the MCP SDK OAuth provider."""
+
+import contextlib
+import logging
+from collections.abc import AsyncGenerator
+
+import httpx
+from mcp.client.auth import OAuthClientProvider
+from mcp.shared.auth import OAuthClientMetadata
+from pydantic import PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+
+class _ConfiguredScopeMetadata(OAuthClientMetadata):
+    """Keep an explicitly configured scope when the MCP SDK applies discovery."""
+
+    _scope_is_authoritative: bool = PrivateAttr(default=False)
+    _configured_scope: str | None = PrivateAttr(default=None)
+    _configured_scope_names: frozenset[str] = PrivateAttr(default_factory=frozenset)
+    _warned_advertisements: set[str] = PrivateAttr(default_factory=set)
+
+    def make_scope_authoritative(self, scope: str | None) -> None:
+        """Lock this metadata to the configured scope string."""
+        self._configured_scope = scope
+        self._configured_scope_names = frozenset(scope.split()) if scope else frozenset()
+        self._scope_is_authoritative = True
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "scope" and self._scope_is_authoritative:
+            advertised_scope = value if isinstance(value, str) else None
+            if advertised_scope and advertised_scope not in self._warned_advertisements:
+                self._warned_advertisements.add(advertised_scope)
+                advertised_names = frozenset(advertised_scope.split())
+                unsupported = sorted(self._configured_scope_names - advertised_names)
+                if unsupported:
+                    logger.warning(
+                        "Configured OAuth scope(s) %s were not advertised for this OAuth request; "
+                        "keeping explicit scope(s) %s instead of discovered scope(s) %s.",
+                        unsupported,
+                        sorted(self._configured_scope_names),
+                        sorted(advertised_names),
+                    )
+            value = self._configured_scope
+        super().__setattr__(name, value)
+
+
+def preserve_configured_scopes(
+    metadata: OAuthClientMetadata,
+    configured_scopes: list[str] | None,
+) -> OAuthClientMetadata:
+    """Make configured scopes authoritative while leaving omitted scopes discoverable."""
+    if configured_scopes is None and metadata.scope is None:
+        return metadata
+
+    scope = " ".join(configured_scopes) if configured_scopes is not None else metadata.scope
+    values = metadata.model_dump(mode="python")
+    values["scope"] = scope
+    protected_metadata = _ConfiguredScopeMetadata.model_validate(values)
+    protected_metadata.make_scope_authoritative(scope)
+    return protected_metadata
+
+
+class ErrorCapturingOAuthClientProvider(OAuthClientProvider):
+    """Remember OAuth flow errors that the MCP HTTP writer logs and swallows."""
+
+    _last_flow_error: Exception | None = None
+
+    def pop_last_flow_error(self) -> Exception | None:
+        """Return and clear the last OAuth flow error."""
+        error = self._last_flow_error
+        self._last_flow_error = None
+        return error
+
+    async def async_auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Proxy the SDK flow while retaining its original exception."""
+        self._last_flow_error = None
+        flow = super().async_auth_flow(request)
+        try:
+            next_request = await anext(flow)
+            while True:
+                response = yield next_request
+                next_request = await flow.asend(response)
+        except StopAsyncIteration:
+            return
+        except Exception as exc:
+            self._last_flow_error = exc
+            raise
+        finally:
+            with contextlib.suppress(Exception):
+                await flow.aclose()

--- a/src/agency_swarm/mcp/oauth_storage_hooks.py
+++ b/src/agency_swarm/mcp/oauth_storage_hooks.py
@@ -21,15 +21,25 @@ class OAuthStorageHooks(RunHooks):  # type: ignore[type-arg]
     Sets the user_id contextvar from MasterContext at the start of each run,
     enabling per-user token isolation in FileTokenStorage.
 
-    Usage:
-        from agency_swarm import Agency
-        from agency_swarm.mcp.oauth import OAuthStorageHooks
+    Agency installs this hook automatically when an agent has an OAuth MCP server:
 
+        from agency_swarm import Agency, Agent
+        from agency_swarm.mcp import MCPServerOAuth
+
+        agent = Agent(
+            name="OAuth Agent",
+            instructions="Use the MCP tools.",
+            mcp_servers=[
+                MCPServerOAuth(
+                    url="https://example.com/mcp",
+                    name="example",
+                )
+            ],
+        )
         agency = Agency(
-            [agent],
+            agent,
             oauth_token_path="./data",
             user_context={"user_id": "user_123"},
-            hooks=[OAuthStorageHooks()],
         )
     """
 

--- a/tests/integration/mcp/test_oauth_end_to_end.py
+++ b/tests/integration/mcp/test_oauth_end_to_end.py
@@ -1,0 +1,373 @@
+"""End-to-end regression tests for MCP OAuth discovery and persistence."""
+
+import asyncio
+import inspect
+import json
+import logging
+import threading
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+import httpx
+import pytest
+from agents.tool_context import ToolContext
+
+from agency_swarm import Agency, Agent
+from agency_swarm.mcp.oauth import (
+    FileTokenStorage,
+    MCPServerOAuth,
+    OAuthCallbackHandler,
+    OAuthRedirectHandler,
+    OAuthStorageHooks,
+)
+from agency_swarm.mcp.oauth_client import MCPServerOAuthClient
+from agency_swarm.tools.mcp_manager import default_mcp_manager
+
+
+@dataclass
+class _OAuthServerState:
+    registration_scopes: list[str | None] = field(default_factory=list)
+    authorization_scopes: list[str | None] = field(default_factory=list)
+
+
+class _OAuthTestServer(HTTPServer):
+    state: _OAuthServerState
+    base_url: str
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _OAuthRequestHandler)
+        host, port = cast("tuple[str, int]", self.server_address)
+        self.base_url = f"http://{host}:{port}"
+        self.state = _OAuthServerState()
+
+
+class _OAuthRequestHandler(BaseHTTPRequestHandler):
+    server: _OAuthTestServer
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Keep the regression test output quiet."""
+
+    def _read_json(self) -> dict[str, object]:
+        length = int(self.headers.get("Content-Length", "0"))
+        return cast("dict[str, object]", json.loads(self.rfile.read(length)))
+
+    def _read_form(self) -> dict[str, str]:
+        length = int(self.headers.get("Content-Length", "0"))
+        values = parse_qs(self.rfile.read(length).decode())
+        return {key: items[0] for key, items in values.items()}
+
+    def _send_json(self, status: int, payload: dict[str, object]) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _send_unauthorized(self) -> None:
+        metadata_url = f"{self.server.base_url}/.well-known/oauth-protected-resource/mcp"
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", f'Bearer resource_metadata="{metadata_url}"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path == "/.well-known/oauth-protected-resource/mcp":
+            self._send_json(
+                200,
+                {
+                    "resource": f"{self.server.base_url}/mcp",
+                    "authorization_servers": [self.server.base_url],
+                    "scopes_supported": ["treasure.read"],
+                },
+            )
+            return
+        if parsed.path == "/.well-known/oauth-authorization-server":
+            self._send_json(
+                200,
+                {
+                    "issuer": self.server.base_url,
+                    "authorization_endpoint": f"{self.server.base_url}/authorize",
+                    "token_endpoint": f"{self.server.base_url}/token",
+                    "registration_endpoint": f"{self.server.base_url}/register",
+                    "response_types_supported": ["code"],
+                    "grant_types_supported": ["authorization_code", "refresh_token"],
+                    "code_challenge_methods_supported": ["S256"],
+                    "token_endpoint_auth_methods_supported": ["none"],
+                    "scopes_supported": ["treasure.read", "user"],
+                },
+            )
+            return
+        if parsed.path == "/authorize":
+            query = parse_qs(parsed.query)
+            scope = query.get("scope", [None])[0]
+            state = query["state"][0]
+            redirect_uri = query["redirect_uri"][0]
+            self.server.state.authorization_scopes.append(scope)
+            callback_query = urlencode({"code": "test-code", "state": state})
+            self.send_response(302)
+            self.send_header("Location", f"{redirect_uri}?{callback_query}")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if parsed.path == "/mcp":
+            self._send_empty(405)
+            return
+        self._send_empty(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlsplit(self.path)
+        if parsed.path == "/register":
+            registration = self._read_json()
+            scope = registration.get("scope")
+            self.server.state.registration_scopes.append(scope if isinstance(scope, str) else None)
+            registration.update(
+                {
+                    "client_id": "test-client",
+                    "client_id_issued_at": 1,
+                    "token_endpoint_auth_method": "none",
+                }
+            )
+            self._send_json(201, registration)
+            return
+        if parsed.path == "/token":
+            token_request = self._read_form()
+            if token_request.get("code") != "test-code":
+                self._send_json(400, {"error": "invalid_grant"})
+                return
+            self._send_json(
+                200,
+                {
+                    "access_token": "test-access-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": self.server.state.authorization_scopes[-1],
+                },
+            )
+            return
+        if parsed.path != "/mcp":
+            self._send_empty(404)
+            return
+        if self.headers.get("Authorization") != "Bearer test-access-token":
+            self._send_unauthorized()
+            return
+
+        request = self._read_json()
+        request_id = request.get("id")
+        method = request.get("method")
+        if request_id is None:
+            self._send_empty(202)
+            return
+        if method == "initialize":
+            self._send_json(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "oauth-test-server", "version": "1.0"},
+                    },
+                },
+            )
+            return
+        if method == "tools/list":
+            self._send_json(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "open_treasure",
+                                "description": "Open the test treasure.",
+                                "inputSchema": {"type": "object", "properties": {}},
+                            }
+                        ]
+                    },
+                },
+            )
+            return
+        self._send_json(
+            200,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": "Method not found"},
+            },
+        )
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._send_empty(204)
+
+
+@pytest.fixture
+def oauth_server() -> Iterator[_OAuthTestServer]:
+    server = _OAuthTestServer()
+    thread = threading.Thread(target=server.serve_forever, name="oauth-regression-server", daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+
+def _headless_handlers(
+    server: _OAuthTestServer,
+) -> tuple[OAuthRedirectHandler, OAuthCallbackHandler]:
+    callback_url: str | None = None
+
+    async def redirect_handler(auth_url: str) -> None:
+        nonlocal callback_url
+        async with httpx.AsyncClient(follow_redirects=False) as client:
+            response = await client.get(auth_url)
+        if not response.is_redirect:
+            response.raise_for_status()
+        callback_url = response.headers["Location"]
+
+    async def callback_handler() -> tuple[str, str | None]:
+        if callback_url is None:
+            raise RuntimeError("Authorization redirect did not produce a callback URL")
+        query = parse_qs(urlsplit(callback_url).query)
+        return query["code"][0], query.get("state", [None])[0]
+
+    return redirect_handler, callback_handler
+
+
+def _oauth_config(
+    server: _OAuthTestServer,
+    cache_dir: Path,
+    *,
+    scopes: list[str] | None,
+) -> MCPServerOAuth:
+    redirect_handler, callback_handler = _headless_handlers(server)
+    return MCPServerOAuth(
+        url=f"{server.base_url}/mcp",
+        name="treasury",
+        scopes=scopes,
+        redirect_uri="http://127.0.0.1/callback",
+        cache_dir=cache_dir,
+        use_env_credentials=False,
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
+    )
+
+
+@asynccontextmanager
+async def _connected_client(config: MCPServerOAuth) -> AsyncIterator[MCPServerOAuthClient]:
+    client = MCPServerOAuthClient(config)
+    try:
+        tools = await client.list_tools()
+        assert [tool.name for tool in tools] == ["open_treasure"]
+        yield client
+    finally:
+        await client.cleanup()
+
+
+def test_documented_agency_oauth_wiring_runs(tmp_path: Path) -> None:
+    """The docstring form should use Agency's automatic OAuth storage hook."""
+    docstring = inspect.getdoc(OAuthStorageHooks)
+    assert docstring is not None
+    assert "hooks=[" not in docstring
+
+    agent = Agent(
+        name="OAuthAgent",
+        instructions="Use OAuth MCP tools.",
+        mcp_servers=[MCPServerOAuth(url="http://127.0.0.1:8001/mcp", name="treasury")],
+    )
+    agency = Agency(
+        agent,
+        oauth_token_path=str(tmp_path),
+        user_context={"user_id": "user_123"},
+    )
+
+    assert agency.default_run_hooks is not None
+
+
+@pytest.mark.asyncio
+async def test_token_storage_error_survives_agent_oauth_activation(
+    oauth_server: _OAuthTestServer,
+    tmp_path: Path,
+) -> None:
+    """The agent result should name the token-file failure, not a transport cancellation."""
+    config = _oauth_config(oauth_server, tmp_path, scopes=["user"])
+    storage = FileTokenStorage(
+        cache_dir=tmp_path,
+        server_name=config.name,
+        server_url=config.url,
+        client_identity=config.get_client_identity(),
+    )
+    token_path = tmp_path / "default" / storage.server_cache_segment / "tokens.json"
+    token_path.mkdir(parents=True)
+    agent = Agent(name="OAuthAgent", instructions="Use OAuth MCP tools.", mcp_servers=[config])
+    activation_tool = next(tool for tool in agent.tools if tool.name == "authenticate_mcp_server")
+    context = ToolContext(
+        context=SimpleNamespace(agent_runtime_state={}, user_context={}),
+        tool_name="authenticate_mcp_server",
+        tool_call_id="call-1",
+        tool_arguments="{}",
+    )
+
+    try:
+        result = await asyncio.wait_for(
+            activation_tool.on_invoke_tool(context, '{"server_name":"treasury"}'),
+            timeout=10,
+        )
+    finally:
+        await default_mcp_manager.shutdown()
+
+    assert "Failed to authenticate MCP server 'treasury'" in result
+    assert "Is a directory" in result
+    assert str(token_path) in result
+    assert "was cancelled" not in result
+
+
+@pytest.mark.asyncio
+async def test_explicit_scopes_reach_registration_and_authorization(
+    oauth_server: _OAuthTestServer,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Explicit scopes should stay authoritative when discovery advertises another scope."""
+    config = _oauth_config(oauth_server, tmp_path, scopes=["user"])
+
+    with caplog.at_level(logging.WARNING):
+        async with _connected_client(config):
+            pass
+
+    assert oauth_server.state.registration_scopes == ["user"]
+    assert oauth_server.state.authorization_scopes == ["user"]
+    assert "not advertised" in caplog.text
+    assert "treasure.read" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_discovery_scopes_are_default_when_scopes_are_omitted(
+    oauth_server: _OAuthTestServer,
+    tmp_path: Path,
+) -> None:
+    """Discovery should supply scopes only when the config leaves them unset."""
+    config = _oauth_config(oauth_server, tmp_path, scopes=None)
+
+    async with _connected_client(config):
+        pass
+
+    assert oauth_server.state.registration_scopes == ["treasure.read"]
+    assert oauth_server.state.authorization_scopes == ["treasure.read"]


### PR DESCRIPTION
### Summary

This pull request fixes the three MCP OAuth defects reported in #744:

- `OAuthStorageHooks` now documents the supported `Agency(agent, oauth_token_path=..., user_context=...)` form. `Agency` installs the storage hook automatically when an agent has an OAuth MCP server.
- The OAuth provider records flow exceptions before the MCP HTTP writer logs and swallows them. `connect()` now raises the saved storage error, so agent activation reports the token-file failure and path instead of a transport cancellation. Cleanup also finishes each owned context before cancellation is re-raised.
- Explicit `MCPServerOAuth(scopes=[...])` values stay authoritative in client registration and authorization requests. When scopes are omitted, discovery supplies the default. A warning names configured scopes that were not advertised for the OAuth request.

The regression tests run a local authorization server and a token-gated MCP server over real HTTP. They cover discovery, dynamic client registration, PKCE authorization, token exchange, authenticated tool listing, and a poisoned token path. Headless handlers replace the browser redirect and callback UI.

### Test plan

- `make format` and `make check`
- OAuth/MCP unit modules: 219 passed, 1 warning
- Full offline suite: 1,153 passed, 2 skipped, 5 warnings
- `tests/integration/mcp`: 26 passed, 1 warning
- `tests/integration/fastapi`: 196 passed, 8 warnings

### Issue number

Closes #744

### Checks

- [x] I've added new tests
- [x] I've updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [x] I've made sure tests pass
