### PR TITLE
docs: add newcomer paths for OAuth and voice

### DIFF
--- a/docs/additional-features/voice-agents/overview.mdx
+++ b/docs/additional-features/voice-agents/overview.mdx
@@ -4,7 +4,30 @@ description: "Design voice-first assistants with the same Agency Swarm agents yo
 icon: "microphone"
 ---
 
-Agency Swarm reuses your existing `Agent` definitions for voice. This page shows how to adapt agents for spoken conversations; deployment lives on the dedicated [Deployment](./deployment) guide.
+Agency Swarm reuses your existing `Agent` definitions for voice. This page shows how to adapt agents for spoken conversations.
+
+## Try it locally
+
+Save this as `voice_demo.py`. It starts the packaged browser client on your computer, so you can speak with your agent before you host anything.
+
+```python
+from agency_swarm import Agency, Agent
+from agency_swarm.ui.demos.realtime import RealtimeDemoLauncher
+
+voice_agent = Agent(
+    name="Voice Concierge",
+    instructions="You are a friendly concierge. Keep answers brief.",
+    voice="marin",
+)
+
+RealtimeDemoLauncher.start(Agency(voice_agent), host="127.0.0.1")
+```
+
+1. Install the voice extra: `pip install "agency-swarm[voice]"`.
+2. Set `OPENAI_API_KEY`, then run `python voice_demo.py`.
+3. Open [http://127.0.0.1:8000](http://127.0.0.1:8000), click **Connect**, and allow microphone access.
+
+When you are ready to host the browser client or connect phone calls, use the [Deployment](./deployment) guide.
 
 ## What you can build
 

--- a/docs/core-framework/tools/mcp-oauth.mdx
+++ b/docs/core-framework/tools/mcp-oauth.mdx
@@ -17,43 +17,10 @@ This feature lets **your users** connect their personal accounts to AI agents yo
 - **Automatic refresh** - Tokens renew automatically; users only re-authorize when needed
 - **Works with any OAuth provider** - GitHub, Google, Notion, and more
 
-## Where OAuth is used (supported run modes)
+## Quickstart: connect a hosted MCP server
 
-<Tabs>
-<Tab title="FastAPI (production)" defaultOpen={true}>
+Hosted servers such as Notion handle OAuth for you. Set your `OPENAI_API_KEY`, then run this script. On the first request, your browser opens so you can authorize the account.
 
-Use this when your agency runs on a server and users authenticate from a web/mobile UI.
-
-- **Mode:** `saas_stream`
-- **Hosted MCP** (Notion): Configure `MCPServerOAuth(url=..., name=...)` and deploy your agency.
-- **Self-hosted MCP** (GitHub/Google): Run your OAuth-enabled MCP server + deploy your agency.
-- **HostedMCPTool (remote MCP)**: Outside FastAPI, provide the OAuth token through `tool_config.authorization`. In FastAPI, leave `authorization` empty and wrap only the OAuth-protected hosted tool with `enable_hosted_mcp_tool_oauth(...)`. Agency Swarm creates an in-memory callback-state registry by default. For multiple workers, an external `oauth_registry` shares callback state only; configure `oauth_token_path` on shared persistent storage as well, or use sticky routing or a single worker. Agency Swarm surfaces the auth URL via `event: oauth_redirect` and injects the access token once authorized. Public hosted MCP servers should stay unwrapped.
-- **Deferred auth trigger (all modes):** Startup never forces OAuth discovery. The model gets an `authenticate_mcp_server(server_name)` tool and OAuth starts only when that tool is invoked for a specific authenticated MCP server.
-- **Tool parameter contract:** `server_name` is constrained to the configured authenticated MCP server names for that agent.
-- **Streaming is required**: OAuth authorization is delivered via `event: oauth_redirect`, so use `POST /{agency}/get_response_stream`. The non-streaming `POST /{agency}/get_response` endpoint is not compatible with OAuth-enabled MCP servers.
-- **Deterministic stream contract after activation:** `meta` -> `oauth_redirect` -> `oauth_status` (`pending`) -> keepalive comments every 15s while waiting -> terminal `oauth_status` (`authorized`, `error:<reason>`, or `timeout`) -> `messages` -> `end`.
-- **Bounded wait:** SaaS OAuth waits up to 10 minutes before emitting `oauth_status` = `timeout`.
-- **Discovery-time auth after activation:** with standard FastMCP auth, MCP schema discovery (`list_tools`) is protected, so OAuth starts during discovery after the model invokes `authenticate_mcp_server(server_name)`.
-- **Per-user token isolation**: Configure `oauth_user_id_dependency` so each authenticated user gets a separate token bucket.
-
-See the FastAPI OAuth section: [OAuth-enabled agencies](/additional-features/fastapi-integration#oauth-enabled-agencies).
-
-</Tab>
-<Tab title="Local browser (dev/scripts)">
-
-Use this when you are running locally (developer machine) and can open a browser.
-
-- **Mode:** `local_browser`
-- **Works with non-streaming**: `agency.get_response_sync(...)` can open the browser and wait for the callback, then continue the run.
-- **Hosted MCP** (Notion): Just the hosted MCP URL.
-- **Self-hosted MCP** (GitHub/Google): Start the MCP server locally + export `*_CLIENT_ID` / `*_CLIENT_SECRET`.
-
-</Tab>
-</Tabs>
-
-## Two types of MCP servers
-
-**Hosted servers** (like Notion) handle OAuth for you—just connect:
 ```python
 from agency_swarm import Agent, Agency
 from agency_swarm.mcp import MCPServerOAuth
@@ -65,7 +32,14 @@ agency = Agency(agent)
 agency.get_response_sync("List my recent Notion pages")  # Local run: browser opens for authorization
 ```
 
-**Self-hosted servers** (GitHub, Google) require you to run a FastMCP server with your OAuth credentials:
+<Note>
+The first run opens the browser for consent. Tokens are cached under `~/.agency-swarm/mcp-tokens/`, reused, and refreshed automatically. Users re-authorize only when refresh is no longer possible.
+</Note>
+
+## Connect a self-hosted MCP server
+
+Self-hosted servers such as GitHub and Google require an OAuth-enabled FastMCP server with your OAuth credentials:
+
 ```bash
 # Terminal 1: Start the MCP server with your OAuth app credentials
 export GITHUB_CLIENT_ID="Iv1.abc123..."
@@ -83,10 +57,6 @@ agent = Agent(name="GitHubAgent", mcp_servers=[github])
 agency = Agency(agent)
 agency.get_response_sync("List my repositories")  # Local run: browser opens for authorization
 ```
-
-<Note>
-The first run opens the browser for consent. Tokens are cached under `~/.agency-swarm/mcp-tokens/`, reused, and refreshed automatically. Users re-authorize only when refresh is no longer possible.
-</Note>
 
 ## OAuth flow at a glance
 
@@ -138,7 +108,43 @@ For GitHub/Google, you need to create an OAuth app and run a FastMCP server:
 
 Then run the FastMCP server (see `examples/mcp_oauth/github_server.py` for GitHub, `examples/mcp_oauth/google_server.py` for Google).
 
-## Configuration reference
+## Reference
+
+### Supported run modes
+
+<Tabs>
+<Tab title="FastAPI (production)" defaultOpen={true}>
+
+Use this when your agency runs on a server and users authenticate from a web/mobile UI.
+
+- **Mode:** `saas_stream`
+- **Hosted MCP** (Notion): Configure `MCPServerOAuth(url=..., name=...)` and deploy your agency.
+- **Self-hosted MCP** (GitHub/Google): Run your OAuth-enabled MCP server and deploy your agency.
+- **HostedMCPTool (remote MCP)**: Outside FastAPI, provide the OAuth token through `tool_config.authorization`. In FastAPI, leave `authorization` empty and wrap only the OAuth-protected hosted tool with `enable_hosted_mcp_tool_oauth(...)`. Agency Swarm creates an in-memory callback-state registry by default. For multiple workers, an external `oauth_registry` shares callback state only; configure `oauth_token_path` on shared persistent storage as well, or use sticky routing or a single worker. Agency Swarm surfaces the auth URL via `event: oauth_redirect` and injects the access token once authorized. Public hosted MCP servers should stay unwrapped.
+- **Deferred auth trigger (all modes):** Startup never forces OAuth discovery. The model gets an `authenticate_mcp_server(server_name)` tool and OAuth starts only when that tool is invoked for a specific authenticated MCP server.
+- **Tool parameter contract:** `server_name` is constrained to the configured authenticated MCP server names for that agent.
+- **Streaming is required**: OAuth authorization is delivered via `event: oauth_redirect`, so use `POST /{agency}/get_response_stream`. The non-streaming `POST /{agency}/get_response` endpoint is not compatible with OAuth-enabled MCP servers.
+- **Deterministic stream contract after activation:** `meta` -> `oauth_redirect` -> `oauth_status` (`pending`) -> keepalive comments every 15 seconds while waiting -> terminal `oauth_status` (`authorized`, `error:<reason>`, or `timeout`) -> `messages` -> `end`.
+- **Bounded wait:** SaaS OAuth waits up to 10 minutes before emitting `oauth_status` = `timeout`.
+- **Discovery-time auth after activation:** with standard FastMCP auth, MCP schema discovery (`list_tools`) is protected, so OAuth starts during discovery after the model invokes `authenticate_mcp_server(server_name)`.
+- **Per-user token isolation**: `oauth_user_id_dependency` is required for OAuth-enabled FastAPI agencies. It must return a stable, non-secret ID for each authenticated user.
+
+See the FastAPI OAuth section: [OAuth-enabled agencies](/additional-features/fastapi-integration#oauth-enabled-agencies).
+
+</Tab>
+<Tab title="Local browser (dev/scripts)">
+
+Use this when you are running locally (developer machine) and can open a browser.
+
+- **Mode:** `local_browser`
+- **Works with non-streaming**: `agency.get_response_sync(...)` can open the browser and wait for the callback, then continue the run.
+- **Hosted MCP** (Notion): Just the hosted MCP URL.
+- **Self-hosted MCP** (GitHub/Google): Start the MCP server locally and export `*_CLIENT_ID` / `*_CLIENT_SECRET`.
+
+</Tab>
+</Tabs>
+
+### Configuration reference
 
 - Naming drives env vars: `name="github"` -> `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`.
 - Scopes are explicit: pass only what the tool needs (e.g., `["repo", "user"]`).
@@ -153,7 +159,7 @@ Then run the FastMCP server (see `examples/mcp_oauth/github_server.py` for GitHu
 </ParamField>
 
 <ParamField param="scopes" type="list[string]">
-  OAuth scopes to request. Defaults to `["user"]`.
+  OAuth scopes to request. When omitted, the server's OAuth discovery supplies the default.
 </ParamField>
 
 <ParamField param="redirect_uri" type="string">
@@ -196,7 +202,7 @@ Then run the FastMCP server (see `examples/mcp_oauth/github_server.py` for GitHu
   Custom async handler to receive the OAuth callback code. Returns a tuple of (code, state). By default, starts a local HTTP server (or prompts for manual paste) to capture the redirect. In FastAPI deployments you typically do **not** set this—`run_fastapi` wires callback handling through `/auth/callback`.
 </ParamField>
 
-## Token storage and isolation
+### Token storage and isolation
 
 Tokens default to `~/.agency-swarm/mcp-tokens/{user}/{server-client}/`. Set `AGENCY_SWARM_MCP_CACHE_DIR` for a global override or pass `cache_dir` per server.
 
@@ -204,7 +210,7 @@ In multi-worker FastAPI deployments, `oauth_registry` and token storage solve di
 
 User-scoped buckets use a collision-resistant filesystem segment derived from the authenticated user ID or `set_oauth_user_id()`. Each server bucket also includes the effective OAuth client configuration, so different client registrations cannot reuse each other's tokens. Legacy buckets that do not identify the user or OAuth client unambiguously are intentionally not auto-migrated; those users must authorize again instead of risking credential reuse.
 
-For FastAPI, pass a trusted dependency that authenticates the request and returns a stable, non-secret user ID:
+OAuth-enabled FastAPI agencies require a trusted dependency that authenticates the request and returns a stable, non-secret user ID:
 
 ```python
 from fastapi import Depends
@@ -254,7 +260,7 @@ Access tokens refresh automatically via the MCP SDK; if a refresh token expires,
 Tools activated by `authenticate_mcp_server` hold a live authenticated session, not just a token file. When one shared Agency serves several users, the activated tools are dropped as soon as the OAuth user changes, so the next user's agent starts from `authenticate_mcp_server` against its own token bucket instead of reusing the previous user's session. Identify every run: call `set_oauth_user_id()` before it, or pass `user_id` through `user_context` (or `context_override`).
 </Note>
 
-## Multiple OAuth servers
+### Multiple OAuth servers
 
 ```python
 from agency_swarm import Agent
@@ -266,7 +272,7 @@ notion = MCPServerOAuth(url="http://localhost:8002/mcp", name="notion", scopes=[
 agent = Agent(name="MultiServiceAgent", mcp_servers=[github, notion])
 ```
 
-## Advanced: Custom handlers (when you are not using FastAPI)
+### Advanced: Custom handlers (when you are not using FastAPI)
 
 If you are building your own UI/server (not using `run_fastapi`), you can send the auth URL to your frontend and wait for the callback code there:
 
@@ -294,12 +300,12 @@ agent = Agent(name="BrowserlessAgent", mcp_servers=[oauth_server])
 
 See [OAuth-enabled agencies](/additional-features/fastapi-integration#oauth-enabled-agencies) for the FastAPI production flow.
 
-## Troubleshooting
+### Troubleshooting
 - Browser doesn’t open or redirect fails: paste the full callback URL when prompted; confirm it matches the provider config.
 - Credentials rejected: re-export `*_CLIENT_ID` and `*_CLIENT_SECRET`, then delete the cached folder for that server.
 - Wrong storage path: set `AGENCY_SWARM_MCP_CACHE_DIR` or pass `cache_dir=Path(...)` to keep tokens in a specific location.
 
-## See Also
+### See Also
 
 - [FastAPI Integration](/additional-features/fastapi-integration)
 - [MCP Integration](/core-framework/tools/mcp-integration)


### PR DESCRIPTION
### Summary

This pull request gives newcomers a working starting point on the OAuth and voice pages.

- Moves the hosted OAuth example to the top and places run-mode and multi-worker details in a lower reference section.
- Adds a local voice demo that starts the bundled browser client before the deployment guide.
- Corrects the OAuth scopes default and documents the required FastAPI user ID dependency.

### Test plan

- `make format`
- `make lint`
- Parsed `docs/docs.json`
- Resolved internal links in both changed pages
- Executed the OAuth quickstart and voice launcher setup without starting a persistent server

### Issue number

N/A

### Checks

- [ ] I've added new tests (not needed for docs-only changes)
- [x] I've added/updated the relevant documentation
- [x] I've run `make lint` and `make format`
- [ ] I've made sure tests pass (not run for docs-only changes)