### PR TITLE
fix: preserve corrected model prices during builds

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,16 +4,20 @@ Custom build hook for Agency Swarm.
 This hook downloads the latest pricing data from LiteLLM before building the package.
 
 The pricing file is:
-1. Downloaded automatically on `main` before each build (via this hook)
-2. Included in the package artifacts (via pyproject.toml)
-3. Committed to the repo so tests can run without network access
+1. Downloaded on `main` and detached release checkouts before each build
+2. Corrected with repository-owned overrides when LiteLLM is temporarily stale
+3. Included in the package artifacts (via pyproject.toml)
+4. Committed to the repo so tests can run without network access
 """
 
 import importlib
+import json
 import logging
 import subprocess
 import tempfile
+import urllib.request
 from pathlib import Path
+from typing import cast
 
 BuildHookInterface: type = object
 try:
@@ -26,17 +30,57 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 
-# URL to the LiteLLM pricing file
 PRICING_FILE_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
-
-# Target path relative to the project root (resolved via self.root in the hook)
 PRICING_FILE_RELATIVE_PATH = Path("src/agency_swarm/data/model_prices_and_context_window.json")
+DOWNLOAD_TIMEOUT_SECONDS = 30
 
+PricingData = dict[str, object]
+PriceOverride = dict[str, tuple[float, float]]
 
-def _warn_if_pricing_file_missing(pricing_file_path: Path) -> None:
-    if pricing_file_path.exists():
-        return
-    logger.error(f"Pricing file not found at {pricing_file_path}. Usage cost tracking may be unavailable at runtime.")
+# Each pair is (the known stale LiteLLM value, the current OpenAI value).
+# Source: https://developers.openai.com/api/docs/pricing (effective 2026-07-30).
+PRICE_OVERRIDES: dict[str, PriceOverride] = {
+    "gpt-5.6-luna": {
+        "cache_creation_input_token_cost": (1.25e-06, 2.5e-07),
+        "cache_creation_input_token_cost_above_272k_tokens": (2.5e-06, 5e-07),
+        "cache_creation_input_token_cost_flex": (6.25e-07, 1.25e-07),
+        "cache_creation_input_token_cost_priority": (2.5e-06, 5e-07),
+        "cache_read_input_token_cost": (1e-07, 2e-08),
+        "cache_read_input_token_cost_above_272k_tokens": (2e-07, 4e-08),
+        "cache_read_input_token_cost_flex": (5e-08, 1e-08),
+        "cache_read_input_token_cost_priority": (2e-07, 4e-08),
+        "input_cost_per_token": (1e-06, 2e-07),
+        "input_cost_per_token_above_272k_tokens": (2e-06, 4e-07),
+        "input_cost_per_token_batches": (5e-07, 1e-07),
+        "input_cost_per_token_flex": (5e-07, 1e-07),
+        "input_cost_per_token_priority": (2e-06, 4e-07),
+        "output_cost_per_token": (6e-06, 1.2e-06),
+        "output_cost_per_token_above_272k_tokens": (9e-06, 1.8e-06),
+        "output_cost_per_token_batches": (3e-06, 6e-07),
+        "output_cost_per_token_flex": (3e-06, 6e-07),
+        "output_cost_per_token_priority": (1.2e-05, 2.4e-06),
+    },
+    "gpt-5.6-terra": {
+        "cache_creation_input_token_cost": (3.125e-06, 2.5e-06),
+        "cache_creation_input_token_cost_above_272k_tokens": (6.25e-06, 5e-06),
+        "cache_creation_input_token_cost_flex": (1.5625e-06, 1.25e-06),
+        "cache_creation_input_token_cost_priority": (6.25e-06, 5e-06),
+        "cache_read_input_token_cost": (2.5e-07, 2e-07),
+        "cache_read_input_token_cost_above_272k_tokens": (5e-07, 4e-07),
+        "cache_read_input_token_cost_flex": (1.25e-07, 1e-07),
+        "cache_read_input_token_cost_priority": (5e-07, 4e-07),
+        "input_cost_per_token": (2.5e-06, 2e-06),
+        "input_cost_per_token_above_272k_tokens": (5e-06, 4e-06),
+        "input_cost_per_token_batches": (1.25e-06, 1e-06),
+        "input_cost_per_token_flex": (1.25e-06, 1e-06),
+        "input_cost_per_token_priority": (5e-06, 4e-06),
+        "output_cost_per_token": (1.5e-05, 1.2e-05),
+        "output_cost_per_token_above_272k_tokens": (2.25e-05, 1.8e-05),
+        "output_cost_per_token_batches": (7.5e-06, 6e-06),
+        "output_cost_per_token_flex": (7.5e-06, 6e-06),
+        "output_cost_per_token_priority": (3e-05, 2.4e-05),
+    },
+}
 
 
 def _get_git_branch(root: str) -> str | None:
@@ -54,56 +98,119 @@ def _get_git_branch(root: str) -> str | None:
     return branch or None
 
 
-class CustomBuildHook(BuildHookInterface):
-    """Build hook that downloads the latest pricing data before building."""
+def _load_pricing_data(raw: bytes, source: str) -> PricingData:
+    try:
+        parsed: object = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"Pricing data from {source} is not valid JSON; build stopped.") from exc
 
-    def initialize(self, version, build_data):
-        """Download pricing data file before build."""
-        try:
-            import urllib.request
+    if not isinstance(parsed, dict) or not parsed:
+        raise RuntimeError(f"Pricing data from {source} must be a non-empty JSON object; build stopped.")
+    if not isinstance(parsed.get("sample_spec"), dict):
+        raise RuntimeError(f"Pricing data from {source} is missing the LiteLLM sample_spec; build stopped.")
+    if not all(isinstance(key, str) and isinstance(value, dict) for key, value in parsed.items()):
+        raise RuntimeError(f"Pricing data from {source} contains invalid model entries; build stopped.")
+    return cast(PricingData, parsed)
 
-            # Resolve path relative to the build root (hatchling may run from a different CWD)
-            pricing_file_path = Path(self.root) / PRICING_FILE_RELATIVE_PATH
 
-            # Ensure the data directory exists
-            pricing_file_path.parent.mkdir(parents=True, exist_ok=True)
+def _validate_existing_pricing_file(pricing_file_path: Path) -> None:
+    if not pricing_file_path.exists():
+        raise RuntimeError(f"Pricing file not found at {pricing_file_path}; build stopped.")
+    _load_pricing_data(pricing_file_path.read_bytes(), str(pricing_file_path))
 
-            branch = _get_git_branch(str(self.root))
-            if branch != "main":
-                # When builds skip the download (non-main branches or when git info isn't available),
-                # still validate the pricing file exists so cost tracking doesn't silently disappear.
-                _warn_if_pricing_file_missing(pricing_file_path)
-                logger.info(
-                    "Skipping pricing data download (branch is not 'main'). "
-                    "Set branch to 'main' to auto-refresh this file during builds."
+
+def _download_pricing_data() -> bytes:
+    logger.info(f"Downloading pricing data from {PRICING_FILE_URL}...")
+    try:
+        with urllib.request.urlopen(PRICING_FILE_URL, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
+            return response.read()
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to download pricing data from {PRICING_FILE_URL}; "
+            "build stopped rather than bundling unverified pricing."
+        ) from exc
+
+
+def _apply_price_overrides(pricing_data: PricingData) -> None:
+    for model_name, field_overrides in PRICE_OVERRIDES.items():
+        raw_model_pricing = pricing_data.get(model_name)
+        if not isinstance(raw_model_pricing, dict):
+            raise RuntimeError(f"LiteLLM pricing data is missing {model_name}; build stopped.")
+        model_pricing = cast(dict[str, object], raw_model_pricing)
+        corrected_count = 0
+
+        for field_name, (stale_value, corrected_value) in field_overrides.items():
+            upstream_value = model_pricing.get(field_name)
+            if upstream_value == corrected_value:
+                continue
+            if upstream_value != stale_value:
+                raise RuntimeError(
+                    f"Unexpected upstream price for {model_name}.{field_name}: "
+                    f"expected {stale_value!r} or {corrected_value!r}, got {upstream_value!r}. "
+                    "The repository override may be stale; build stopped."
                 )
-                return
+            model_pricing[field_name] = corrected_value
+            corrected_count += 1
 
-            logger.info(f"Downloading pricing data from {PRICING_FILE_URL}...")
-            with urllib.request.urlopen(PRICING_FILE_URL) as resp:
-                downloaded = resp.read()
-
-            if pricing_file_path.exists():
-                existing = pricing_file_path.read_bytes()
-                if existing == downloaded:
-                    logger.info("Pricing data is already up to date; no file changes needed.")
-                    return
-
-            with tempfile.NamedTemporaryFile(dir=pricing_file_path.parent, delete=False) as tmp:
-                tmp.write(downloaded)
-                tmp_path = Path(tmp.name)
-            tmp_path.replace(pricing_file_path)
-            logger.info(f"Successfully updated pricing data at {pricing_file_path}")
-
-            # The file is already included in pyproject.toml artifacts, so we don't need to add it here
-            # but we ensure it exists before the build proceeds
-
-        except Exception as e:
-            logger.warning(f"Failed to download pricing data: {e}. Build will continue with existing file if present.")
-            # Don't fail the build if download fails - use existing file or handle gracefully
-            pricing_file_path = Path(self.root) / PRICING_FILE_RELATIVE_PATH
-            _warn_if_pricing_file_missing(pricing_file_path)
+        if corrected_count:
+            logger.warning(
+                "Applied repository pricing override for %s: corrected %d stale upstream fields.",
+                model_name,
+                corrected_count,
+            )
+        else:
+            logger.warning(
+                "LiteLLM upstream now matches the repository pricing override for %s; "
+                "the override is redundant and can be removed.",
+                model_name,
+            )
 
 
-# Export the hook class for hatchling to discover
+def _serialize_pricing_data(pricing_data: PricingData) -> bytes:
+    return (json.dumps(pricing_data, indent=4) + "\n").encode()
+
+
+def _write_atomically(pricing_file_path: Path, content: bytes) -> None:
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=pricing_file_path.parent, delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = Path(tmp.name)
+        tmp_path.chmod(0o644)
+        tmp_path.replace(pricing_file_path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Build hook that refreshes and validates LiteLLM pricing data."""
+
+    def initialize(self, version: str, build_data: dict[str, object]) -> None:
+        """Refresh main-branch pricing data or validate the committed offline copy."""
+        pricing_file_path = Path(self.root) / PRICING_FILE_RELATIVE_PATH
+        pricing_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        branch = _get_git_branch(str(self.root))
+        if branch not in {"main", "HEAD"}:
+            _validate_existing_pricing_file(pricing_file_path)
+            logger.info(
+                "Skipping pricing data download (branch is neither 'main' nor detached HEAD). "
+                "Build from 'main' or a release checkout to auto-refresh this file."
+            )
+            return
+
+        downloaded = _download_pricing_data()
+        pricing_data = _load_pricing_data(downloaded, PRICING_FILE_URL)
+        _apply_price_overrides(pricing_data)
+        updated = _serialize_pricing_data(pricing_data)
+
+        if pricing_file_path.exists() and pricing_file_path.read_bytes() == updated:
+            logger.info("Pricing data is already up to date after repository overrides.")
+            return
+
+        _write_atomically(pricing_file_path, updated)
+        logger.info(f"Successfully updated pricing data at {pricing_file_path}")
+
+
 __all__ = ["CustomBuildHook"]

