### PR TITLE
docs: make API v2 the default platform reference

### DIFF
--- a/.cursor/rules/writing-docs.mdc
+++ b/.cursor/rules/writing-docs.mdc
@@ -19,7 +19,7 @@ When writing or improving documentation for Agency Swarm, your primary goal is c
 ## Platform API documentation
 
 - Keep one API overview at `docs/platform/integrations/web-api.mdx`, using the existing Feature Overview, Authentication, Endpoints, and Additional Notes layout.
-- Publish endpoint routes without deployment hostnames or staging environment details. Omit OpenAPI server URLs, use the simple endpoint display, and use `API_BASE_URL` in runnable examples.
+- Show only routes in endpoint bars using the simple endpoint display. Set production-only OpenAPI server URLs for generated code examples; never publish staging URLs or environment selectors. Keep `API_BASE_URL` in the overview examples.
 - Present API v2 as the default. Keep detailed examples in accordions and endpoint contracts in `docs/openapi.json`.
 - Link API v1 only from the deprecated notice at the bottom. Keep its reference pages accessible by URL but hidden from navigation with `x-hidden`.
 

--- a/.cursor/rules/writing-docs.mdc
+++ b/.cursor/rules/writing-docs.mdc
@@ -19,6 +19,7 @@ When writing or improving documentation for Agency Swarm, your primary goal is c
 ## Platform API documentation
 
 - Keep one API overview at `docs/platform/integrations/web-api.mdx`, using the existing Feature Overview, Authentication, Endpoints, and Additional Notes layout.
+- Publish endpoint routes without deployment hostnames or staging environment details. Omit OpenAPI server URLs, use the simple endpoint display, and use `API_BASE_URL` in runnable examples.
 - Present API v2 as the default. Keep detailed examples in accordions and endpoint contracts in `docs/openapi.json`.
 - Link API v1 only from the deprecated notice at the bottom. Keep its reference pages accessible by URL but hidden from navigation with `x-hidden`.
 

--- a/.cursor/rules/writing-docs.mdc
+++ b/.cursor/rules/writing-docs.mdc
@@ -16,6 +16,12 @@ When writing or improving documentation for Agency Swarm, your primary goal is c
 - Hide complexity under tabs, dropdowns, etc.
 - Split pages into sub pages if needed. Use ~150 visible lines as a readability target, not a hard limit. Collapsed content (for example accordions) does not count toward this target.
 
+## Platform API documentation
+
+- Keep one API overview at `docs/platform/integrations/web-api.mdx`, using the existing Feature Overview, Authentication, Endpoints, and Additional Notes layout.
+- Present API v2 as the default. Keep detailed examples in accordions and endpoint contracts in `docs/openapi.json`.
+- Link API v1 only from the deprecated notice at the bottom. Keep its reference pages accessible by URL but hidden from navigation with `x-hidden`.
+
 ## Release Notes
 
 Use these rules for release notes so the intro stays readable and every claim stays tied to a shipped change.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,6 +8,11 @@
     "dark": "#B76E00"
   },
   "favicon": "/images/favicon.svg",
