### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ path = "hatch_build.py"
 
 [project]
 name = "agency-swarm"
-version = "1.10.5"
+version = "1.11.0"
 description = "Agency Swarm framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "agency-swarm"
-version = "1.10.5"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "ag-ui-protocol" },


### PR DESCRIPTION
This pull request updates Agency Swarm’s version metadata from `1.10.5` to `1.11.0` in `pyproject.toml` and `uv.lock`. It changes no runtime code, docs, or tests. The notes below cover changes already merged since `v1.10.5`; this pull request does not publish a release.

### Summary

- Set the project version to `1.11.0`.
- Keep the editable Agency Swarm package entry in `uv.lock` at the same version.

### Release notes

The `1.11.0` change range adds realtime voice calls, per-user OAuth for MCP servers, first-class system reminders, and a new default model. It also fixes usage-cost accounting and several smaller docs and tool-loading issues.

#### Voice agents

- Run an existing agency as a realtime voice service with `run_realtime(agency=...)`, add `/<agency>/realtime` to an existing FastAPI app with `run_fastapi(enable_realtime=True)`, or use `Agency.to_realtime()` for custom servers. The same work adds OpenAI and xAI support, a browser demo, and a Twilio phone bridge in [#735](https://github.com/VRSEN/agency-swarm/pull/735).

#### MCP OAuth

- Connect OAuth-protected MCP servers with `MCPServerOAuth`, defer sign-in until the agent calls `authenticate_mcp_server`, and store tokens in user-scoped buckets. FastAPI streams `oauth_redirect` and `oauth_status` events, while protected `HostedMCPTool` instances can opt into the same flow in [#734](https://github.com/VRSEN/agency-swarm/pull/734).
- Preserve explicitly configured OAuth scopes during discovery and surface the original OAuth flow error instead of a generic cancellation in [#758](https://github.com/VRSEN/agency-swarm/pull/758).

#### System reminders

- Add `Agent(system_reminders=...)` with string and callable shorthand, plus `AfterEveryUserMessage` and `EveryNToolCalls`. Reminders reach model input without being saved to thread history; tool-count reminders cover local and hosted tools, and reminder settings invalidate stale conversation-starter caches in [#732](https://github.com/VRSEN/agency-swarm/pull/732).
- Keep `AfterEveryUserMessage` reminders active when concurrent runs share one Agency and thread in [#746](https://github.com/VRSEN/agency-swarm/pull/746).

#### Models and cost tracking

- Change the framework default to `gpt-5.6-luna`, normalize `Agent(model=None)` to that default, pin its reasoning effort to `none`, preserve explicit model settings, and move `openai-agents` from `0.14.8` to `0.18.1` in [#741](https://github.com/VRSEN/agency-swarm/pull/741).
- Price tiered usage per request and charge provider-reported cache-write tokens at the cache-creation rate in [#759](https://github.com/VRSEN/agency-swarm/pull/759).
- Correct bundled `gpt-5.6-luna` prices after OpenAI’s July 30, 2026 price cut in [#760](https://github.com/VRSEN/agency-swarm/pull/760), then keep the corrected Luna and Terra data from being replaced by stale upstream data during builds in [#761](https://github.com/VRSEN/agency-swarm/pull/761).

#### Other fixes and docs

- Skip `test_*.py`, `*_test.py`, `conftest.py`, and dot-prefixed files when `load_tools_from_folder` discovers tools in [#730](https://github.com/VRSEN/agency-swarm/pull/730).
- Update the hosted widget embed example in [#729](https://github.com/VRSEN/agency-swarm/pull/729), refresh the Agent Swarm TUI guide for the current CLI in [#728](https://github.com/VRSEN/agency-swarm/pull/728), and align the model, voice, OAuth, and reminder guides with current behavior on `main` in [#757](https://github.com/VRSEN/agency-swarm/pull/757).

#### Upgrade notes and limits

- **Default model and SDK:** Agents without an explicit model, including `Agent(model=None)`, now use `gpt-5.6-luna` instead of the former `gpt-5.4-mini` default. Luna’s implicit reasoning effort is `none`; explicit models and explicit model settings still win. Set `model=` before upgrading if your app must keep a different model, and align any separate `openai-agents` pin with `0.18.1`.
- **One voice for the whole call:** Install `agency-swarm[voice]` before using voice agents. A realtime call selects its voice once from `run_realtime(voice=...)`, the entry agent, or the provider default. Handoffs change the active agent, instructions, and tools, but cannot change the voice after audio starts.
- **OAuth is per user and streaming-only in FastAPI:** Configure a trusted `oauth_user_id_dependency`; do not accept a user ID directly from a request header or body. OAuth-enabled FastAPI agencies must use `/get_response_stream` or AG-UI because `/get_response` returns `400`. The wait is capped at 10 minutes. Multi-worker apps also need shared persistent `oauth_token_path` storage, sticky routing, or one worker. Legacy token buckets without an unambiguous user and client are not migrated, so affected users must authorize again.
- **System reminder boundary:** Creating the first agent with `system_reminders` installs a process-wide boundary around SDK `Runner` calls and `RunState` serialization. It stays installed for the process and also wraps SDK agents without reminders. Processes that never create a reminder-enabled agent leave the SDK Runner unchanged.
- **Cost accounting:** Tiered prices now use each request’s input size, and cache writes use their own rate when the provider reports them. A tiered multi-request aggregate without a complete per-request breakdown raises `UsageCostCalculationError` instead of returning an unsafe estimate. Bundled Luna standard rates are `$0.20` per million input tokens and `$1.20` per million output tokens.

### Maintenance

Dependency updates cover coverage in [#714](https://github.com/VRSEN/agency-swarm/pull/714), FastAPI in [#715](https://github.com/VRSEN/agency-swarm/pull/715), MCP in [#716](https://github.com/VRSEN/agency-swarm/pull/716), datamodel-code-generator in [#717](https://github.com/VRSEN/agency-swarm/pull/717), griffe in [#736](https://github.com/VRSEN/agency-swarm/pull/736), langchain-core in [#737](https://github.com/VRSEN/agency-swarm/pull/737), websockets in [#738](https://github.com/VRSEN/agency-swarm/pull/738), and Ruff in [#739](https://github.com/VRSEN/agency-swarm/pull/739).

The MCP OAuth and manager modules were split without changing their public imports in [#756](https://github.com/VRSEN/agency-swarm/pull/756). Two no-PR internal policy commits updated review commands and reduced the checked-in policy to a repository-specific addendum: [`7253262`](https://github.com/VRSEN/agency-swarm/commit/725326272cdff62c7353e29b17a4316828e6e5e6) and [`a9e2a9c`](https://github.com/VRSEN/agency-swarm/commit/a9e2a9c89c3c430f50838d80a9313d49631007e7).

**Full change range:** [`v1.10.5...69e22d8`](https://github.com/VRSEN/agency-swarm/compare/v1.10.5...69e22d841d101bb061a7eca5bb073552825cccb6)

### Test plan

- `make format` passed with 390 files unchanged; Ruff fixes were clean.
- `make check` passed Ruff and mypy across 136 source files.
- `make ci` passed: 1,646 tests passed, 2 skipped, and total coverage was 92%.
- `uv run pytest tests/integration` passed: 481 integration tests passed.
- A detached build of candidate `820bd4b1350ede3c6e3ccaee7a5179bed313e35a` produced the wheel and source archive. The installed wheel returned a non-empty live streamed response and loaded the corrected Luna and Terra prices. The required pre-release Codex review exited 0 with no actionable finding.

### Issue number

N/A

### Checks

- [x] New tests are not needed for this two-field metadata-only diff.
- [x] The full `v1.10.5` change range and upgrade notes are included above.
- [x] I've run `make lint` through `make check` and run `make format`.
- [x] I've made sure the full test and integration suites pass.