--- a/tests/test_build_modules/test_hatch_build.py
+++ b/tests/test_build_modules/test_hatch_build.py
@@ -1,42 +1,161 @@
+import io
+import json
 import logging
 import subprocess
+from pathlib import Path
 
-from hatch_build import PRICING_FILE_RELATIVE_PATH, CustomBuildHook
+import pytest
+
+import hatch_build
+from hatch_build import PRICE_OVERRIDES, PRICING_FILE_RELATIVE_PATH, CustomBuildHook
 
 
-def _build_hook_with_root(tmp_path) -> CustomBuildHook:
+def _build_hook_with_root(tmp_path: Path) -> CustomBuildHook:
     hook = CustomBuildHook.__new__(CustomBuildHook)
     hook.root = str(tmp_path)
     return hook
 
 
-def test_skipping_download_still_warns_if_pricing_file_missing(monkeypatch, tmp_path, caplog):
-    def _raise_no_git(*_args, **_kwargs):
+def _pricing_payload(*, corrected: bool = False) -> dict[str, object]:
+    value_index = 1 if corrected else 0
+    payload: dict[str, object] = {
+        "sample_spec": {},
+        "new-upstream-model": {"input_cost_per_token": 9e-09},
+    }
+    for model_name, overrides in PRICE_OVERRIDES.items():
+        payload[model_name] = {field_name: values[value_index] for field_name, values in overrides.items()}
+    return payload
+
+
+def _mock_refresh_download(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: bytes,
+    *,
+    branch: str = "main",
+) -> None:
+    monkeypatch.setattr(hatch_build, "_get_git_branch", lambda _root: branch)
+    monkeypatch.setattr(
+        hatch_build.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: io.BytesIO(payload),
+    )
+
+
+def _pricing_file(tmp_path: Path) -> Path:
+    pricing_file_path = tmp_path / PRICING_FILE_RELATIVE_PATH
+    pricing_file_path.parent.mkdir(parents=True, exist_ok=True)
+    return pricing_file_path
+
+
+def test_non_main_build_requires_pricing_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    def _raise_no_git(*_args: object, **_kwargs: object) -> None:
         raise FileNotFoundError("git")
 
     monkeypatch.setattr(subprocess, "run", _raise_no_git)