+  "api": {
+    "playground": {
+      "display": "simple"
+    }
+  },
   "navigation": {
     "tabs": [
       {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -43,7 +43,7 @@
         "required": ["type", "image_url"],
         "properties": {
           "type": {"type": "string", "enum": ["input_image"]},
-          "image_url": {"type": "string", "minLength": 1, "description": "An image URL or image data URL."},
+          "image_url": {"type": "string", "minLength": 1, "description": "An HTTP(S) image URL accessible to the runtime. Embedded data URLs pass API validation but are not supported by the current runtime file uploader."},
           "detail": {"type": "string", "enum": ["auto", "low", "high"], "default": "auto"}
         }
       },
@@ -62,7 +62,7 @@
           "chatId": {
             "type": "string",
             "nullable": true,
-            "description": "An existing platform chat ID. aliasChatId takes precedence when both are provided."
+            "description": "An existing platform chat ID. Do not combine with aliasChatId; completion requests return 400 when both are provided."
           },
           "aliasChatId": {
             "type": "string",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5,6 +5,7 @@
     "version": "1.0.0",
     "description": "Reference documentation for the Agencii Platform API. Provides endpoints allowing you to run your agents on custom backends or on other unsupported channels. ⚡ Live Postman Example: https://www.postman.com/vrsen-ai/agencii-api/overview"
   },
+  "servers": [{"url": "https://agency-swarm-app-japboyzddq-uc.a.run.app"}],
   "components": {
     "securitySchemes": {
       "PlatformApiKey": {"type": "http", "scheme": "bearer", "description": "Platform API key from Profile Icon > API Keys. Send `Authorization: Bearer YOUR_API_KEY`."},
@@ -215,6 +216,7 @@
   "security": [ { "BearerAuth": [] } ],
   "paths": {
     "/get_completion_v2": {
+      "servers": [{"url": "https://api-integration-v2-japboyzddq-uc.a.run.app"}],
       "post": {
         "summary": "Get response",
         "operationId": "getCompletionV2",
@@ -259,6 +261,7 @@
       }
     },
     "/get_chat_messages": {
+      "servers": [{"url": "https://api-integration-v2-japboyzddq-uc.a.run.app"}],
       "post": {
         "summary": "Get chat messages",
         "operationId": "getChatMessages",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,6 +13,7 @@
   ],
   "components": {
     "securitySchemes": {
+      "PlatformApiKey": {"type": "http", "scheme": "bearer", "description": "Platform API key from Profile Icon > API Keys. Send `Authorization: Bearer YOUR_API_KEY`."},
       "BearerAuth": {
         "type": "http",
         "scheme": "bearer",
@@ -21,6 +22,110 @@
       }
     },
     "schemas": {
+      "ApiV2File": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "file_url"],
+        "properties": {
+          "type": {"type": "string", "enum": ["input_file"]},
+          "file_url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://",
+            "description": "Runtime-accessible HTTP(S) URL. A signed URL is supported; extra request headers are not."
+          },
+          "filename": {
+            "type": "string",
+            "nullable": true,
+            "minLength": 1,
+            "description": "Optional non-blank file name without directory separators. Defaults to the URL file name. Duplicate names receive unique suffixes."
+          }
+        }
+      },
+      "ApiV2Image": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "image_url"],
+        "properties": {
+          "type": {"type": "string", "enum": ["input_image"]},
+          "image_url": {"type": "string", "minLength": 1, "description": "An image URL or image data URL."},
+          "detail": {"type": "string", "enum": ["auto", "low", "high"], "default": "auto"}
+        }
+      },
+      "ApiV2CompletionRequest": {
+        "example": {"apiIntegrationId": "your-integration-id", "message": "Hi!", "aliasChatId": "customer-123-conversation-1"},
+        "type": "object",
+        "required": ["apiIntegrationId", "message"],
+        "properties": {
+          "apiIntegrationId": {"type": "string", "description": "ID of an API integration connected to a deployed agency."},
+          "message": {"type": "string", "minLength": 1, "description": "The user message, including when attachments are supplied."},
+          "agent": {
+            "type": "string",
+            "nullable": true,
+            "description": "Entry-point agent ID, not display name. Overrides the saved default. Missing or empty uses the saved default, then the first available entry point if stale. Unknown explicit IDs return 400."
+          },
+          "chatId": {
+            "type": "string",
+            "nullable": true,
+            "description": "An existing platform chat ID. aliasChatId takes precedence when both are provided."
+          },
+          "aliasChatId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Your conversation ID. Reuse it for follow-up messages. Without either chat identifier a new conversation starts."
+          },
+          "additionalInstructions": {"type": "string", "nullable": true, "description": "Additional instructions for this request."},
+          "user_context": {"oneOf": [{"type": "object", "additionalProperties": true}, {"type": "string"}], "description": "Context to pass to the agency."},
+          "attachments": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "oneOf": [{"$ref": "#/components/schemas/ApiV2File"}, {"$ref": "#/components/schemas/ApiV2Image"}],
+              "discriminator": {
+                "propertyName": "type",
+                "mapping": {"input_file": "#/components/schemas/ApiV2File", "input_image": "#/components/schemas/ApiV2Image"}
+              }
+            },
+            "description": "JSON file/image attachments. OpenAI file_id/tools, PDF file_data, local paths and multipart uploads are unsupported."
+          }
+        }
+      },
+      "ApiV2Error": {"type": "object", "required": ["error"], "properties": {"error": {"type": "string"}}},
+      "ApiV2HistoryRequest": {
+        "example": {"apiIntegrationId": "your-integration-id", "aliasChatId": "customer-123-conversation-1"},
+        "type": "object",
+        "required": ["apiIntegrationId"],
+        "anyOf": [{"required": ["chatId"]}, {"required": ["aliasChatId"]}],
+        "properties": {
+          "apiIntegrationId": {"type": "string", "description": "API integration ID."},
+          "chatId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Existing platform chat ID. Takes precedence over aliasChatId on this history endpoint."
+          },
+          "aliasChatId": {"type": "string", "minLength": 1, "description": "Conversation alias. Supply one chat identifier."}
+        }
+      },
+      "ApiV2HistoryResponse": {
+        "type": "object",
+        "required": ["chatId", "items"],
+        "properties": {
+          "chatId": {"type": "string"},
+          "aliasChatId": {"type": "string"},
+          "numMessages": {"type": "integer"},
+          "status": {"type": "object", "additionalProperties": true, "description": "Saved run status when available."},
+          "items": {
+            "type": "array",
+            "items": {"type": "object", "additionalProperties": true},
+            "description": "Stored messages, tool calls, reasoning and other chat items. Item structure depends on its type."
+          },
+          "files": {
+            "type": "array",
+            "items": {"type": "object", "properties": {"name": {"type": "string"}, "url": {"type": "string", "format": "uri"}}},
+            "description": "Download links for resolvable persistent agency files. May be empty."
+          }
+        }
+      },
       "Attachment": {
         "type": "object",
         "description": "Object representing a file attachment.",
@@ -115,9 +220,95 @@
   },
   "security": [ { "BearerAuth": [] } ],
   "paths": {
+    "/get_completion_v2": {
+      "servers": [
+        {"url": "https://api-integration-v2-japboyzddq-uc.a.run.app", "description": "Production API v2"},
+        {"url": "https://api-integration-v2-qd6wo466iq-uc.a.run.app", "description": "Staging API v2"}
+      ],
+      "post": {
+        "summary": "Get response",
+        "operationId": "getCompletionV2",
+        "tags": ["API Reference"],
+        "description": "Send a message to an agency-backed integration. Returns raw runtime SSE unless Text Only Mode is enabled in integration settings, in which case it waits and returns text/plain. textOnly is not a request field. Request-body and integration checks precede authentication. The stream may contain wrapped events, metadata, tool events, final messages and [DONE]; do not assume every event is a text delta. See the [API guide](/platform/integrations/web-api) for examples.",
+        "security": [{"PlatformApiKey": []}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2CompletionRequest"}}}},
+        "responses": {
+          "200": {
+            "description": "SSE by default, or a completed plain-text answer when the integration enables Text Only Mode. No platform chat ID is added to the response; retain your chatId/aliasChatId. Once SSE headers are sent, handle stream errors or interruptions even after HTTP 200.",
+            "headers": {
+              "X-Run-Id": {
+                "description": "Forwarded only when supplied by the streaming runtime. Not returned by text-only mode.",
+                "schema": {"type": "string"}
+              }
+            },
+            "content": {
+              "text/event-stream": {
+                "schema": {"type": "string"},
+                "example": "data: {\"data\":{\"type\":\"raw_response_event\",\"data\":{\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}}}\n\n"
+              },
+              "text/plain": {"schema": {"type": "string"}, "example": "Hello! How can I help?"}
+            }
+          },
+          "400": {
+            "description": "Invalid body or attachments, empty message, unknown explicit agent, or integration not agency-backed.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "401": {
+            "description": "Missing, empty, malformed or invalid platform API key.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "404": {
+            "description": "Integration not found or could not be loaded.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "500": {
+            "description": "Server configuration failure or upstream failure before streaming starts.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          }
+        }
+      }
+    },
+    "/get_chat_messages": {
+      "servers": [
+        {"url": "https://api-integration-v2-japboyzddq-uc.a.run.app", "description": "Production API v2"},
+        {"url": "https://api-integration-v2-qd6wo466iq-uc.a.run.app", "description": "Staging API v2"}
+      ],
+      "post": {
+        "summary": "Get chat messages",
+        "operationId": "getChatMessages",
+        "tags": ["API Reference"],
+        "description": "Return the saved history for an API chat. Supply exactly one chat identifier; if both are provided, chatId wins. The key owner must own the integration. During generation the final answer may not yet be saved.",
+        "security": [{"PlatformApiKey": []}],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2HistoryRequest"}}}},
+        "responses": {
+          "200": {
+            "description": "Saved chat items and available status/file metadata. Null fields are omitted; arrays can be empty.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2HistoryResponse"}}}
+          },
+          "400": {
+            "description": "Invalid request fields or neither chat identifier supplied.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "401": {
+            "description": "API key authentication failed.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "403": {
+            "description": "Caller does not own the integration or the chat belongs to another integration.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          },
+          "404": {
+            "description": "Integration or chat not found.",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ApiV2Error"}}}
+          }
+        }
+      }
+    },
     "/create_new_chat": {
       "post": {
         "summary": "Create new chat",
+        "deprecated": true,
+        "x-hidden": true,
         "description": "Creates a new chat instance for a user based on a provided API integration. Requires a valid platform token in the headers for authentication. Ensure the apiIntegrationId corresponds to an existing integration.",
         "requestBody": {
           "required": true,
@@ -170,6 +361,8 @@
     "/get_response": {
       "post": {
         "summary": "Get response",
+        "deprecated": true,
+        "x-hidden": true,
         "description": "Processes a message using the specified API integration and returns a response from the agent. Requires a valid platform token. Ensure the apiIntegrationId is valid. Supports continuing existing chats via chatId or aliasChatId and attaching files with tools.",
         "requestBody": {
           "required": true,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5,12 +5,6 @@
     "version": "1.0.0",
     "description": "Reference documentation for the Agencii Platform API. Provides endpoints allowing you to run your agents on custom backends or on other unsupported channels. ⚡ Live Postman Example: https://www.postman.com/vrsen-ai/agencii-api/overview"
   },
-  "servers": [
-    {
-      "url": "https://agency-swarm-app-japboyzddq-uc.a.run.app",
-      "description": "Production server"
-    }
-  ],
   "components": {
     "securitySchemes": {
       "PlatformApiKey": {"type": "http", "scheme": "bearer", "description": "Platform API key from Profile Icon > API Keys. Send `Authorization: Bearer YOUR_API_KEY`."},
@@ -221,10 +215,6 @@
   "security": [ { "BearerAuth": [] } ],
   "paths": {
     "/get_completion_v2": {
-      "servers": [
-        {"url": "https://api-integration-v2-japboyzddq-uc.a.run.app", "description": "Production API v2"},
-        {"url": "https://api-integration-v2-qd6wo466iq-uc.a.run.app", "description": "Staging API v2"}
-      ],
       "post": {
         "summary": "Get response",
         "operationId": "getCompletionV2",
@@ -269,10 +259,6 @@
       }
     },
     "/get_chat_messages": {
-      "servers": [
-        {"url": "https://api-integration-v2-japboyzddq-uc.a.run.app", "description": "Production API v2"},
-        {"url": "https://api-integration-v2-qd6wo466iq-uc.a.run.app", "description": "Staging API v2"}
-      ],
       "post": {
         "summary": "Get chat messages",
         "operationId": "getChatMessages",

--- a/docs/platform/integrations/web-api.mdx
+++ b/docs/platform/integrations/web-api.mdx
@@ -6,17 +6,17 @@ icon: "code"
 
 ## Feature Overview
 
-API Integrations provide a set of endpoints allowing you to run your agents on custom backends or on other unsupported channels.
+API Integrations provide a set of endpoints allowing you to run your agents on custom backends or on other unsupported channels. This page covers API v2 for integrations connected to a deployed agency.
 
 <Info>
-⚡ Live Postman Example: [Go to Postman →](https://www.postman.com/vrsen-ai/agencii-api/overview)
+Responses stream as **Server-Sent Events (SSE)** by default. Enable **Text Only Mode** in the integration settings to receive only the final answer as plain text.
 </Info>
 
 ---
 
 ## Authentication
 
-- **Note**: You can only use platform tokens for these endpoints. Find or create one inside **Profile Icon > API Keys**.
+- **Note**: You can only use platform tokens for these endpoints. Find or create one inside **Profile Icon > API Keys**. Keep your key on your server.
 - **Headers**:
     - `Authorization`: `Bearer <your_token>`
         - **Example**: `Bearer sk-agencii-H7sb111...`
@@ -28,29 +28,205 @@ API Integrations provide a set of endpoints allowing you to run your agents on c
 
 <CardGroup cols={2}>
 <Card
-  title="Create New Chat"
-  icon="plus"
-  href="/platform/integrations/api/create-new-chat"
+  title="Get Response"
+  icon="bolt"
+  href="/platform/integrations/api/api-reference/get-response"
 >
-  Start a new conversation session.
+  Send a message, stream the reply, and include PDF or image attachments.
 </Card>
 
 <Card
-  title="Get Response"
-  icon="bolt"
-  href="/platform/integrations/api/get-response"
+  title="Get Chat Messages"
+  icon="messages"
+  href="/platform/integrations/api/api-reference/get-chat-messages"
 >
-  Get a response from your agent.
+  Retrieve saved messages, run status, and available files from a conversation.
 </Card>
 </CardGroup>
+
+Completion requests create a chat when needed. You do not need a separate create-chat call.
+
+<Accordion title="Send your first message">
+Create an **API integration**, choose its agency and default agent, and copy the integration ID.
+
+```bash
+export AGENCY_API_KEY="your-platform-api-key"
+export API_V2_BASE_URL="https://api-integration-v2-japboyzddq-uc.a.run.app"
+
+curl --no-buffer --fail-with-body \
+  "$API_V2_BASE_URL/get_completion_v2" \
+  -H "Authorization: Bearer $AGENCY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "apiIntegrationId": "your-integration-id",
+    "message": "Hi! What can you help me with?",
+    "aliasChatId": "customer-123-conversation-1"
+  }'
+```
+
+Use a new `aliasChatId` for each conversation. Reuse it for follow-up messages in that conversation.
+
+<Accordion title="Use the staging environment">
+  Set `API_V2_BASE_URL` to `https://api-integration-v2-qd6wo466iq-uc.a.run.app`. Use an integration ID and platform API key from that environment.
+</Accordion>
+
+</Accordion>
 
 ---
 
 ## Additional Notes
 
-- All timestamps are in ISO 8601 format.
-- Ensure that your `apiIntegrationId` is valid and corresponds to an existing integration.
-- Replace placeholder values with actual data when making requests.
-- The `attachments` parameter in `/get_response` allows you to include files and specify tools for processing.
+- Use a valid `apiIntegrationId` connected to a deployed agency.
+- Reuse `aliasChatId` for follow-up messages in the same conversation. Without a chat identifier, each request starts a new conversation.
+- Use the agent's entry-point ID to override the saved default for a request.
+- Read SSE responses incrementally. Text Only Mode returns plain text; errors before streaming starts return JSON.
+
+<Accordion title="Request fields">
+Send JSON to `POST /get_completion_v2` with `Authorization: Bearer <platform-api-key>`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `apiIntegrationId` | string, required | ID of an API integration connected to an agency. |
+| `message` | string, required | Your message. Send non-empty text, including when attaching a file. |
+| `agent` | string | Entry-point agent ID. Overrides the integration's saved default for this request. |
+| `aliasChatId` | string | Your conversation identifier. Takes precedence over `chatId` for completion requests. |
+| `chatId` | string | Continue a chat by its platform ID. |
+| `attachments` | array | File or image objects, as shown in **Attach a PDF or image**. |
+| `additionalInstructions` | string | Extra instructions for this request. |
+| `user_context` | object or string | Context to pass to the agency, such as a customer ID. |
+
+If `agent` is omitted or empty, the integration uses its saved default. If that setting is missing or stale, it falls back to the first available entry point. An unknown explicit agent ID returns `400`. Use the agent's entry-point ID, which may differ from its display name.
+</Accordion>
+
+<Accordion title="Read the stream">
+The default response has `Content-Type: text/event-stream`. Read it incrementally instead of calling a JSON response parser. This Python example displays the raw SSE lines:
+
+```python
+import os
+
+import requests  # Install with: pip install requests
+
+with requests.post(
+    f"{os.environ['API_V2_BASE_URL']}/get_completion_v2",
+    headers={"Authorization": f"Bearer {os.environ['AGENCY_API_KEY']}"},
+    json={
+        "apiIntegrationId": "your-integration-id",
+        "message": "Explain your role.",
+        "aliasChatId": "customer-123-conversation-1",
+    },
+    stream=True,
+    timeout=(10, 600),
+) as response:
+    response.raise_for_status()
+    response.encoding = "utf-8"
+    if response.headers.get("Content-Type", "").startswith("text/plain"):
+        print(response.text)
+    else:
+        for line in response.iter_lines(decode_unicode=True):
+            print(line, flush=True)
+```
+
+For a UI, use an SSE parser with a streaming POST client. A network chunk can contain part of an event or several events. Native browser `EventSource` cannot send this POST body or its authorization header.
+
+**Event format and response headers**
+  API v2 forwards the agency runtime's SSE stream. The event payload depends on the deployed runtime version. It can include metadata, agent and tool events, wrapped response events, and final messages.
+
+  For example, a text delta from the framework runtime can look like this (other fields omitted):
+
+  ```text
+  data: {"data":{"type":"raw_response_event","data":{"type":"response.output_text.delta","delta":"Hello"}}}
+
+  ```
+
+  The framework runtime can also emit named `meta`, `messages`, and `end` events, with `[DONE]` as the `end` data. Parse complete SSE events, ignore comment/keepalive lines, and handle errors and an interrupted stream. Do not assume that every `data:` payload is text or JSON: `[DONE]` is a marker.
+
+  `X-Run-Id` is forwarded when the upstream runtime supplies it. API v2 also sets `Cache-Control: no-cache` and `X-Accel-Buffering: no` for streaming responses. It does not currently add an `X-Chat-ID` header. Use a known `chatId` or your own `aliasChatId` to continue the conversation.
+</Accordion>
+
+<Accordion title="Return only the answer">
+Enable **Text Only Mode** in the API integration settings, then send the same request. The setting belongs to the integration; sending `textOnly` in the request body does not change the response mode.
+
+The request waits for completion and returns `Content-Type: text/plain; charset=utf-8`:
+
+```text
+Hi! I can help answer questions and work with your documents.
+```
+
+The body contains only the answer, without JSON fields or event framing. With the toggle disabled or unset, the response is SSE. Error responses remain JSON with an error status in both modes.
+</Accordion>
+
+<Accordion title="Attach a PDF or image">
+Add `attachments` to the completion request:
+
+```json
+{
+  "apiIntegrationId": "your-integration-id",
+  "message": "Summarize this PDF and compare it with the chart.",
+  "aliasChatId": "customer-123-conversation-1",
+  "attachments": [
+    {
+      "type": "input_file",
+      "file_url": "https://your-storage.example.com/report.pdf",
+      "filename": "report.pdf"
+    },
+    {
+      "type": "input_image",
+      "image_url": "https://your-storage.example.com/chart.png",
+      "detail": "auto"
+    }
+  ]
+}
+```
+
+Replace the example URLs with files the runtime can download without extra authorization headers. Signed storage URLs work too; keep them valid until the runtime has fetched the files. File interpretation depends on the deployed agent's model and tools.
+
+- **Files:** use `input_file` with an HTTP(S) `file_url`. `filename` is optional and must be a file name without directories. If omitted, it is derived from the URL. Duplicate names receive unique suffixes.
+- **Images:** use `input_image` with an `image_url`. Image URLs and image data URLs are supported. `detail` accepts `auto`, `low`, or `high`; it defaults to `auto`.
+- **Unsupported formats:** OpenAI `file_id`/`tools` objects, inline PDF `file_data`, local file paths, and multipart uploads are not accepted by this JSON endpoint. Upload a local PDF to accessible storage first.
+</Accordion>
+
+<Accordion title="Continue a chat and read its history">
+Completion requests create a chat when needed. Send the same `aliasChatId` or an existing `chatId` with the next message. If neither is supplied, each request starts a new conversation. API v2 does not add a platform chat ID to the completion response.
+
+Retrieve the saved chat with `POST /get_chat_messages`:
+
+```bash
+curl --fail-with-body \
+  "$API_V2_BASE_URL/get_chat_messages" \
+  -H "Authorization: Bearer $AGENCY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "apiIntegrationId": "your-integration-id",
+    "aliasChatId": "customer-123-conversation-1"
+  }'
+```
+
+The JSON response includes the platform `chatId` and saved `items`: user messages, agent messages, tool calls, and other stored item types. It can also include the alias, message count, run status, and download links for available files in persistent agency storage. A history request during generation may not yet include the final answer.
+
+Supply exactly one chat identifier to avoid ambiguity. Completion requests prefer `aliasChatId` when both are provided; history requests prefer `chatId`. History requests require the API key owner to own the integration.
+</Accordion>
+
+<Accordion title="Handle errors">
+Completion errors before streaming starts return JSON containing an `error` message:
+
+| Status | Completion condition |
+| --- | --- |
+| `400` | Invalid JSON/fields/attachments, empty message, unknown explicit agent, or integration not connected to an agency. |
+| `401` | Missing, empty, malformed, or invalid platform API key. |
+| `404` | The integration cannot be found or loaded. |
+| `500` | Server configuration or upstream agent failure before streaming starts. |
+
+The completion endpoint checks the request body and integration before authentication. A malformed request can therefore return `400` or `404` even if its credentials are invalid. After SSE headers are sent, a stream failure cannot change the HTTP status; handle error events and interrupted responses as well as HTTP errors.
+
+History requests return `400` for invalid fields or a missing chat identifier, `401` for invalid credentials, `403` for denied access, and `404` for a missing integration or chat. Use a separate alias for a new conversation; retrying a completion with the same alias can append another user message.
+</Accordion>
 
 ---
+
+<Warning>
+**API v1 is deprecated.** Use API v2 for new integrations. The earlier endpoints use a different server and request format.
+
+Legacy reference: [Create New Chat](/platform/integrations/api/create-new-chat) and [Get Response](/platform/integrations/api/get-response).
+
+[API v1 Postman examples](https://www.postman.com/vrsen-ai/agencii-api/overview)
+</Warning>

--- a/docs/platform/integrations/web-api.mdx
+++ b/docs/platform/integrations/web-api.mdx
@@ -85,7 +85,7 @@ Send JSON to `POST /get_completion_v2` with `Authorization: Bearer <platform-api
 | `apiIntegrationId` | string, required | ID of an API integration connected to an agency. |
 | `message` | string, required | Your message. Send non-empty text, including when attaching a file. |
 | `agent` | string | Entry-point agent ID. Overrides the integration's saved default for this request. |
-| `aliasChatId` | string | Your conversation identifier. Takes precedence over `chatId` for completion requests. |
+| `aliasChatId` | string | Your conversation identifier. Do not send it together with `chatId`. |
 | `chatId` | string | Continue a chat by its platform ID. |
 | `attachments` | array | File or image objects, as shown in **Attach a PDF or image**. |
 | `additionalInstructions` | string | Extra instructions for this request. |
@@ -148,7 +148,7 @@ The request waits for completion and returns `Content-Type: text/plain; charset=
 Hi! I can help answer questions and work with your documents.
 ```
 
-The body contains only the answer, without JSON fields or event framing. With the toggle disabled or unset, the response is SSE. Error responses remain JSON with an error status in both modes.
+The body contains only the answer, without JSON fields or event framing. With the toggle disabled or unset, the response is SSE. Errors before streaming starts return JSON with an error status. Once SSE starts, inspect events for errors even when the HTTP status is `200`.
 </Accordion>
 
 <Accordion title="Attach a PDF or image">
@@ -177,7 +177,7 @@ Add `attachments` to the completion request:
 Replace the example URLs with files the runtime can download without extra authorization headers. Signed storage URLs work too; keep them valid until the runtime has fetched the files. File interpretation depends on the deployed agent's model and tools.
 
 - **Files:** use `input_file` with an HTTP(S) `file_url`. `filename` is optional and must be a file name without directories. If omitted, it is derived from the URL. Duplicate names receive unique suffixes.
-- **Images:** use `input_image` with an `image_url`. Image URLs and image data URLs are supported. `detail` accepts `auto`, `low`, or `high`; it defaults to `auto`.
+- **Images:** use `input_image` with an `image_url`. Use an HTTP(S) URL that the runtime can download. Embedded `data:` URLs currently pass API validation but fail in the runtime file uploader; upload the image to accessible storage first. `detail` accepts `auto`, `low`, or `high`; it defaults to `auto`.
 - **Unsupported formats:** OpenAI `file_id`/`tools` objects, inline PDF `file_data`, local file paths, and multipart uploads are not accepted by this JSON endpoint. Upload a local PDF to accessible storage first.
 </Accordion>
 
@@ -199,7 +199,7 @@ curl --fail-with-body \
 
 The JSON response includes the platform `chatId` and saved `items`: user messages, agent messages, tool calls, and other stored item types. It can also include the alias, message count, run status, and download links for available files in persistent agency storage. A history request during generation may not yet include the final answer.
 
-Supply exactly one chat identifier to avoid ambiguity. Completion requests prefer `aliasChatId` when both are provided; history requests prefer `chatId`. History requests require the API key owner to own the integration.
+Supply exactly one chat identifier to avoid ambiguity. Completion requests return `400` if both `aliasChatId` and `chatId` are provided; history requests prefer `chatId`. History requests require the API key owner to own the integration.
 </Accordion>
 
 <Accordion title="Handle errors">

--- a/docs/platform/integrations/web-api.mdx
+++ b/docs/platform/integrations/web-api.mdx
@@ -47,14 +47,14 @@ Responses stream as **Server-Sent Events (SSE)** by default. Enable **Text Only 
 Completion requests create a chat when needed. You do not need a separate create-chat call.
 
 <Accordion title="Send your first message">
-Create an **API integration**, choose its agency and default agent, and copy the integration ID.
+Create an **API integration**, choose its agency and default agent, and copy the integration ID. Set `API_BASE_URL` in your environment before running the examples; endpoint paths below are relative to that base URL.
 
 ```bash
 export AGENCY_API_KEY="your-platform-api-key"
-export API_V2_BASE_URL="https://api-integration-v2-japboyzddq-uc.a.run.app"
+: "${API_BASE_URL:?Set API_BASE_URL to your API base URL}"
 
 curl --no-buffer --fail-with-body \
-  "$API_V2_BASE_URL/get_completion_v2" \
+  "$API_BASE_URL/get_completion_v2" \
   -H "Authorization: Bearer $AGENCY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -65,10 +65,6 @@ curl --no-buffer --fail-with-body \
 ```
 
 Use a new `aliasChatId` for each conversation. Reuse it for follow-up messages in that conversation.
-
-<Accordion title="Use the staging environment">
-  Set `API_V2_BASE_URL` to `https://api-integration-v2-qd6wo466iq-uc.a.run.app`. Use an integration ID and platform API key from that environment.
-</Accordion>
 
 </Accordion>
 
@@ -107,7 +103,7 @@ import os
 import requests  # Install with: pip install requests
 
 with requests.post(
-    f"{os.environ['API_V2_BASE_URL']}/get_completion_v2",
+    f"{os.environ['API_BASE_URL']}/get_completion_v2",
     headers={"Authorization": f"Bearer {os.environ['AGENCY_API_KEY']}"},
     json={
         "apiIntegrationId": "your-integration-id",
@@ -192,7 +188,7 @@ Retrieve the saved chat with `POST /get_chat_messages`:
 
 ```bash
 curl --fail-with-body \
-  "$API_V2_BASE_URL/get_chat_messages" \
+  "$API_BASE_URL/get_chat_messages" \
   -H "Authorization: Bearer $AGENCY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
Make API v2 the default on the existing API documentation page while keeping its layout. Add endpoint references and examples for SSE streaming, Text Only Mode, agent selection, PDF/image attachments, chat history, and authentication errors.

 Endpoint bars display only routes, without a server selector. Public documentation omits staging details; overview examples use API_BASE_URL. Keep API v1 references accessible from the deprecated notice at the bottom and hidden from navigation. Record these conventions in the documentation writing rules.

The production URL is the intended address based on the confirmed project suffix. API v2 has not yet been merged and deployed to production. Publish these docs alongside that deployment.

Validation: Mintlify build validation, JSON and example syntax checks, and local browser review passed. The staging completion route returned the expected validation error for an empty POST. Empty POST requests to the intended production completion and history URLs returned 404, consistent with deployment being pending. No agent runs were started; full end-to-end responses remain unverified.