+    hook = _build_hook_with_root(tmp_path)
 
+    with pytest.raises(RuntimeError, match="Pricing file not found"):
+        hook.initialize(version="0.0.0", build_data={})
+
+
+def test_non_main_build_validates_existing_pricing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(hatch_build, "_get_git_branch", lambda _root: "dev")
+    pricing_file_path = _pricing_file(tmp_path)
+    pricing_file_path.write_text('{"sample_spec": {}, "model": {}}', encoding="utf-8")
     hook = _build_hook_with_root(tmp_path)
 
     caplog.set_level(logging.INFO)
     hook.initialize(version="0.0.0", build_data={})
 
-    expected_path = tmp_path / PRICING_FILE_RELATIVE_PATH
-    assert "Skipping pricing data download (branch is not 'main')." in caplog.text
-    assert f"Pricing file not found at {expected_path}" in caplog.text
+    assert "Skipping pricing data download (branch is neither 'main' nor detached HEAD)." in caplog.text
 
 
-def test_skipping_download_does_not_error_when_pricing_file_exists(monkeypatch, tmp_path, caplog):
-    monkeypatch.setattr(subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout="dev\n"))
-
-    pricing_file_path = tmp_path / PRICING_FILE_RELATIVE_PATH
-    pricing_file_path.parent.mkdir(parents=True, exist_ok=True)
-    pricing_file_path.write_text("{}", encoding="utf-8")
-
+def test_non_main_build_rejects_malformed_pricing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(hatch_build, "_get_git_branch", lambda _root: "dev")
+    pricing_file_path = _pricing_file(tmp_path)
+    pricing_file_path.write_text("{", encoding="utf-8")
     hook = _build_hook_with_root(tmp_path)
 
-    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError, match="is not valid JSON"):
+        hook.initialize(version="0.0.0", build_data={})
+
+
+@pytest.mark.parametrize("branch", ["main", "HEAD"])
+def test_refresh_build_applies_overrides_and_keeps_upstream_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    branch: str,
+) -> None:
+    payload = json.dumps(_pricing_payload()).encode()
+    _mock_refresh_download(monkeypatch, payload, branch=branch)
+    pricing_file_path = _pricing_file(tmp_path)
+    hook = _build_hook_with_root(tmp_path)
+
+    caplog.set_level(logging.WARNING)
     hook.initialize(version="0.0.0", build_data={})
 
-    assert "Skipping pricing data download (branch is not 'main')." in caplog.text
-    assert "Pricing file not found at" not in caplog.text
+    built_pricing = json.loads(pricing_file_path.read_bytes())
+    assert built_pricing["new-upstream-model"]["input_cost_per_token"] == 9e-09
+    for model_name, overrides in PRICE_OVERRIDES.items():
+        for field_name, (_, corrected_value) in overrides.items():
+            assert built_pricing[model_name][field_name] == corrected_value
+        assert f"Applied repository pricing override for {model_name}" in caplog.text
+
+
+def test_main_build_logs_when_overrides_are_redundant(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = json.dumps(_pricing_payload(corrected=True)).encode()
+    _mock_refresh_download(monkeypatch, payload)
+    hook = _build_hook_with_root(tmp_path)
+
+    caplog.set_level(logging.WARNING)
+    hook.initialize(version="0.0.0", build_data={})
+
+    for model_name in PRICE_OVERRIDES:
+        assert f"override for {model_name}; the override is redundant" in caplog.text
+
+
+def test_main_build_rejects_unexpected_upstream_price(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    upstream = _pricing_payload()
+    luna = upstream["gpt-5.6-luna"]
+    assert isinstance(luna, dict)
+    luna["input_cost_per_token"] = 3e-07
+    _mock_refresh_download(monkeypatch, json.dumps(upstream).encode())
+    pricing_file_path = _pricing_file(tmp_path)
+    original = b'{"sample_spec": {}, "existing": {}}\n'
+    pricing_file_path.write_bytes(original)
+    hook = _build_hook_with_root(tmp_path)
+
+    with pytest.raises(RuntimeError, match="override may be stale"):
+        hook.initialize(version="0.0.0", build_data={})
+
+    assert pricing_file_path.read_bytes() == original
+
+
+def test_main_build_rejects_malformed_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _mock_refresh_download(monkeypatch, b"{")
+    hook = _build_hook_with_root(tmp_path)
+
+    with pytest.raises(RuntimeError, match="is not valid JSON"):
+        hook.initialize(version="0.0.0", build_data={})
+
+
+def test_main_build_fails_when_download_is_unavailable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(hatch_build, "_get_git_branch", lambda _root: "main")
+
+    def _raise_offline(*_args: object, **_kwargs: object) -> None:
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(hatch_build.urllib.request, "urlopen", _raise_offline)
+    hook = _build_hook_with_root(tmp_path)
+
+    with pytest.raises(RuntimeError, match="build stopped rather than bundling unverified pricing"):
+        hook.initialize(version="0.0.0", build_data={})


### PR DESCRIPTION
This pull request fixes release builds silently replacing repository-corrected GPT-5.6 prices with stale data from LiteLLM `main`.

### Summary

- Keep the full LiteLLM refresh so builds still receive genuine upstream model updates.
- Apply explicit, field-level Luna and Terra corrections only when upstream still has the known pre-cut values.
- Treat already-corrected upstream values as a no-op and log that the override is ready to remove.
- Stop the build on an unknown price mismatch, malformed JSON, or download failure instead of bundling unverified prices.
- Refresh detached release checkouts as well as `main`, while validating the committed offline copy on other branches.

OpenAI's July 30 price change reduced both Luna and Terra prices. The corresponding LiteLLM correction exists in [BerriAI/litellm#35258](https://github.com/BerriAI/litellm/pull/35258), but it has not reached LiteLLM `main`.

### Test plan

- `make format`
- `make check`
- `uv run pytest -q tests/test_build_modules/test_hatch_build.py` — 9 passed
- Full test suite — 1,645 passed, 2 skipped
- Built from a checkout named `main` and from a detached release checkout at this commit. Both wheels had SHA-256 `3c97534bfbe3aefda61bc5eb6863491469f9b85f734e20eb49316840dc0edb65`.
- Inspected the JSON inside each wheel and confirmed Luna input/output/cached-input/cache-write prices of `2e-07`, `1.2e-06`, `2e-08`, and `2.5e-07`, plus the corrected long-context and service-tier fields. Terra and all 36 overridden fields were also correct.

### Issue number

Follow-up to #760.

### Checks

- [x] I've added new tests
- [x] Documentation is not needed for this internal build-hook change
- [x] I've run `make check` and `make format`
- [x] I've made sure tests pass
